### PR TITLE
Auto-update development prover server after release

### DIFF
--- a/.github/workflows/update_dev_prover.yaml
+++ b/.github/workflows/update_dev_prover.yaml
@@ -1,0 +1,35 @@
+# Auto-updates the development Prover server with a latest nightly vlayer release,
+# after a successful release.
+name: Update Prover Server
+on: 
+  workflow_run:
+    workflows: ["Release binaries"]
+    types: [completed]
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+jobs:
+  update-prover-server:
+    name: Update Prover server
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    defaults:
+      run:
+        working-directory: ansible
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Add deployer ssh key and run the Ansible playbook
+        run: |
+          eval "$(ssh-agent -s)"
+          ssh-add - <<< "${{ secrets.DEVELOPMENT_DEPLOYER_SSH_KEY }}"
+
+          ansible-playbook -i hosts.yml --limit "dev_prover" prover.yml \
+            --vault-password-file <(echo '${{ secrets.ANSIBLE_DEVELOPMENT_VAULT_PASSWORD }}')
+      - name: Clean up manually added ssh keys
+        if: always()
+        run: |
+          eval "$(ssh-agent -s)"
+          ssh-add -D

--- a/ansible/host_vars/dev_prover.yml
+++ b/ansible/host_vars/dev_prover.yml
@@ -1,5 +1,6 @@
 ---
 ansible_host: 54.175.221.188
+ansible_host_public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINo/MK9nQ3Xy7iCdw6kcewjFdIagBC8HzS/L2tqgmUjc
 ansible_user: ubuntu
 vlayer_prover_host: 0.0.0.0
 vlayer_prover_port: 3000

--- a/ansible/prover.yml
+++ b/ansible/prover.yml
@@ -1,6 +1,21 @@
 ---
 - name: Install vlayer prover
   hosts: provers
+  gather_facts: false
+
+  pre_tasks:
+    - name: Ensure .ssh exists
+      delegate_to: 127.0.0.1
+      ansible.builtin.file:
+        path: ~/.ssh
+        state: directory
+        mode: '700'
+    - name: Save host public key to ssh known hosts
+      delegate_to: 127.0.0.1
+      ansible.builtin.known_hosts:
+        path: ~/.ssh/known_hosts
+        name: "{{ inventory_hostname }}"
+        key: "{{ inventory_hostname }},{{ ansible_host }} {{ ansible_host_public_key }}"
 
   roles:
     - role: prover


### PR DESCRIPTION
- This adds a workflow which runs after a successful release (or manually), which updates the development prover server with latest nightly vlayer.
- The workflow adds an SSH key from secrets which is accepted by the prover server, and removes it afterwards - so it cannot be used by other jobs on the same runner.
- Ansible is strict with host key checking. Added the public host key of the prover server so it can be checked by Ansible.
- Example of a successful run is [here](https://github.com/vlayer-xyz/vlayer/actions/runs/11293084445/job/31410430672).