### PR TITLE
Remove server_utils dependency on call_host

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1776,6 +1776,7 @@ dependencies = [
  "dotenv",
  "ethers-core",
  "ethers-providers",
+ "host_utils",
  "mpt",
  "revm",
  "risc0-ethereum-contracts",
@@ -4761,6 +4762,10 @@ checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "host_utils"
+version = "0.1.0"
 
 [[package]]
 name = "html5ever"
@@ -7901,9 +7906,9 @@ dependencies = [
  "anyhow",
  "axum",
  "axum-jrpc",
- "call_host",
  "ethers",
  "hex",
+ "host_utils",
  "http-body-util",
  "mime",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "test_runner",
     "web_proof",
     "server_utils",
+    "host_utils",
 ]
 default-members = ["cli"]
 
@@ -104,6 +105,7 @@ server_utils = { path = "server_utils" }
 mpt = { path = "mpt" }
 web_proof = { path = "web_proof" }
 test_runner = { path = "test_runner" }
+host_utils = { path = "host_utils" }
 
 risc0-ethereum-contracts = { path = "../contracts/lib/risc0-ethereum/contracts" }
 

--- a/rust/host_utils/Cargo.toml
+++ b/rust/host_utils/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "host_utils"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust/host_utils/src/lib.rs
+++ b/rust/host_utils/src/lib.rs
@@ -1,0 +1,6 @@
+#[derive(Default, Copy, Clone)]
+pub enum ProofMode {
+    #[default]
+    Fake,
+    Groth16,
+}

--- a/rust/server_utils/Cargo.toml
+++ b/rust/server_utils/Cargo.toml
@@ -19,4 +19,4 @@ tower = { workspace = true }
 tower-http = { workspace = true, features = ["trace"] }
 tower-request-id = { workspace = true }
 tracing = { workspace = true }
-call_host = { workspace = true }
+host_utils = { workspace = true }

--- a/rust/server_utils/src/proof_mode.rs
+++ b/rust/server_utils/src/proof_mode.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use call_host::host::config::ProofMode as HostProofMode;
+use host_utils::ProofMode as HostProofMode;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum ProofMode {

--- a/rust/services/call/host/Cargo.toml
+++ b/rust/services/call/host/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 risc0-ethereum-contracts = { workspace = true }
 risc0-zkp = { workspace = true }
 risc0-zkvm = { workspace = true }
+host_utils = { workspace = true }
 call_engine = { workspace = true }
 call_guest_wrapper = { workspace = true }
 mpt = { workspace = true }

--- a/rust/services/call/host/src/host/config.rs
+++ b/rust/services/call/host/src/host/config.rs
@@ -2,12 +2,7 @@ use std::collections::HashMap;
 
 use alloy_primitives::ChainId;
 
-#[derive(Default, Clone, Copy)]
-pub enum ProofMode {
-    #[default]
-    Fake,
-    Groth16,
-}
+use host_utils::ProofMode;
 
 #[derive(Default)]
 pub struct HostConfig {

--- a/rust/services/call/host/src/host/prover.rs
+++ b/rust/services/call/host/src/host/prover.rs
@@ -3,7 +3,8 @@ use risc0_zkvm::{
     BonsaiProver, ExecutorEnv, ExternalProver, ProveInfo, Prover as ProverTrait, ProverOpts,
 };
 
-use super::config::{HostConfig, ProofMode};
+use super::config::HostConfig;
+use host_utils::ProofMode;
 
 pub(super) struct Prover {
     mode: ProofMode,


### PR DESCRIPTION
Having server_utils depending on call service introduced unecesary recompilations when working on chain proofs.
This PR starts a new package host_utils which for now has only one member but I'll move more common code from host there while writing the second host