### PR TITLE
Rename packages to avoid name conflicts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "rust-analyzer.linkedProjects": [
     "rust/Cargo.toml",
-    "rust/guest_wrapper/risc0_guest/Cargo.toml"
+    "rust/call/guest_wrapper/risc0_guest/Cargo.toml"
   ],
   "cSpell.words": [
     "augmentors",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1708,6 +1708,118 @@ dependencies = [
 ]
 
 [[package]]
+name = "call_engine"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rlp-derive",
+ "alloy-sol-types",
+ "alloy-trie",
+ "anyhow",
+ "as-any",
+ "dyn-clone",
+ "ethers-core",
+ "lazy_static",
+ "mpt",
+ "nybbles",
+ "once_cell",
+ "revm",
+ "risc0-zkvm",
+ "rlp",
+ "serde",
+ "serde_json",
+ "test-log",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "call_guest"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rlp-derive",
+ "anyhow",
+ "as-any",
+ "call_engine",
+ "mpt",
+ "revm",
+]
+
+[[package]]
+name = "call_guest_wrapper"
+version = "0.1.0"
+dependencies = [
+ "risc0-build",
+ "risc0-build-ethereum",
+]
+
+[[package]]
+name = "call_host"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "anyhow",
+ "auto_impl",
+ "call_engine",
+ "call_guest_wrapper",
+ "ctor",
+ "derive_more",
+ "dotenv",
+ "dyn-clone",
+ "ethereum-types",
+ "ethers-core",
+ "ethers-providers",
+ "hex",
+ "lazy_static",
+ "log",
+ "mpt",
+ "revm",
+ "risc0-ethereum-contracts",
+ "risc0-zkp",
+ "risc0-zkvm",
+ "serde",
+ "serde_json",
+ "test-log",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.18",
+ "url",
+]
+
+[[package]]
+name = "call_server"
+version = "0.1.0"
+dependencies = [
+ "alloy-chains",
+ "alloy-primitives",
+ "anyhow",
+ "axum",
+ "axum-jrpc",
+ "call_engine",
+ "call_host",
+ "ethers",
+ "hex",
+ "http-body-util",
+ "lazy_static",
+ "mime",
+ "reqwest 0.12.5",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-request-id",
+ "tracing",
+ "web_proof",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1880,12 +1992,12 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
+ "call_server",
  "clap",
  "flate2",
  "regex",
  "reqwest 0.12.5",
  "serde_json",
- "server",
  "tar",
  "tempfile",
  "test_runner",
@@ -4542,28 +4654,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "guest"
-version = "0.1.0"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rlp-derive",
- "anyhow",
- "as-any",
- "mpt",
- "revm",
- "vlayer-engine",
-]
-
-[[package]]
-name = "guest_wrapper"
-version = "0.1.0"
-dependencies = [
- "risc0-build",
- "risc0-build-ethereum",
-]
-
-[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4705,41 +4795,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "host"
-version = "0.1.0"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-types",
- "anyhow",
- "auto_impl",
- "ctor",
- "derive_more",
- "dotenv",
- "dyn-clone",
- "ethereum-types",
- "ethers-core",
- "ethers-providers",
- "guest_wrapper",
- "hex",
- "lazy_static",
- "log",
- "mpt",
- "revm",
- "risc0-ethereum-contracts",
- "risc0-zkp",
- "risc0-zkvm",
- "serde",
- "serde_json",
- "test-log",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-subscriber 0.3.18",
- "url",
- "vlayer-engine",
 ]
 
 [[package]]
@@ -7908,34 +7963,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "server"
-version = "0.1.0"
-dependencies = [
- "alloy-chains",
- "alloy-primitives",
- "anyhow",
- "axum",
- "axum-jrpc",
- "ethers",
- "hex",
- "host",
- "http-body-util",
- "lazy_static",
- "mime",
- "reqwest 0.12.5",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tower",
- "tower-http",
- "tower-request-id",
- "tracing",
- "vlayer-engine",
- "web_proof",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8508,6 +8535,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-sol-types",
+ "call_engine",
  "clap",
  "color-eyre",
  "comfy-table",
@@ -8525,7 +8553,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "vlayer-engine",
 ]
 
 [[package]]
