### PR TITLE
Add missing instalation of clang to GH release workflow.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,11 @@ jobs:
         with:
           version: nightly-5ac78a9cd4b94dc53d1fe5e0f42372b28b5a7559 # 2024-06-02
 
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v2.0.3
+        with:
+          version: "17.0.5"
+
       - name: "Build binaries"
         run: cargo build --release --target ${{ matrix.target }}
 


### PR DESCRIPTION
This PR fixes failing release.