### PR TITLE
Link libusb statically in release.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,6 @@ lint = "clippy --workspace --all-targets --all-features"
 # Should be in sync with ./vscode/settings.json "rust-analyzer.server.extraEnv" section to avoid recompilation of guest_wrapper
 CC_riscv32im_risc0_zkvm_elf = "clang"
 CFLAGS_riscv32im_risc0_zkvm_elf = "-nostdlibinc -DRING_CORE_NOSTDLIBINC=1 -target riscv32-unknown-elf -march=rv32im"
+
+# link libusb statically to avoid runtime linking issues
+LIBUSB_STATIC = "1"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,8 +74,6 @@ jobs:
       - name: "Build binaries"
         env:
           VLAYER_RELEASE: "nightly"
-          # link libusb statically to avoid runtime linking issues
-          LIBUSB_STATIC: 1
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package release

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,8 @@
   "rust-analyzer.server.extraEnv": {
     // Should be in sync with ./cargo/config.toml [env] section to avoid recompilation of guest_wrapper
     "CC_riscv32im_risc0_zkvm_elf": "clang",
-    "CFLAGS_riscv32im_risc0_zkvm_elf": "-nostdlibinc -DRING_CORE_NOSTDLIBINC=1 -target riscv32-unknown-elf -march=rv32im"
+    "CFLAGS_riscv32im_risc0_zkvm_elf": "-nostdlibinc -DRING_CORE_NOSTDLIBINC=1 -target riscv32-unknown-elf -march=rv32im",
+    "LIBUSB_STATIC": "1"
   },
   "cSpell.words": [
     "augmentors",


### PR DESCRIPTION
## Testing 
Ran a test release build here: https://github.com/vlayer-xyz/vlayer/actions/runs/10827015959/job/30039239852
Downloaded the binary and it didn't complain about missing libusb anymore.