### PR TITLE
Refactor server integration_tests 2/8

### DIFF
--- a/rust/server/tests/integration_tests.rs
+++ b/rust/server/tests/integration_tests.rs
@@ -1,40 +1,13 @@
 use axum::http::StatusCode;
 use axum_jrpc::{JsonRpcRequest, Value};
 use core::str;
-use ethers::{
-    contract::abigen,
-    core::utils::{Anvil, AnvilInstance},
-    middleware::SignerMiddleware,
-    providers::{Http, Provider},
-    signers::{LocalWallet, Signer},
-};
+use ethers::core::utils::AnvilInstance;
 use serde_json::json;
 use server::server::{server, Config};
-use std::{sync::Arc, time::Duration};
 
 mod test_helpers;
 
-use test_helpers::{body_to_json, body_to_string, post};
-
-abigen!(ExampleProver, "./testdata/ExampleProver.json",);
-
-async fn setup_anvil() -> AnvilInstance {
-    let anvil = Anvil::new().spawn();
-    let wallet: LocalWallet = anvil.keys()[0].clone().into();
-    let provider = Provider::<Http>::try_from(anvil.endpoint())
-        .unwrap()
-        .interval(Duration::from_millis(10u64));
-    let client = Arc::new(SignerMiddleware::new(
-        provider,
-        wallet.with_chain_id(anvil.chain_id()),
-    ));
-    ExampleProver::deploy(client.clone(), ())
-        .unwrap()
-        .send()
-        .await
-        .unwrap();
-    anvil
-}
+use test_helpers::{anvil::setup_anvil, body_to_json, body_to_string, post};
 
 mod server_tests {
     use super::*;

--- a/rust/server/tests/test_helpers/anvil.rs
+++ b/rust/server/tests/test_helpers/anvil.rs
@@ -1,0 +1,28 @@
+use ethers::{
+    contract::abigen,
+    core::utils::{Anvil, AnvilInstance},
+    middleware::SignerMiddleware,
+    providers::{Http, Provider},
+    signers::{LocalWallet, Signer},
+};
+use std::{sync::Arc, time::Duration};
+
+abigen!(ExampleProver, "./testdata/ExampleProver.json",);
+
+pub(crate) async fn setup_anvil() -> AnvilInstance {
+    let anvil = Anvil::new().spawn();
+    let wallet: LocalWallet = anvil.keys()[0].clone().into();
+    let provider = Provider::<Http>::try_from(anvil.endpoint())
+        .unwrap()
+        .interval(Duration::from_millis(10u64));
+    let client = Arc::new(SignerMiddleware::new(
+        provider,
+        wallet.with_chain_id(anvil.chain_id()),
+    ));
+    ExampleProver::deploy(client.clone(), ())
+        .unwrap()
+        .send()
+        .await
+        .unwrap();
+    anvil
+}

--- a/rust/server/tests/test_helpers/mod.rs
+++ b/rust/server/tests/test_helpers/mod.rs
@@ -9,6 +9,8 @@ use serde::{de::DeserializeOwned, Serialize};
 use serde_json::to_string;
 use tower::ServiceExt;
 
+pub(crate) mod anvil;
+
 pub(crate) async fn post<T>(app: Router, url: &str, body: &T) -> anyhow::Result<Response<Body>>
 where
     T: Serialize,


### PR DESCRIPTION
1. use `assert_eq!(expected, actual)` rather than `assert_eq!(actual, expected)` - it is a convention
2. Move `setup_anvil` to `tests/test_helpers`