### PR TITLE
chore: do not remove ImageID on RISC0_SKIP_BUILD

### DIFF
--- a/rust/services/call/guest_wrapper/build.rs
+++ b/rust/services/call/guest_wrapper/build.rs
@@ -4,8 +4,13 @@ fn main() -> Result<()> {
     #[cfg(not(clippy))]
     {
         use risc0_build_ethereum::{generate_solidity_files, Options};
+        use std::env;
         use std::fs::{create_dir_all, remove_file};
         use std::path::Path;
+
+        if env::var("RISC0_SKIP_BUILD").is_ok() {
+            return Ok(());
+        }
 
         let guests = risc0_build::embed_methods();
 


### PR DESCRIPTION
We used to have a solution similar to this one, but had to disable it, since it caused some problems with IDEs and CIs - I do not remember exactly what was the issue. 

The following seems to work, let's test it.


Prev: https://github.com/vlayer-xyz/vlayer/commit/817e75838e474d3891549aa27a8d298b605524ec