### PR TITLE
Fix vlayerup script

### DIFF
--- a/bash/vlayerup/vlayerup
+++ b/bash/vlayerup/vlayerup
@@ -77,7 +77,7 @@ ensure() {
 
 # Downloads $1 into $2 or stdout
 download() {
-  if [ -n "$2" ]; then
+  if [ -n "${2:-}" ]; then
     # output into $2
     if check_cmd curl; then
       curl -#o "$2" -L "$1"


### PR DESCRIPTION
Script failed when var `2` was unset.
This change ensures that when the var is unset, then non-emptiness check (`-n`) is run against empty string.


Notation: `${foo:-val}  -  $foo, or val if unset (or null)`