### PR TITLE
Remove unused PhantomData

### DIFF
--- a/rust/guest_wrapper/guest/src/guest.rs
+++ b/rust/guest_wrapper/guest/src/guest.rs
@@ -19,7 +19,7 @@ impl Guest {
         Guest { env }
     }
 
-    pub fn run(self, call_data: CallTxData<()>) {
+    pub fn run(self, call_data: CallTxData) {
         guest_evm_call(call_data, &self.env);
     }
 }

--- a/rust/guest_wrapper/guest/src/main.rs
+++ b/rust/guest_wrapper/guest/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
         call: Call { caller, to, data },
     } = env::read();
 
-    let call_data = CallTxData::<()>::new_from_bytes(caller, to, data);
+    let call_data = CallTxData::new_from_bytes(caller, to, data);
 
     let returns = Guest::new(evm_input).run(call_data);
     env::commit(&returns);

--- a/rust/host/src/host.rs
+++ b/rust/host/src/host.rs
@@ -37,7 +37,7 @@ impl Host {
         Ok(Host { env })
     }
 
-    pub fn run(mut self, call_tx_data: CallTxData<()>) -> anyhow::Result<Vec<u8>> {
+    pub fn run(mut self, call_tx_data: CallTxData) -> anyhow::Result<Vec<u8>> {
         let CallTxData {
             caller, to, data, ..
         } = call_tx_data.clone();

--- a/rust/host/src/main.rs
+++ b/rust/host/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> anyhow::Result<()> {
         0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
     ];
 
-    let call_tx_data = CallTxData::<()>::new_from_bytes(CALLER, CONTRACT, raw_call_data.clone());
+    let call_tx_data = CallTxData::new_from_bytes(CALLER, CONTRACT, raw_call_data.clone());
 
     let _return_data = Host::try_new()?.run(call_tx_data)?;
 

--- a/rust/vlayer/steel/src/contract.rs
+++ b/rust/vlayer/steel/src/contract.rs
@@ -23,7 +23,7 @@ use revm::{
     },
     Database, Evm,
 };
-use std::{fmt::Debug, marker::PhantomData};
+use std::fmt::Debug;
 
 /// Represents a contract that is initialized with a specific environment and contract address.
 ///
@@ -73,37 +73,20 @@ use std::{fmt::Debug, marker::PhantomData};
 /// [EvmEnv::new]: crate::EvmEnv::new
 /// [EthEvmEnv::from_rpc]: crate::ethereum::EthEvmEnv::from_rpc
 
-#[derive(Debug, Clone)]
-pub struct CallTxData<C> {
+#[derive(Debug, Clone, Default)]
+pub struct CallTxData {
     pub caller: Address,
     pub gas_limit: u64,
     pub gas_price: U256,
     pub to: Address,
     pub value: U256,
     pub data: Vec<u8>,
-    phantom: PhantomData<C>,
 }
 
-// We can't derive `Default` for `CallTxData` as it would require `C: Default`
-impl<C> Default for CallTxData<C> {
-    fn default() -> Self {
-        Self {
-            phantom: PhantomData,
-            // We can't use `..Default::default()` here as it would cause recursion
-            caller: Default::default(),
-            gas_limit: Default::default(),
-            gas_price: Default::default(),
-            to: Default::default(),
-            value: Default::default(),
-            data: Default::default(),
-        }
-    }
-}
-
-impl<C> CallTxData<C> {
+impl CallTxData {
     const DEFAULT_GAS_LIMIT: u64 = 30_000_000;
 
-    pub fn new(address: Address, call: &C) -> Self
+    pub fn new<C>(address: Address, call: &C) -> Self
     where
         C: SolCall,
     {
@@ -128,7 +111,7 @@ impl<C> CallTxData<C> {
 }
 
 /// Executes the call in the provided [Evm].
-fn transact<C, DB>(mut evm: Evm<'_, (), DB>, tx: CallTxData<C>) -> Result<Vec<u8>, String>
+fn transact<DB>(mut evm: Evm<'_, (), DB>, tx: CallTxData) -> Result<Vec<u8>, String>
 where
     DB: Database,
     <DB as Database>::Error: Debug,

--- a/rust/vlayer/steel/src/contract/call.rs
+++ b/rust/vlayer/steel/src/contract/call.rs
@@ -5,7 +5,7 @@ use crate::host::{provider::Provider, HostEvmEnv};
 use crate::{EvmBlockHeader, GuestEvmEnv};
 
 #[cfg(feature = "host")]
-pub fn evm_call<C, P, H>(tx: CallTxData<C>, env: &mut HostEvmEnv<P, H>) -> anyhow::Result<Vec<u8>>
+pub fn evm_call<P, H>(tx: CallTxData, env: &mut HostEvmEnv<P, H>) -> anyhow::Result<Vec<u8>>
 where
     P: Provider,
     H: EvmBlockHeader,
@@ -17,7 +17,7 @@ where
     transact(evm, tx).map_err(|err| anyhow::anyhow!(err))
 }
 
-pub fn guest_evm_call<C, H>(tx: CallTxData<C>, env: &GuestEvmEnv<H>) -> Vec<u8>
+pub fn guest_evm_call<H>(tx: CallTxData, env: &GuestEvmEnv<H>) -> Vec<u8>
 where
     H: EvmBlockHeader,
 {

--- a/rust/vlayer/steel/tests/eth_call.rs
+++ b/rust/vlayer/steel/tests/eth_call.rs
@@ -324,7 +324,7 @@ struct CallOverrides {
 }
 
 impl CallOverrides {
-    fn apply<C>(&self, mut tx_data: CallTxData<C>) -> CallTxData<C> {
+    fn apply(&self, mut tx_data: CallTxData) -> CallTxData {
         if let Some(gas_price) = self.gas_price {
             tx_data.gas_price = gas_price;
         }


### PR DESCRIPTION
`PhantomData` was used mainly to do return empty result assertion [here](https://github.com/vlayer-xyz/vlayer/pull/15/files#r1644300637)
```rust
#[allow(clippy::let_unit_value)]
let _ = CallTxData::<C>::RETURNS;
```

```rust
const RETURNS: () = assert!(
  mem::size_of::<C::Return>() > 0,
  "Function call must have a return value"
);
```
as we are generic now, we don't assert however there is a [task to test this case](https://www.notion.so/vlayer/Pass-Call-with-additional-fields-from-Guest-to-Host-6ddc1dc8eabb429495f94fe533ef7719?pvs=4)