@@ -9318,33 +9345,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "vlayer-engine"
-version = "0.1.0"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rlp-derive",
- "alloy-sol-types",
- "alloy-trie",
- "anyhow",
- "as-any",
- "dyn-clone",
- "ethers-core",
- "lazy_static",
- "mpt",
- "nybbles",
- "once_cell",
- "revm",
- "risc0-zkvm",
- "rlp",
- "serde",
- "serde_json",
- "test-log",
- "thiserror",
- "tracing",
-]
 
 [[package]]
 name = "vsimd"

--- a/rust/call/engine/Cargo.toml
+++ b/rust/call/engine/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vlayer-engine"
+name = "call_engine"
 description = "Query Ethereum state, or any other EVM-based blockchain state within the RISC Zero zkVM."
 version = "0.1.0"
 edition = "2021"

--- a/rust/call/guest/Cargo.toml
+++ b/rust/call/guest/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "guest"
+name = "call_guest"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-vlayer-engine = { path = "../engine" }
+call_engine = { path = "../engine" }
 alloy-primitives = { workspace = true }
 alloy-rlp-derive = { version = "0.3.5" }
 alloy-rlp = { version = "0.3.5", default-features = false }

--- a/rust/call/guest/src/guest.rs
+++ b/rust/call/guest/src/guest.rs
@@ -1,5 +1,5 @@
 use crate::{db::wrap_state::WrapStateDb, input_validation::ValidatedMultiEvmInput};
