### PR TITLE
chore: bump foundry in GH Actions

### DIFF
--- a/.github/workflows/cli_test.yaml
+++ b/.github/workflows/cli_test.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-5ac78a9cd4b94dc53d1fe5e0f42372b28b5a7559 # 2024-06-02
+          version: nightly-626221f5ef44b4af950a08e09bd714650d9eb77d # 2024-08-02
 
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-5ac78a9cd4b94dc53d1fe5e0f42372b28b5a7559 # 2024-06-02
+          version: nightly-626221f5ef44b4af950a08e09bd714650d9eb77d # 2024-08-02
 
       - name: Check clang and LLVM version
         env:

--- a/.github/workflows/foundry.yaml
+++ b/.github/workflows/foundry.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-5ac78a9cd4b94dc53d1fe5e0f42372b28b5a7559 # 2024-06-02
+          version: nightly-626221f5ef44b4af950a08e09bd714650d9eb77d # 2024-08-02
 
       - name: Mock ImageId.sol
         run: ./bash/mock-imageid.sh

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-5ac78a9cd4b94dc53d1fe5e0f42372b28b5a7559 # 2024-06-02
+          version: nightly-626221f5ef44b4af950a08e09bd714650d9eb77d # 2024-08-02
 
       - name: Run Clippy Host
         working-directory: rust

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-5ac78a9cd4b94dc53d1fe5e0f42372b28b5a7559 # 2024-06-02
+          version: nightly-626221f5ef44b4af950a08e09bd714650d9eb77d # 2024-08-02
 
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2.0.4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-5ac78a9cd4b94dc53d1fe5e0f42372b28b5a7559 # 2024-06-02
+          version: nightly-626221f5ef44b4af950a08e09bd714650d9eb77d # 2024-08-02
 
       - name: Check clang and LLVM version
         env:

--- a/.github/workflows/version_e2e.yaml
+++ b/.github/workflows/version_e2e.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-5ac78a9cd4b94dc53d1fe5e0f42372b28b5a7559 # 2024-06-02
+          version: nightly-626221f5ef44b4af950a08e09bd714650d9eb77d # 2024-08-02
 
       - name: Check clang and LLVM version
         env:


### PR DESCRIPTION
Let's bump foundry to a version that supports `soldeer`