### PR TITLE
Don't reset chain id on set block

### DIFF
--- a/rust/services/call/engine/src/evm/env/location.rs
+++ b/rust/services/call/engine/src/evm/env/location.rs
@@ -15,3 +15,9 @@ impl ExecutionLocation {
         }
     }
 }
+
+impl From<(BlockNumber, ChainId)> for ExecutionLocation {
+    fn from((block_number, chain_id): (BlockNumber, ChainId)) -> Self {
+        Self::new(block_number, chain_id)
+    }
+}

--- a/rust/services/call/engine/src/inspector.rs
+++ b/rust/services/call/engine/src/inspector.rs
@@ -98,7 +98,7 @@ impl<'a> TravelInspector<'a> {
             "Travel contract called with function: setBlock and block number: {:?}! Chain id remains {:?}.",
             block_number, chain_id
         );
-        self.location = Some(ExecutionLocation::new(block_number, chain_id));
+        self.location = Some((block_number, chain_id).into());
     }
 
     fn set_chain(&mut self, chain_id: ChainId, block_number: u64) {
@@ -106,7 +106,7 @@ impl<'a> TravelInspector<'a> {
             "Travel contract called with function: setChain, with chain id: {:?} block number: {:?}!",
             chain_id, block_number
         );
-        self.location = Some(ExecutionLocation::new(block_number, chain_id));
+        self.location = Some((block_number, chain_id).into());
     }
 
     fn on_call(&self, inputs: &CallInputs) -> Option<CallOutcome> {
@@ -207,10 +207,10 @@ mod test {
 
     #[test]
     fn set_block_sets_chain_id_to_latest_not_start() {
-        let locations = vec![
-            ExecutionLocation::new(MAINNET_BLOCK, MAINNET_ID),
-            ExecutionLocation::new(SEPOLIA_BLOCK, SEPOLIA_ID),
-            ExecutionLocation::new(SEPOLIA_BLOCK - 1, SEPOLIA_ID),
+        let locations: Vec<ExecutionLocation> = vec![
+            (MAINNET_BLOCK, MAINNET_ID).into(),
+            (SEPOLIA_BLOCK, SEPOLIA_ID).into(),
+            (SEPOLIA_BLOCK - 1, SEPOLIA_ID).into(),
         ];
         let mut inspector = TravelInspector::new(locations[0].chain_id, |_, _| Ok(vec![]));
 

--- a/rust/services/call/host/src/host.rs
+++ b/rust/services/call/host/src/host.rs
@@ -59,7 +59,7 @@ where
         let providers = CachedMultiProvider::new(provider_factory);
         let block_number = get_block_number(&providers, config.start_chain_id)?;
         let envs = CachedEvmEnv::from_factory(HostEvmEnvFactory::new(providers));
-        let start_execution_location = ExecutionLocation::new(block_number, config.start_chain_id);
+        let start_execution_location = (block_number, config.start_chain_id).into();
         let prover = Prover::new(config.proof_mode);
 
         Ok(Host {
@@ -76,7 +76,7 @@ where
     ) -> Result<Self, HostError> {
         let providers = CachedMultiProvider::new(provider_factory);
         let envs = CachedEvmEnv::from_factory(HostEvmEnvFactory::new(providers));
-        let start_execution_location = ExecutionLocation::new(block_number, config.start_chain_id);
+        let start_execution_location = (block_number, config.start_chain_id).into();
         let prover = Prover::new(config.proof_mode);
 
         Ok(Host {


### PR DESCRIPTION
setBlock is a function that should allow one to travel within the chain. There was a bug. It used to reset chainId to start chain.
This fixes it and adds a regression test