-use vlayer_engine::{
+use call_engine::{
     engine::Engine,
     evm::{
         env::{

--- a/rust/call/guest/src/input_validation/multi.rs
+++ b/rust/call/guest/src/input_validation/multi.rs
@@ -1,10 +1,10 @@
 use crate::db::wrap_state::WrapStateDb;
-use std::cell::RefCell;
-use std::rc::Rc;
-use vlayer_engine::evm::{
+use call_engine::evm::{
     env::{cached::MultiEvmEnv, EvmEnv},
     input::MultiEvmInput,
 };
+use std::cell::RefCell;
+use std::rc::Rc;
 
 use super::single::ValidatedEvmInput;
 
@@ -47,12 +47,12 @@ mod multi_evm_env_from_input {
 
     use super::*;
     use as_any::Downcast;
-    use mpt::EMPTY_ROOT_HASH;
-    use vlayer_engine::{
+    use call_engine::{
         block_header::eth::EthBlockHeader,
         config::{MAINNET_ID, MAINNET_MERGE_BLOCK_NUMBER},
         evm::{env::location::ExecutionLocation, input::EvmInput},
     };
+    use mpt::EMPTY_ROOT_HASH;
 
     #[test]
     fn success() -> anyhow::Result<()> {

--- a/rust/call/guest/src/input_validation/single.rs
+++ b/rust/call/guest/src/input_validation/single.rs
@@ -1,5 +1,5 @@
 use crate::db::{state::StateDb, wrap_state::WrapStateDb};
-use vlayer_engine::evm::{env::EvmEnv, input::EvmInput};
+use call_engine::evm::{env::EvmEnv, input::EvmInput};
 
 pub struct ValidatedEvmInput(pub(crate) EvmInput);
 
@@ -32,8 +32,8 @@ mod evm_env_from_input {
 
     use super::*;
     use as_any::Downcast;
+    use call_engine::block_header::eth::EthBlockHeader;
     use mpt::EMPTY_ROOT_HASH;
-    use vlayer_engine::block_header::eth::EthBlockHeader;
 
     #[test]
     fn success() {

--- a/rust/call/guest/src/lib.rs
+++ b/rust/call/guest/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod db;
 pub mod guest;
 pub mod input_validation;
+pub use call_engine::io::Input;
 pub use guest::Guest;
-pub use vlayer_engine::io::Input;

--- a/rust/call/guest_wrapper/Cargo.toml
+++ b/rust/call/guest_wrapper/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "guest_wrapper"
+name = "call_guest_wrapper"
 version = "0.1.0"
 edition = "2021"
 

--- a/rust/call/guest_wrapper/risc0_guest/Cargo.lock
+++ b/rust/call/guest_wrapper/risc0_guest/Cargo.lock
@@ -625,6 +625,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "call_engine"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rlp-derive",
+ "alloy-sol-types",
+ "anyhow",
+ "as-any",
+ "dyn-clone",
+ "ethers-core",
+ "lazy_static",
+ "mpt",
+ "nybbles",
+ "once_cell",
+ "revm",
+ "risc0-zkvm",
+ "rlp",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "call_guest"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rlp-derive",
+ "anyhow",
+ "as-any",
+ "call_engine",
+ "mpt",
+ "revm",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,20 +1119,6 @@ dependencies = [
  "ff",
  "rand_core",
  "subtle",
-]
-
-[[package]]
-name = "guest"
-version = "0.1.0"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rlp-derive",
- "anyhow",
- "as-any",
- "mpt",
- "revm",
- "vlayer-engine",
 ]
 
 [[package]]
@@ -2214,11 +2239,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "risc0_guest"
+name = "risc0_call_guest"
 version = "0.1.0"
 dependencies = [
  "alloy-sol-types",
- "guest",
+ "call_guest",
  "risc0-zkvm",
 ]
 
@@ -2969,31 +2994,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "vlayer-engine"
-version = "0.1.0"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rlp-derive",
- "alloy-sol-types",
- "anyhow",
- "as-any",
- "dyn-clone",
- "ethers-core",
- "lazy_static",
- "mpt",
- "nybbles",
- "once_cell",
- "revm",
- "risc0-zkvm",
- "rlp",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
-]
 
 [[package]]
 name = "wait-timeout"

--- a/rust/call/guest_wrapper/risc0_guest/Cargo.toml
+++ b/rust/call/guest_wrapper/risc0_guest/Cargo.toml
@@ -2,12 +2,12 @@
 
 
 [package]
-name = "risc0_guest"
+name = "risc0_call_guest"
 version = "0.1.0"
 edition = "2021"
 
 
 [dependencies]
-guest = { path = "../../guest" }
+call_guest = { path = "../../guest" }
 alloy-sol-types = { version = "0.7.5", default-features = false }
 risc0-zkvm = { version = "1.0.1", default-features = false }

--- a/rust/call/guest_wrapper/risc0_guest/src/main.rs
+++ b/rust/call/guest_wrapper/risc0_guest/src/main.rs
@@ -3,7 +3,7 @@
 risc0_zkvm::guest::entry!(main);
 
 use alloy_sol_types::SolValue;
-use guest::{Guest, Input};
+use call_guest::{Guest, Input};
 use risc0_zkvm::guest::env;
 
 fn main() {

--- a/rust/call/guest_wrapper/src/lib.rs
+++ b/rust/call/guest_wrapper/src/lib.rs
@@ -2,4 +2,4 @@
 include!(concat!(env!("OUT_DIR"), "/methods.rs"));
 
 #[cfg(clippy)]
-pub const RISC0_GUEST_ELF: &[u8] = &[];
+pub const RISC0_CALL_GUEST_ELF: &[u8] = &[];

--- a/rust/call/host/Cargo.toml
+++ b/rust/call/host/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "host"
+name = "call_host"
 version = "0.1.0"
 edition = "2021"
 
@@ -7,8 +7,8 @@ edition = "2021"
 risc0-ethereum-contracts = { path = "../../../contracts/lib/risc0-ethereum/contracts" }
 risc0-zkp = { workspace = true }
 risc0-zkvm = { workspace = true }
-vlayer-engine = { path = "../engine" }
-guest_wrapper = { path = "../guest_wrapper" }
+call_engine = { path = "../engine" }
+call_guest_wrapper = { path = "../guest_wrapper" }
 mpt = { path = "../../mpt" }
 tracing-subscriber = { workspace = true }
 alloy-primitives = { workspace = true, features = ["rlp", "serde"] }

--- a/rust/call/host/src/db/proof.rs
+++ b/rust/call/host/src/db/proof.rs
@@ -2,13 +2,13 @@ use super::provider::{ProviderDb, ProviderDbError};
 use crate::{proof::EIP1186Proof, provider::BlockingProvider};
 use alloy_primitives::{Address, Bytes, B256, U256};
 use anyhow::Context;
+use call_engine::block_header::EvmBlockHeader;
 use mpt::MerkleTrie;
 use revm::{
     primitives::{AccountInfo, Bytecode, HashMap, HashSet},
     DatabaseRef,
 };
 use std::{cell::RefCell, rc::Rc};
-use vlayer_engine::block_header::EvmBlockHeader;
 
 #[derive(Default, Debug)]
 struct State {

--- a/rust/call/host/src/evm_env/cached.rs
+++ b/rust/call/host/src/evm_env/cached.rs
@@ -2,10 +2,10 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use vlayer_engine::evm::env::{
+use call_engine::evm::env::{
     cached::MultiEvmEnv, location::ExecutionLocation, EvmEnv, EvmEnvFactory,
 };
-use vlayer_engine::utils::InteriorMutabilityCache;
+use call_engine::utils::InteriorMutabilityCache;
 
 use crate::db::proof::ProofDb;
 use crate::provider::BlockingProvider;

--- a/rust/call/host/src/evm_env/factory.rs
+++ b/rust/call/host/src/evm_env/factory.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use vlayer_engine::evm::env::{location::ExecutionLocation, EvmEnv, EvmEnvFactory};
+use call_engine::evm::env::{location::ExecutionLocation, EvmEnv, EvmEnvFactory};
 
 use crate::{
     db::proof::ProofDb,

--- a/rust/call/host/src/host.rs
+++ b/rust/call/host/src/host.rs
@@ -5,16 +5,16 @@ use crate::provider::factory::{EthersProviderFactory, ProviderFactory};
 use crate::provider::multi::CachedMultiProvider;
 use crate::provider::{BlockingProvider, EthersClient, EthersProvider};
 use alloy_primitives::ChainId;
+use call_engine::engine::Engine;
+use call_engine::evm::env::{cached::CachedEvmEnv, location::ExecutionLocation};
+use call_engine::evm::input::MultiEvmInput;
+use call_engine::io::{Call, GuestOutput, HostOutput, Input};
+use call_guest_wrapper::RISC0_CALL_GUEST_ELF;
 use config::HostConfig;
 use error::HostError;
 use ethers_core::types::BlockNumber;
-use guest_wrapper::RISC0_GUEST_ELF;
 use risc0_ethereum_contracts::groth16::abi_encode;
 use risc0_zkvm::{default_prover, is_dev_mode, ExecutorEnv, ProverOpts};
-use vlayer_engine::engine::Engine;
-use vlayer_engine::evm::env::{cached::CachedEvmEnv, location::ExecutionLocation};
-use vlayer_engine::evm::input::MultiEvmInput;
-use vlayer_engine::io::{Call, GuestOutput, HostOutput, Input};
 
 pub mod config;
 pub mod error;
@@ -84,7 +84,7 @@ where
             into_multi_input(self.envs).map_err(|err| HostError::CreatingInput(err.to_string()))?;
         let env = Self::build_executor_env(self.start_execution_location, multi_evm_input, call)?;
 
-        let (seal, raw_guest_output) = Self::prove(env, RISC0_GUEST_ELF)?;
+        let (seal, raw_guest_output) = Self::prove(env, RISC0_CALL_GUEST_ELF)?;
         let guest_output = GuestOutput::from_outputs(&host_output, &raw_guest_output)?;
 
         if guest_output.evm_call_result != host_output {

--- a/rust/call/host/src/host/error.rs
+++ b/rust/call/host/src/host/error.rs
@@ -1,9 +1,9 @@
 use crate::provider::EthersProviderError;
 use alloy_primitives::ChainId;
+use call_engine::{engine::EngineError, io::GuestOutputError};
 use ethers_providers::ProviderError;
 use risc0_zkp::verify::VerificationError;
 use thiserror::Error;
-use vlayer_engine::{engine::EngineError, io::GuestOutputError};
 
 #[derive(Error, Debug)]
 pub enum HostError {

--- a/rust/call/host/src/host_tests.rs
+++ b/rust/call/host/src/host_tests.rs
@@ -3,11 +3,11 @@ mod test {
 
     use crate::host::{config::HostConfig, error::HostError, Host};
     use crate::provider::{EthersClient, EthersProvider};
+    use call_engine::config::MAINNET_ID;
+    use call_engine::engine::EngineError;
+    use call_engine::io::Call;
     use guest_wrapper::RISC0_GUEST_ELF;
     use risc0_zkvm::ExecutorEnv;
-    use vlayer_engine::config::MAINNET_ID;
-    use vlayer_engine::engine::EngineError;
-    use vlayer_engine::io::Call;
 
     #[test]
     fn host_prove_invalid_guest_elf() {

--- a/rust/call/host/src/into_input.rs
+++ b/rust/call/host/src/into_input.rs
@@ -2,10 +2,10 @@ use crate::db::proof::ProofDb;
 use crate::provider::BlockingProvider;
 use anyhow::anyhow;
 use anyhow::{ensure, Ok};
+use call_engine::block_header::EvmBlockHeader;
+use call_engine::evm::env::cached::CachedEvmEnv;
+use call_engine::evm::input::{EvmInput, MultiEvmInput};
 use std::rc::Rc;
-use vlayer_engine::block_header::EvmBlockHeader;
-use vlayer_engine::evm::env::cached::CachedEvmEnv;
-use vlayer_engine::evm::input::{EvmInput, MultiEvmInput};
 
 pub fn into_input<P: BlockingProvider>(
     db: ProofDb<P>,

--- a/rust/call/host/src/lib.rs
+++ b/rust/call/host/src/lib.rs
@@ -4,5 +4,5 @@ pub mod host;
 pub mod into_input;
 pub mod proof;
 pub mod provider;
-pub use vlayer_engine::evm::env::location::ExecutionLocation;
-pub use vlayer_engine::io::Call;
+pub use call_engine::evm::env::location::ExecutionLocation;
+pub use call_engine::io::Call;

--- a/rust/call/host/src/provider.rs
+++ b/rust/call/host/src/provider.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, TxNumber, U256};
 use auto_impl::auto_impl;
+use call_engine::block_header::EvmBlockHeader;
 use std::error::Error as StdError;
-use vlayer_engine::block_header::EvmBlockHeader;
 
 pub mod cache;
 pub mod ethers;

--- a/rust/call/host/src/provider/cache.rs
+++ b/rust/call/host/src/provider/cache.rs
@@ -2,10 +2,10 @@ use super::{BlockingProvider, EIP1186Proof};
 use alloy_primitives::BlockNumber;
 use alloy_primitives::{Address, Bytes, StorageKey, StorageValue, TxNumber, U256};
 use anyhow::bail;
+use call_engine::block_header::EvmBlockHeader;
 use ethers_core::types::BlockNumber as BlockTag;
 use json::{AccountQuery, BlockQuery, JsonCache, ProofQuery, StorageQuery};
 use std::{cell::RefCell, collections::hash_map::Entry, path::PathBuf};
-use vlayer_engine::block_header::EvmBlockHeader;
 
 pub mod json;
 

--- a/rust/call/host/src/provider/cache/json.rs
+++ b/rust/call/host/src/provider/cache/json.rs
@@ -1,6 +1,7 @@
 use super::EIP1186Proof;
 use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, TxNumber, U256};
 use anyhow::Context;
+use call_engine::block_header::EvmBlockHeader;
 use ethers_core::types::BlockNumber as BlockTag;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -9,7 +10,6 @@ use std::{
     io::{BufReader, BufWriter},
     path::PathBuf,
 };
-use vlayer_engine::block_header::EvmBlockHeader;
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum SerializableBlockTag {

--- a/rust/call/host/src/provider/ethers.rs
+++ b/rust/call/host/src/provider/ethers.rs
@@ -1,12 +1,12 @@
 use super::{BlockingProvider, EIP1186Proof};
 use alloy_primitives::BlockNumber;
 use alloy_primitives::{B256, U256};
+use call_engine::block_header::{eth::EthBlockHeader, EvmBlockHeader};
 use ethers_core::types::Block;
 use ethers_core::types::BlockNumber as BlockTag;
 use ethers_providers::{Middleware, MiddlewareError};
 use thiserror::Error;
 use tokio::runtime::{Handle, Runtime};
-use vlayer_engine::block_header::{eth::EthBlockHeader, EvmBlockHeader};
 
 /// An error that can occur when interacting with the provider.
 #[derive(Error, Debug)]

--- a/rust/call/host/src/provider/factory.rs
+++ b/rust/call/host/src/provider/factory.rs
@@ -110,7 +110,7 @@ impl ProviderFactory<CachedProvider<EthersProvider<EthersClient>>> for CachedPro
 
 #[cfg(test)]
 mod test {
-    use vlayer_engine::config::MAINNET_ID;
+    use call_engine::config::MAINNET_ID;
 
     use super::*;
 

--- a/rust/call/host/src/provider/multi.rs
+++ b/rust/call/host/src/provider/multi.rs
@@ -2,9 +2,9 @@ use super::factory::ProviderFactory;
 use super::BlockingProvider;
 use crate::host::error::HostError;
 use alloy_primitives::ChainId;
+use call_engine::utils::InteriorMutabilityCache;
 use std::cell::RefCell;
 use std::{collections::HashMap, rc::Rc};
-use vlayer_engine::utils::InteriorMutabilityCache;
 
 type MultiProvider<P> = HashMap<ChainId, Rc<P>>;
 
@@ -35,9 +35,9 @@ mod get {
     use crate::provider::{factory::FileProviderFactory, FileProvider};
 
     use super::*;
+    use call_engine::config::MAINNET_ID;
     use null_provider_factory::NullProviderFactory;
     use std::path::PathBuf;
-    use vlayer_engine::config::MAINNET_ID;
 
     mod null_provider_factory {
         use super::{HostError, ProviderFactory};

--- a/rust/call/host/src/provider/null.rs
+++ b/rust/call/host/src/provider/null.rs
@@ -1,8 +1,8 @@
 use super::{BlockingProvider, EIP1186Proof};
 use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, TxNumber, U256};
+use call_engine::block_header::EvmBlockHeader;
 use ethers_core::types::BlockNumber as BlockTag;
 use std::{convert::Infallible, marker::PhantomData};
-use vlayer_engine::block_header::EvmBlockHeader;
 
 /// A simple provider that panics on all queries.
 #[derive(Debug, PartialEq)]

--- a/rust/call/host/tests/integration_tests.rs
+++ b/rust/call/host/tests/integration_tests.rs
@@ -3,7 +3,8 @@ use alloy_sol_types::{sol, SolCall};
 use dotenv::dotenv;
 use ethers_core::types::BlockNumber as BlockTag;
 
-use host::{
+use call_engine::config::{MAINNET_ID, SEPOLIA_ID};
+use call_host::{
     host::{config::HostConfig, error::HostError, Host},
     provider::{
         factory::{CachedProviderFactory, FileProviderFactory, ProviderFactory},
@@ -12,7 +13,6 @@ use host::{
     Call,
 };
 use std::{collections::HashMap, env};
-use vlayer_engine::config::{MAINNET_ID, SEPOLIA_ID};
 
 // To activate recording, set UPDATE_SNAPSHOTS to true.
 // Recording creates new testdata directory and writes return data from Alchemy into files in that directory.

--- a/rust/call/server/Cargo.toml
+++ b/rust/call/server/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "server"
+name = "call_server"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-vlayer-engine = { path = "../engine" }
+call_engine = { path = "../engine" }
 
 anyhow = { workspace = true }
 axum = { version = "0.7.5", features = ["macros"] }
@@ -21,7 +21,7 @@ tracing = "0.1.40"
 alloy-primitives = { workspace = true }
 hex = "0.4.3"
 axum-jrpc = "0.7.1"
-host = { path = "../host" }
+call_host = { path = "../host" }
 alloy-chains = "0.1.23"
 web_proof = { path = "../../web_proof" }
 

--- a/rust/call/server/README.md
+++ b/rust/call/server/README.md
@@ -1,4 +1,4 @@
-# Proving server
+# Call proofs server
 
 ## Running
 

--- a/rust/call/server/src/error.rs
+++ b/rust/call/server/src/error.rs
@@ -2,8 +2,8 @@ use axum_jrpc::{
     error::{JsonRpcError, JsonRpcErrorReason},
     Value,
 };
+use call_host::host::error::HostError;
 use hex::FromHexError;
-use host::host::error::HostError;
 use thiserror::Error;
 use tokio::task::JoinError;
 

--- a/rust/call/server/src/handlers/v_call.rs
+++ b/rust/call/server/src/handlers/v_call.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use crate::error::AppError;
 use crate::server::ServerConfig;
-use host::host::{config::HostConfig, Host};
-use host::Call as HostCall;
+use call_host::host::{config::HostConfig, Host};
+use call_host::Call as HostCall;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use types::{Augmentors, Call, CallContext, CallResult};

--- a/rust/call/server/src/handlers/v_call/types.rs
+++ b/rust/call/server/src/handlers/v_call/types.rs
@@ -3,7 +3,7 @@ use crate::utils::{parse_address_field, parse_hex_field};
 use alloy_chains::Chain;
 use alloy_primitives::{BlockNumber, ChainId};
 use axum_jrpc::Value;
-use host::Call as HostCall;
+use call_host::Call as HostCall;
 use serde::{Deserialize, Serialize};
 use web_proof::types::WebProof;
 
@@ -52,7 +52,7 @@ pub struct CallResult {
 mod test {
     use super::Call;
     use crate::error::AppError;
-    use host::Call as HostCall;
+    use call_host::Call as HostCall;
 
     const TO: &str = "0x7Ad53bbA1004e46dd456316912D55dBc5D311a03";
     const DATA: &str = "0x0000";

--- a/rust/call/server/src/server.rs
+++ b/rust/call/server/src/server.rs
@@ -5,10 +5,10 @@ use crate::layers::request_id::RequestIdLayer;
 use crate::layers::trace::init_trace_layer;
 use alloy_primitives::ChainId;
 use axum::{routing::post, Router};
+use call_engine::config::{MAINNET_ID, SEPOLIA_ID};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tracing::info;
-use vlayer_engine::config::{MAINNET_ID, SEPOLIA_ID};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ServerConfig {

--- a/rust/call/server/tests/test_helpers/mod.rs
+++ b/rust/call/server/tests/test_helpers/mod.rs
@@ -3,6 +3,7 @@ use axum::{
     http::{header::CONTENT_TYPE, Request, Response},
 };
 use axum_jrpc::Value;
+use call_server::server::{server, ServerConfig};
 use ethers::{
     contract::abigen,
     core::{
@@ -19,7 +20,6 @@ use mime::APPLICATION_JSON;
 use serde::Serialize;
 use serde_json::json;
 use serde_json::to_string;
-use server::server::{server, ServerConfig};
 use std::collections::HashMap;
 use std::{sync::Arc, time::Duration};
 use tower::ServiceExt;

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -15,7 +15,7 @@ flate2 = "1.0.30"
 regex = "1.10.4"
 reqwest = { version = "0.12.5", features = ["json"] }
 serde_json = "1.0.120"
-server = { path = "../call/server" }
+call_server = { path = "../call/server" }
 tar = "0.4.41"
 tempfile = "3.10.1"
 thiserror = { workspace = true }

--- a/rust/cli/src/commands/serve.rs
+++ b/rust/cli/src/commands/serve.rs
@@ -1,5 +1,5 @@
 use crate::errors::CLIError;
-use server::server::{serve, ServerConfig};
+use call_server::server::{serve, ServerConfig};
 use tracing::info;
 
 pub(crate) async fn run_serve(server_config: ServerConfig) -> Result<(), CLIError> {

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -1,8 +1,8 @@
 use crate::errors::CLIError;
+use call_server::server::ServerConfig;
 use clap::{Parser, Subcommand};
 use commands::args::{InitArgs, ServeArgs};
 use commands::{init::init, serve::run_serve};
-use server::server::ServerConfig;
 use test_runner::cli::TestArgs;
 use tracing::{error, info};
 

--- a/rust/test_runner/Cargo.toml
+++ b/rust/test_runner/Cargo.toml
@@ -24,4 +24,4 @@ regex = "1.10.4"
 serde_json = "1.0.120"
 tracing = { workspace = true }
 tokio = { workspace = true }
-vlayer-engine = { path = "../call/engine" }
+call_engine = { path = "../call/engine" }

--- a/rust/test_runner/src/cheatcode_inspector.rs
+++ b/rust/test_runner/src/cheatcode_inspector.rs
@@ -3,9 +3,7 @@ use foundry_evm::revm::interpreter::{CallInputs, CallOutcome};
 use foundry_evm::revm::primitives::U256;
 use foundry_evm::revm::{Database, EvmContext, Inspector};
 
-use vlayer_engine::utils::evm_call::{
-    create_return_outcome, create_revert_outcome, split_calldata,
-};
+use call_engine::utils::evm_call::{create_return_outcome, create_revert_outcome, split_calldata};
 
 use crate::cheatcodes::{callProverCall, getProofCall, Proof, CHEATCODE_CALL_ADDR};
 

--- a/rust/test_runner/src/cli.rs
+++ b/rust/test_runner/src/cli.rs
@@ -63,7 +63,7 @@ use crate::{
     contract_runner::ContractRunner, filter::FilterArgs, filter::ProjectPathsAwareFilter,
     summary::TestSummaryReporter, test_executor::TestExecutor,
 };
-use vlayer_engine::inspector::{TRAVEL_CONTRACT_ADDR, TRAVEL_CONTRACT_HASH};
+use call_engine::inspector::{TRAVEL_CONTRACT_ADDR, TRAVEL_CONTRACT_HASH};
 
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::merge_impl_figment_convert!(TestArgs, opts, evm_opts);


### PR DESCRIPTION
Cargo workspaces need each package to have unique name so we can't have just `guest` and need to prefix with `call_guest`. Same for engine, host, server