### PR TITLE
Skip actions when not needed

### DIFF
--- a/.github/workflows/foundry.yaml
+++ b/.github/workflows/foundry.yaml
@@ -6,13 +6,9 @@ env:
   FOUNDRY_PROFILE: ci
 
 jobs:
-  forge-test:
-    strategy:
-      fail-fast: true
-
-
-    name: Foundry project
-    runs-on: ubuntu-latest
+  check-files:
+    name: Checking changed files
+    runs-on: ubuntu-latest    
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,22 +21,32 @@ jobs:
           files: |
               **.sol
               **/foundry.toml
+    outputs:
+      any_changed: ${{ steps.changed-sol-files.outputs.any_changed }} 
+  forge-test:
+    needs: check-files
+    if: needs.check-files.outputs.any_changed== 'true'
+    strategy:
+      fail-fast: true
+    name: Foundry project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Install Foundry
-        if: steps.changed-sol-files.outputs.any_changed == 'true'
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly-5ac78a9cd4b94dc53d1fe5e0f42372b28b5a7559 # 2024-06-02
 
       - name: Run Forge build
-        if: steps.changed-sol-files.outputs.any_changed == 'true'
         working-directory: ./examples/simple
         run: |
           forge --version
           forge build --sizes
 
       - name: Run Forge tests
-        if: steps.changed-sol-files.outputs.any_changed == 'true'      
         working-directory: ./examples/simple
         run: |
           forge test -vvv

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,33 +2,40 @@ name: Lint
 on: [push, merge_group]
 
 jobs:
-  rust-lint:
-    runs-on: ubuntu-latest
-
+  check-files:
+    name: Checking changed files
+    runs-on: ubuntu-latest    
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-      - name: Get all changed Rust files
-        id: changed-rust-files
+      - name: Get all changed Solidity files
+        id: changed-sol-files
         uses: tj-actions/changed-files@v44
         with:
           files: |
             **.rs
             */Cargo.toml
             **.sol
+    outputs:
+      any_changed: ${{ steps.changed-sol-files.outputs.any_changed }}   
+  rust-lint:
+    runs-on: ubuntu-latest
+    needs: check-files
+    if: needs.check-files.outputs.any_changed== 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - uses: cargo-bins/cargo-binstall@main
-        if: steps.changed-rust-files.outputs.any_changed == 'true'
       
       - name: Set up Rust
-        if: steps.changed-rust-files.outputs.any_changed == 'true'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: rust
 
       - name: Run Clippy Host
-        if: steps.changed-rust-files.outputs.any_changed == 'true'
         working-directory: rust
         env:
           RUSTFLAGS: "-Dwarnings"
@@ -37,7 +44,6 @@ jobs:
           cargo clippy --all-targets --all-features
 
       - name: Run Clippy Guest
-        if: steps.changed-rust-files.outputs.any_changed == 'true'
         working-directory: rust/guest_wrapper/guest
         env:
           RUSTFLAGS: "-Dwarnings"

--- a/.github/workflows/prove.yaml
+++ b/.github/workflows/prove.yaml
@@ -2,9 +2,28 @@ name: Local prover
 on: [push, merge_group]
 
 jobs:
+  check-files:
+    name: Checking changed files
+    runs-on: ubuntu-latest    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Get all changed Solidity files
+        id: changed-sol-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            **.rs
+            */Cargo.toml
+            **.sol 
+    outputs:
+      any_changed: ${{ steps.changed-sol-files.outputs.any_changed }}            
   rust-prove:
     runs-on: ubuntu-latest
-
+    needs: check-files
+    if: needs.check-files.outputs.any_changed== 'true'
     steps:
       - uses: cargo-bins/cargo-binstall@main
 
@@ -13,44 +32,29 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Get changed files in the rust folder
-        id: changed-files-rust
-        uses: tj-actions/changed-files@v44
-        with:
-          files: |
-            **.rs
-            */Cargo.toml
-            **.sol
-
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        if: steps.changed-files-rust.outputs.any_changed == 'true'
         with:
           cache-workspaces: "rust -> target"
 
       - name: Install risc0 instaler
-        if: steps.changed-files-rust.outputs.any_changed == 'true'
         run: cargo binstall -y cargo-risczero --force
 
       - name: Install risc0 toolchain
-        if: steps.changed-files-rust.outputs.any_changed == 'true'
         run: cargo risczero install
 
       - name: Install Foundry
-        if: steps.changed-files-rust.outputs.any_changed == 'true'
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly-5ac78a9cd4b94dc53d1fe5e0f42372b28b5a7559 # 2024-06-02
 
       - name: Start Anvil
-        if: steps.changed-files-rust.outputs.any_changed == 'true'
         run: |
           anvil &
           ANVIL_SERVER_PID=$!
           echo "ANVIL_SERVER_PID=$ANVIL_SERVER_PID" >> $GITHUB_ENV
 
       - name: Deploy simple example contract
-        if: steps.changed-files-rust.outputs.any_changed == 'true'
         working-directory: examples/simple
         run: |
           output=$(mktemp)
@@ -60,7 +64,6 @@ jobs:
           grep '[A-Z0-9_]\+=[a-zA-Z0-9]\+' <${output} >>${GITHUB_ENV}
 
       - name: Run host
-        if: steps.changed-files-rust.outputs.any_changed == 'true'
         working-directory: rust/host
         run: cargo run
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,15 +3,14 @@ name: Test
 on: [push, merge_group]
 
 jobs:
-  rust-test:
-    runs-on: ubuntu-latest
-
+  check-files:
+    name: Checking changed files
+    runs-on: ubuntu-latest    
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      
       - name: Get changed files in the rust folder
         id: changed-files-rust
         uses: tj-actions/changed-files@v44
@@ -20,22 +19,29 @@ jobs:
             **.rs
             */Cargo.toml
             **.sol      
-     
+    outputs:
+      any_changed: ${{ steps.changed-files-rust.outputs.any_changed }}
+  rust-test:
+    runs-on: ubuntu-latest
+    needs: check-files
+    if: needs.check-files.outputs.any_changed== 'true'
+    steps:
+      - uses: cargo-bins/cargo-binstall@main
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        if: steps.changed-files-rust.outputs.any_changed == 'true'
         with:
           cache-workspaces: rust
 
       - name: Install risc0 instaler
-        if: steps.changed-files-rust.outputs.any_changed == 'true'
         run: cargo binstall -y cargo-risczero --force
  
       - name: Install risc0 toolchain
-        if: steps.changed-files-rust.outputs.any_changed == 'true'
         run: cargo risczero install
       
       - name: Run workspace rust tests
-        if: steps.changed-files-rust.outputs.any_changed == 'true'
         working-directory: rust
         run: cargo test --workspace


### PR DESCRIPTION
Small improvement to our CI that allow to save ~5 mins of runner precious minutes when changes are doc related only. 

Current problem: 
Despite changing just book/*.md files we are running linters, tests for Rust files etc. 

Solution: 
Run linters, Rust tests, Foundry only when it's necessary (relevant files changed). 

Why I didn't use `path` filters (like in `book.yaml` action)? 
It didn't work as we have required checks run on every PR. These filters made checks not fulfilled and merging was not possible. Had to use `changed-files` action and add if statement to every step as workaround. 
