### PR TITLE
Intercept call in simple_travel example, add it to e2e tests

### DIFF
--- a/bash/e2e-test.sh
+++ b/bash/e2e-test.sh
@@ -9,3 +9,15 @@
   --example simple \
   --caller 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 \
   --data 0xcad0899b00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002 
+
+./bash/prove-example.sh \
+  --mode dev \
+  --example simple_travel \
+  --caller 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 \
+  --data 0xe56a41f9
+
+./bash/prove-example.sh \
+  --mode prod \
+  --example simple_travel \
+  --caller 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 \
+  --data 0xe56a41f9

--- a/contracts/src/Prover.sol
+++ b/contracts/src/Prover.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 interface ITraveler {
     // These functions need to return something because otherwise Solidity compiler won't generate CALL opcode when they're called.
-    function setBlock(uint256 blockNo) external returns (uint256);
+    function setBlock(uint256 blockNo) external returns (bool);
     function setChain(uint256 chainId, uint256 blockNo) external returns (bool);
 }
 

--- a/rust/engine/src/inspector.rs
+++ b/rust/engine/src/inspector.rs
@@ -2,7 +2,7 @@ use alloy_primitives::hex::decode;
 use alloy_primitives::{address, Address, Bytes};
 use ethers_core::types::U256;
 use once_cell::sync::Lazy;
-use revm::interpreter::{Gas, InstructionResult, Interpreter, InterpreterResult, OpCode};
+use revm::interpreter::{Gas, InstructionResult, InterpreterResult};
 use revm::{
     interpreter::{CallInputs, CallOutcome},
     Database, EvmContext, Inspector,
@@ -70,14 +70,14 @@ impl<DB: Database> Inspector<DB> for SetInspector {
                         argument
                     );
                     self.set_block = Some(argument);
-                    return Some(MockCallOutcome::from(U256::zero()).0)
+                    return Some(MockCallOutcome::from(U256::zero()).0);
                 } else if selector == *SET_CHAIN_SELECTOR {
                     info!(
                         "Travel contract called with function: setChain and argument: {:?}!",
                         argument
                     );
                     self.set_chain = Some(argument);
-                    return Some(MockCallOutcome::from(U256::zero()).0)
+                    return Some(MockCallOutcome::from(U256::zero()).0);
                 }
             }
             // If the call is not setBlock/setChain but setBlock/setChain is active, intercept the call.


### PR DESCRIPTION
This PR tweaks some variables in SetInspector so that the call in simple_travel example gets intercepted. It also adds simple_travel proving to e2e tests.