### PR TITLE
Book: update expected params

### DIFF
--- a/book/src/appendix/api.md
+++ b/book/src/appendix/api.md
@@ -27,11 +27,11 @@ and the response:
  {
     "method": "v_call",
     "params": [
-        {   "from": "<from address>", # optional field
+        {   "caller": "<from address>", # optional field
             "to": "<contract address>",
             "data": "0x<abi encoded calldata>"
         },
-        {"chainId": 1, "blockNo": "latest"},
+        {"chain_id": 1, "block_no": "latest"},
         {
             "email": "<base64? encoded raw email>",
             "web": "<encoded web artifacts>",


### PR DESCRIPTION
Feedback from Wiktor at Discord: 
```
Now trying to call JSON RPC server. Tried the format from the book and it expects the following
caller instead of from
chain_id instead of chainId
block_no instead of blockNo
```