### PR TITLE
Book: prover params

### DIFF
--- a/bash/vlayerup/vlayerup
+++ b/bash/vlayerup/vlayerup
@@ -14,7 +14,7 @@ main() {
   need_cmd git
   need_cmd curl
 
-  # Compute the URL of the release tarball in the Vlayer repository (will work with public repo)
+  # Compute the URL of the release tarball in the vlayer repository (will work with public repo)
   # TODO: Add support for different platforms/architectures
     PLATFORM=$(tolower "$(uname -s)")
     EXT="tar.gz"

--- a/book/src/advanced/prover.md
+++ b/book/src/advanced/prover.md
@@ -81,6 +81,17 @@ vlayer serve
 
 See [JSON-RPC API appendix](/appendix/api.md) for more detailed call specification.
 
+### Network Specific Configuration 
+The vlayer prover server can use different RPC node providers to query blockchain data. RPC urls for specific chains can be provided by passing the `rpc-url' configuration parameter:
+```sh 
+vlayer serve --rpc-url <chain-id>:<url>
+```
+
+Configuring multiple RPC URLs at once is also possible:
+```sh
+vlayer serve --rpc-url 11155111:https://eth-sepolia.g.alchemy.com/v2/  --rpc-url 1:https://eth-mainnet.alchemyapi.io/v2/
+```
+
 ## Proving Modes
 
 The vlayer node provides two proving modes:

--- a/book/src/appendix/api.md
+++ b/book/src/appendix/api.md
@@ -1,7 +1,7 @@
 # vlayer JSON-RPC API
 
 vlayer exposes one RPC endpoint under `/` with the following methods:
-- `v_call`
+- `v_prove`
 - `v_getProofReceipt`
 
 With general format of request looking a follows.
@@ -27,28 +27,19 @@ And the response format below.
 ```
 
 
-## v_call
-`v_call` is the core endpoint that vlayer provides for requesting proof of computation generation, with the following format request:
+## v_prove
+`v_prove` is the core endpoint that vlayer provides, with the following format request:
 
 ```json
 {
-    "method": "v_call",
-    "params": [
-        {   
-            "to": "<contract address>",
-            "data": "0x<abi encoded calldata>",
-        },
-        {
-            "block_no": "<desired block number>",
-            "chain_id": "<desired chain id>",
-        },
-        {
-             "web_proof": {
-                "notary_pub_key": "<notary public key>",
-                "tls_proof": "<tls proof value>",
-            }
-        }
-    ]
+    "method": "v_prove",
+    "params": [{   
+        "to": "<contract address>",
+        "data": "0x<abi encoded calldata>",
+        "chain_id": "<desired chain id>",
+        "email": "<optional email proof structure>",
+        "web": "<optional web proof structure>",
+    }]
 }
 ```
 
@@ -67,7 +58,7 @@ and the response:
 ## v_getProofReceipt
 
 ### Query
-To get result of `v_call` query `v_getProofReceipt`. 
+To get result of `v_prove` query `v_getProofReceipt`. 
 
 ```json
 {

--- a/book/src/appendix/architecture/block_proof.md
+++ b/book/src/appendix/architecture/block_proof.md
@@ -1,6 +1,6 @@
 # Block proof cache
 
-Vlayer allows one to provably execute Solidity code offchain and use proof of that execution onchain. To do that - one needs a verified source of storage data which is provided by storage proofs. Proofs connect to a single block hash that is later verified on-chain.
+vlayer allows one to provably execute Solidity code offchain and use proof of that execution onchain. To do that - one needs a verified source of storage data which is provided by storage proofs. Proofs connect to a single block hash that is later verified on-chain.
 
 We also provide time-travel functionality. As a result of that - our state and storage proofs do not connect to a single block, but to multiple blocks. In order to prove that a set of blocks belongs to the chain - we prove two facts:
 

--- a/rust/call/engine/src/sol/execution_commitment.rs
+++ b/rust/call/engine/src/sol/execution_commitment.rs
@@ -1,4 +1,4 @@
-// Keep everything in the Vlayer library private except the commitment.
+// Keep everything in the vlayer library private except the commitment.
 mod private {
     alloy_sol_types::sol!(#![sol(all_derives)] "../../../contracts/src/ExecutionCommitment.sol");
 }


### PR DESCRIPTION
- Rename `v_prove` into `v_call` 
- Provide up to date structure of `v_call` params 
- Document `rpc-url` parameter for `vlayer serve` 
- Make `vlayer` lowercase everywhere