### PR TITLE
Limit triggering pushes to own workflows

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,7 +8,7 @@ on:
       - "examples/**"
       - "packages/vlayer/**"
       - "bash/**"
-      - ".github/workflows/**"
+      - ".github/workflows/e2e.yaml"
       - "contracts/**"
   merge_group:
 concurrency:

--- a/.github/workflows/rust_test.yaml
+++ b/.github/workflows/rust_test.yaml
@@ -6,7 +6,7 @@ on:
       - "rust-toolchain.toml"
       - "rust/**"
       - "examples/**"
-      - ".github/workflows/**"
+      - ".github/workflows/rust_test.yaml"
     branches:
       - "**"
   merge_group:

--- a/.github/workflows/sdk_test.yaml
+++ b/.github/workflows/sdk_test.yaml
@@ -4,7 +4,7 @@ on:
   push:
     paths:
       - "packages/sdk/**"
-      - ".github/workflows/**"
+      - ".github/workflows/sdk_test.yaml"
     branches:
       - "**"
   merge_group:

--- a/.github/workflows/vlayer_test.yaml
+++ b/.github/workflows/vlayer_test.yaml
@@ -8,7 +8,7 @@ on:
       - "rust-toolchain.toml"
       - "rust/**"
       - "examples/**"
-      - ".github/workflows/**"
+      - ".github/workflows/vlayer_test.yaml"
     branches:
       - "**"
   merge_group:


### PR DESCRIPTION
Currently, if you edit one workflow, you trigger all others (including E2E which is slow and occupies our runners).