### PR TITLE
Set rust-analyzer env vars to match those from cargo to avoid guest_wrapper recompilation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,6 @@
 lint = "clippy --workspace --all-targets --all-features"
 
 [env]
+# Should be in sync with ./vscode/settings.json "rust-analyzer.server.extraEnv" section to avoid recompilation of guest_wrapper
 CC_riscv32im_risc0_zkvm_elf = "clang"
 CFLAGS_riscv32im_risc0_zkvm_elf = "-nostdlibinc -DRING_CORE_NOSTDLIBINC=1 -target riscv32-unknown-elf -march=rv32im"
-# RISC0_SKIP_BUILD = "1"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,11 @@
     "rust/Cargo.toml",
     "rust/call/guest_wrapper/risc0_guest/Cargo.toml"
   ],
+  "rust-analyzer.server.extraEnv": {
+    // Should be in sync with ./cargo/config.toml [env] section to avoid recompilation of guest_wrapper
+    "CC_riscv32im_risc0_zkvm_elf": "clang",
+    "CFLAGS_riscv32im_risc0_zkvm_elf": "-nostdlibinc -DRING_CORE_NOSTDLIBINC=1 -target riscv32-unknown-elf -march=rv32im"
+  },
   "cSpell.words": [
     "augmentors",
     "binstall",

--- a/book/src/contributing/vlayer.md
+++ b/book/src/contributing/vlayer.md
@@ -44,18 +44,3 @@ bun run prove.ts
 ``` 
 
 For guides about the project structure, check out [architecture appendix](/appendix/architecture.md).
-
-## Developer experience
-
-Incremental compilation in this repo is slow by default because it re-compiles `guest_wrapper` to `RISC-V` target to generate up to date `GUEST_ELF`.
-Most developer workflows don't need this and therefore would benefit from temporarily disabling this step.
-
-Examples on when you should disable it:
-* Getting something to type-check/compile
-* Working on unit-tests of functionality that does not call any guest code through host
-
-Examples when you should not disable it:
-* CI
-* Integration/E2E tests that call guest through host
-
-To disable guest build - set the flag: `RISC0_SKIP_BUILD = "1"` in `.cargo/config.toml`. This file is respected by both rust-analyzer in the IDE as well as CLI commands

--- a/rust/call/server/src/server.rs
+++ b/rust/call/server/src/server.rs
@@ -19,7 +19,7 @@ pub fn server(config: ServerConfig) -> Router {
     config.proof_mode.set_risc0_flag();
     let config = Arc::new(config);
     let jrpc_handler = move |params| Box::pin(v_call(config.clone(), params)) as Pin<Box<_>>;
-    let http_handler = move |req| async move { route(req, "v_call", jrpc_handler).await };
+    let http_handler = |req| async move { route(req, "v_call", jrpc_handler).await };
 
     Router::new()
         .route("/", post(http_handler))


### PR DESCRIPTION
There is [an issue](https://github.com/rust-lang/rust-analyzer/issues/5828), that rust-analyzer does not respect evn variables set in `./cargo/config.toml` and they need to be duplicated to avoid flickering and recompilation

This superceeds https://github.com/vlayer-xyz/vlayer/pull/388 as this is a better solution. It compiles guest when something changed. I still get fast compile times for other code with this solution

The only problem is that we need to keep those flags in sync, but I've added comments in two places. Nice that JSON finally supports comments in 2024