### PR TITLE
Added WebSocket proxy section in web proofs book documentation.

### DIFF
--- a/book/src/javascript/web-proofs.md
+++ b/book/src/javascript/web-proofs.md
@@ -153,7 +153,7 @@ cargo install websocat
 websocat --binary -v ws-l:0.0.0.0:55688 tcp:api.x.com:443
 ```
 
-replacing `api.x.com` with the domain you'd like to use. Then use your local WS proxy (running at port 55688) when creating Web Proof provider: 
+Replace `api.x.com` with the domain you'd like to use. Then, configure your Web Proof provider to use your local WebSocket proxy (running on port 55688):
 
 ```ts
 import { createExtensionWebProofProvider } from '@vlayer/sdk/web_proof'


### PR DESCRIPTION
This addresses the issue described in [Discord](https://discord.com/channels/1196440523662163999/1265569498203684905/1294235386956091476).

I've tested this instruction with our web-proof example (modifying the code after `vlayer init`) and it worked fine for `api.x.com` with local proxy.