### PR TITLE
fix: run fake proofs on main branch e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -51,7 +51,8 @@ jobs:
         
       - name: Run e2e test
         env:
-          PROVING_MODE: ${{ github.ref == 'refs/heads/main' && 'prod' || 'dev' }}
+          # PROVING_MODE: ${{ github.ref == 'refs/heads/main' && 'prod' || 'dev' }}
+          PROVING_MODE: 'dev'
           BONSAI_API_URL: ${{ vars.BONSAI_API_URL }}
           BONSAI_API_KEY: ${{ secrets.BONSAI_API_KEY }}
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}


### PR DESCRIPTION
Let's disable prod proving in main e2e tests for now. I'm trying resolve the issue with risc0 team, but apparently it takes a bit longer than a day