### PR TITLE
Add guest profiling feature to host.

### DIFF
--- a/rust/call/host/Cargo.toml
+++ b/rust/call/host/Cargo.toml
@@ -30,3 +30,6 @@ alloy-sol-types = { workspace = true }
 test-log = { workspace = true }
 anyhow = { workspace = true }
 ctor = { workspace = true }
+
+[features]
+profiling = []

--- a/rust/call/host/src/host.rs
+++ b/rust/call/host/src/host.rs
@@ -102,6 +102,7 @@ where
         })
     }
 
+    #[cfg(not(feature = "profiling"))]
     pub(crate) fn prove(
         env: ExecutorEnv,
         guest_elf: &[u8],
@@ -133,5 +134,18 @@ where
             .build()
             .map_err(|err| HostError::ExecutorEnvBuilder(err.to_string()))?;
         Ok(env)
+    }
+
+    #[cfg(feature = "profiling")]
+    pub(crate) fn prove(
+        env: ExecutorEnv,
+        guest_elf: &[u8],
+    ) -> Result<(Vec<u8>, Vec<u8>), HostError> {
+        use risc0_zkvm::{default_executor, ExecutorEnv};
+
+        let exec = default_executor();
+        exec.execute(env, guest_elf)?;
+
+        Ok((Vec::new(), Vec::new()))
     }
 }

--- a/rust/call/server/Cargo.toml
+++ b/rust/call/server/Cargo.toml
@@ -29,3 +29,6 @@ lazy_static = { workspace = true }
 web_proof = { path = "../../web_proof", features = ["fixtures"] }
 ethers = { workspace = true }
 assert-json-diff = "2.0.2"
+
+[features]
+profiling = ["call_host/profiling"]

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -33,3 +33,6 @@ regex = "1.10.6"
 
 [build-dependencies]
 vergen = { workspace = true, features = ["build", "git", "gitcl"] }
+
+[features]
+profiling = ["call_server/profiling"]


### PR DESCRIPTION
This is my proposal to make it possible to profile guest code with pprof. It enables running `cargo run --features profiling --bin vlayer serve` and thus using this feature within our examples.

Next step will be to add a bash script to run example profiling.