### PR TITLE
Add wasm-unsafe-eval to CSP in extension manifest.

### DIFF
--- a/packages/browser-extension/src/manifest.json
+++ b/packages/browser-extension/src/manifest.json
@@ -38,5 +38,8 @@
       "matches": ["*://*/*"],
       "js": ["src/content.ts"]
     }
-  ]
+  ],
+  "content_security_policy": {
+        "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';"
+    }
 }


### PR DESCRIPTION
This was missing to make the published extension work.