### PR TITLE
Fix github job ids

### DIFF
--- a/.github/workflows/foundry.yaml
+++ b/.github/workflows/foundry.yaml
@@ -1,4 +1,4 @@
-name: test
+name: Forge test
 
 on: [push, merge_group]
 
@@ -6,7 +6,7 @@ env:
   FOUNDRY_PROFILE: ci
 
 jobs:
-  check:
+  forge-test:
     strategy:
       fail-fast: true
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,7 +2,7 @@ name: Lint
 on: [push, merge_group]
 
 jobs:
-  rust:
+  rust-lint:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/prove.yaml
+++ b/.github/workflows/prove.yaml
@@ -2,7 +2,7 @@ name: Local prover
 on: [push, merge_group]
 
 jobs:
-  prove:
+  rust-prove:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on: [push, merge_group]
 
 jobs:
-  rust:
+  rust-test:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
It's important for rust caching to work correctly as now we have cache flickering between test & lint