### PR TITLE
Reproduced string Verifier param verification issues in Verifier test.

### DIFF
--- a/contracts/test/Verifier.t.sol
+++ b/contracts/test/Verifier.t.sol
@@ -46,6 +46,15 @@ contract ExampleVerifier is Verifier {
     {
         return value;
     }
+
+    function verifyWithString(Proof calldata, string calldata value)
+        external
+        view
+        onlyVerified(PROVER, SIMPLE_PROVER_SELECTOR)
+        returns (string memory)
+    {
+        return value;
+    }
 }
 
 contract Verifier_OnlyVerified_Modifier_Tests is Test {
@@ -98,5 +107,28 @@ contract Verifier_OnlyVerified_Modifier_Tests is Test {
 
         assertEq(exampleVerifier.verifySomethingElse(proof, true), true);
         assertEq(exampleVerifier.verifySomethingElse(proof, false), false);
+    }
+
+    function test_journaledStringParam() public view {
+        string memory value = "abc";
+        (Proof memory proof,) = helpers.createProof(commitment, abi.encode(value));
+
+        assertEq(exampleVerifier.verifyWithString(proof, value), value);
+    }
+
+    function test_journaledStringParamCannotBeChanged() public {
+        string memory value = "abc";
+        (Proof memory proof,) = helpers.createProof(commitment, abi.encode(value));
+
+        value = "def";
+
+        vm.expectRevert(VerificationFailed.selector);
+        assertEq(exampleVerifier.verifyWithString(proof, value), value);
+    }
+
+    function test_functionCanHaveNonJournaledStringParams() public view {
+        (Proof memory proof,) = helpers.createProof(commitment);
+
+        assertEq(exampleVerifier.verifyWithString(proof, "xyz"), "xyz");
     }
 }


### PR DESCRIPTION
This commit reproduces the issue we noticed when trying to pass `string` between `Prover` and `Verifier` in web proof example. `Verifier` call works with `onlyVerified` removed and the issue is with verification, which is reproduced in these failing tests.