### PR TITLE
Do not cancel in-progress jobs on `main`

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,7 +12,8 @@ on:
       - "contracts/**"
   merge_group:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Do not cancel jobs on main by forcing a unique group name.
+  group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.run_id || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/foundry.yaml
+++ b/.github/workflows/foundry.yaml
@@ -11,7 +11,8 @@ on:
       - '**'
   merge_group:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Do not cancel jobs on main by forcing a unique group name.
+  group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.run_id || github.ref_name }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,7 +10,8 @@ on:
       - '**'
   merge_group:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Do not cancel jobs on main by forcing a unique group name.
+  group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.run_id || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/lint_solidity.yaml
+++ b/.github/workflows/lint_solidity.yaml
@@ -6,7 +6,8 @@ on:
       - 'contracts/**'
   merge_group:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Do not cancel jobs on main by forcing a unique group name.
+  group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.run_id || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/rust_test.yaml
+++ b/.github/workflows/rust_test.yaml
@@ -11,7 +11,8 @@ on:
       - "**"
   merge_group:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Do not cancel jobs on main by forcing a unique group name.
+  group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.run_id || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sdk_test.yaml
+++ b/.github/workflows/sdk_test.yaml
@@ -9,7 +9,8 @@ on:
       - "**"
   merge_group:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Do not cancel jobs on main by forcing a unique group name.
+  group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.run_id || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ts_lint.yaml
+++ b/.github/workflows/ts_lint.yaml
@@ -6,7 +6,8 @@ on:
       - 'packages/**'
   merge_group:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Do not cancel jobs on main by forcing a unique group name.
+  group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.run_id || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tsc.yaml
+++ b/.github/workflows/tsc.yaml
@@ -6,7 +6,8 @@ on:
       - 'packages/**'
   merge_group:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Do not cancel jobs on main by forcing a unique group name.
+  group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.run_id || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/vlayer_test.yaml
+++ b/.github/workflows/vlayer_test.yaml
@@ -13,7 +13,8 @@ on:
       - "**"
   merge_group:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Do not cancel jobs on main by forcing a unique group name.
+  group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.run_id || github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Make sure the jobs are not canceled on pushes `main`.

Caution: It is possible to set `cancel-in-progress: ${{ github.ref_name != 'main' }}`, but this is **a false promise** - doesn't completely work as intended, because there can only ever be 1 pending job within a concurrency group. So if there is a commit A on `main` running, and we merge a commit B, it will be pending and wait for job A to finish. But if another commit C gets merged quickly, it still won't cancel the job A but it will cancel the pending job B - not what we want.

So we make sure each commit on `main` has it's own concurrency group, and we only cancel jobs on PRs.

**Edit**:
Recreated this PR with a different approach, because we do want jobs running on all pushed commits.