### PR TITLE
CI: Manual release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,10 @@ name: Release binaries
 on: 
   schedule:
     - cron: '0 22 * * 1-5' # Mon-Fri at 22:00 UTC
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 jobs:
   build-release:
     defaults:


### PR DESCRIPTION
- This will add a little button [here](https://github.com/vlayer-xyz/vlayer/actions/workflows/release.yaml) to manually trigger a release - also keeping the existing nightly scheduled releases.
- We ensure that only one release job runs at a given time globally - we don't want to run into unexpected problems.
We will wait for them to finish one-by-one in order.