### PR TITLE
CI: free up macos disk space

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,15 @@ jobs:
         with:
           submodules: recursive
 
+      # Free up disk space as the macOS runners end up using most for Xcode
+      # versions we don't need and use iOS simulators.
+      - name: Free up disk space
+        if:  matrix.runner == 'macos-latest' 
+        run: |
+          echo '*** Delete iOS simulators and their caches'
+          xcrun simctl delete all
+          sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/*
+
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:


### PR DESCRIPTION
Root cause is in GH Actions runner, that it suddenly has much less disk space available, so, as suggested in GH Issue comment, we are deleting iOS Simulators, since we are not using them anyways.

Related to: https://github.com/actions/runner-images/issues/10511

Fix as suggested in: https://github.com/actions/runner-images/issues/10511#issuecomment-2329762800