### PR TITLE
Add missing description to browser extensions

### DIFF
--- a/packages/browser-extension/package.json
+++ b/packages/browser-extension/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@vlayer/browser-extension",
+  "description": "Generate Web Proofs of your private data from any website.",
   "private": true,
   "version": "1.0.0",
   "type": "module",


### PR DESCRIPTION
This fixes the botched overview on the store.
It will be added to manifest [here](https://github.com/vlayer-xyz/vlayer/blob/8b33b73a85045a444e4581ac96351a33d4614be6/packages/browser-extension/vite.config.ts#L11).
Kudos for @vanruch for finding this.

![Screenshot 2024-10-14 at 10 05 51](https://github.com/user-attachments/assets/5351d1a4-9de6-4ca3-87ce-d38074681fad)
