### PR TITLE
Closure callback

### DIFF
--- a/rust/engine/src/engine.rs
+++ b/rust/engine/src/engine.rs
@@ -49,7 +49,7 @@ where
         Self { envs }
     }
 
-    pub fn call(&self, tx: &Call, location: ExecutionLocation) -> Result<Vec<u8>, EngineError> {
+    pub fn call(&'a self, tx: &Call, location: ExecutionLocation) -> Result<Vec<u8>, EngineError> {
         let env = self
             .envs
             .get(location)
@@ -80,12 +80,9 @@ where
         None
     }
 
-    fn transact<F>(
-        mut evm: Evm<'_, TravelInspector<F>, WrapDatabaseRef<&D>>,
-    ) -> Result<Vec<u8>, EngineError>
-    where
-        F: Fn(ExecutionLocation, CallInputs) -> Option<CallOutcome>,
-    {
+    fn transact(
+        mut evm: Evm<'_, TravelInspector<'a>, WrapDatabaseRef<&D>>,
+    ) -> Result<Vec<u8>, EngineError> {
         let ResultAndState { result, .. } = evm
             .transact_preverified()
             .map_err(|err| EngineError::TransactPreverifiedError(format!("{:?}", err)))?;

--- a/rust/test_runner/src/cli.rs
+++ b/rust/test_runner/src/cli.rs
@@ -63,7 +63,7 @@ use crate::{
     contract_runner::ContractRunner, filter::FilterArgs, filter::ProjectPathsAwareFilter,
     summary::TestSummaryReporter, test_executor::TestExecutor,
 };
-use vlayer_engine::inspector::{TravelInspector, TRAVEL_CONTRACT_ADDR, TRAVEL_CONTRACT_HASH};
+use vlayer_engine::inspector::{NoopInspector, TRAVEL_CONTRACT_ADDR, TRAVEL_CONTRACT_HASH};
 
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::merge_impl_figment_convert!(TestArgs, opts, evm_opts);
@@ -806,7 +806,7 @@ fn run_test_suite(
         contract,
         libs_to_deploy: &runner.libs_to_deploy,
         // MODIFICATION: Replace Executor with TestExecutor
-        executor: TestExecutor::new(executor, TravelInspector::default()),
+        executor: TestExecutor::new(executor, NoopInspector),
         revert_decoder: &runner.revert_decoder,
         initial_balance: runner.evm_opts.initial_balance,
         sender: runner.sender.unwrap_or_default(),

--- a/rust/test_runner/src/composite_inspector.rs
+++ b/rust/test_runner/src/composite_inspector.rs
@@ -5,15 +5,15 @@ use forge::revm::{Database, EvmContext, Inspector};
 use foundry_evm::inspectors::InspectorStack;
 use foundry_evm_core::backend::DatabaseExt;
 use foundry_evm_core::InspectorExt;
-use vlayer_engine::inspector::TravelInspector;
+use vlayer_engine::inspector::NoopInspector;
 
 pub struct CompositeInspector {
-    pub set_inspector: TravelInspector,
+    pub set_inspector: NoopInspector,
     pub inspector_stack: InspectorStack,
 }
 
 impl CompositeInspector {
-    pub fn new(set_inspector: TravelInspector, inspector_stack: InspectorStack) -> Self {
+    pub fn new(set_inspector: NoopInspector, inspector_stack: InspectorStack) -> Self {
         Self {
             set_inspector,
             inspector_stack,

--- a/rust/test_runner/src/contract_runner.rs
+++ b/rust/test_runner/src/contract_runner.rs
@@ -34,7 +34,6 @@ use tracing::{debug, debug_span, enabled, trace};
 pub const LIBRARY_DEPLOYER: Address = address!("1F95D37F27EA0dEA9C252FC09D5A6eaA97647353");
 
 /// A type that executes all tests of a contract
-#[derive(Clone, Debug)]
 pub struct ContractRunner<'a> {
     /// The data of the contract.
     pub contract: &'a TestContract,

--- a/rust/test_runner/src/test_executor.rs
+++ b/rust/test_runner/src/test_executor.rs
@@ -22,17 +22,16 @@ use foundry_evm::inspectors::{InspectorData, InspectorStack};
 use foundry_evm_core::backend::{BackendResult, CowBackend};
 use foundry_evm_core::decode::RevertDecoder;
 use tracing::instrument;
-use vlayer_engine::inspector::TravelInspector;
+use vlayer_engine::inspector::NoopInspector;
 
 /// MODIFICATION: This struct is a wrapper around the Executor struct from foundry_evm that adds our inspector that will be passed to the backend
-#[derive(Clone, Debug)]
 pub struct TestExecutor {
-    pub inspector: TravelInspector,
+    pub inspector: NoopInspector,
     pub executor: Executor,
 }
 
 impl TestExecutor {
-    pub fn new(executor: Executor, inspector: TravelInspector) -> Self {
+    pub fn new(executor: Executor, inspector: NoopInspector) -> Self {
         Self {
             inspector,
             executor,


### PR DESCRIPTION
Travel inspector callback requires self reference to be able to spawn other EVMs and actually execute calls
Unfortunately - test_runner requires that `Inspector` is `Send + Clone + Default + Debug` which is absolutely not true with Inspector containing real callback.
Therefore - I've created `NoopInspector` and used it in test_runner for now.
It should be a separate task and a separate decision - how to integrate one into another