### PR TITLE
Add global lint fix script

### DIFF
--- a/bash/lint-fix.sh
+++ b/bash/lint-fix.sh
@@ -6,22 +6,21 @@ VLAYER_HOME=$(git rev-parse --show-toplevel)
 
 for example in $(find ${VLAYER_HOME}/examples -type d -maxdepth 1 -mindepth 1) ; do
   (
-    echo "Running eslint for: ${example}"
     cd "${example}/vlayer"
 
-    bun install --no-save
-    bun run eslint . --fix
-    bun run lint:solidity -- --fix --noPrompt
+    bun install --no-save --silent
+    bun run --silent eslint . --fix
+    bun run --silent lint:solidity -- --fix --noPrompt
   )
 done
 
 cd "${VLAYER_HOME}/packages"
-bun install --no-save
-bun run lint:fix
+bun install --no-save --silent
+bun run --silent lint:fix
 
 cd "${VLAYER_HOME}/contracts"
-bun install --no-save
-bun run lint:solidity -- --fix --noPrompt
+bun install --no-save --silent
+bun run --silent lint:solidity -- --fix --noPrompt
 
 forge fmt "${VLAYER_HOME}/examples" -- --write
 forge fmt "${VLAYER_HOME}/contracts/src" -- --write


### PR DESCRIPTION
To avoid this:
<img width="306" alt="image" src="https://github.com/user-attachments/assets/d5a2c5f9-cba5-4a49-8574-230e18e90edd">
