### PR TITLE
Introduce node_exporter to prover servers

### DIFF
--- a/.github/workflows/update_prover_servers.yaml
+++ b/.github/workflows/update_prover_servers.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Install ansible galaxy collections
+        run: ansible-galaxy collection install -r requirements.yml
       - name: Add deployer ssh key and run the Ansible playbook
         run: |
           eval "$(ssh-agent -s)"

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -5,6 +5,7 @@ This is a collection of vlayer ansible scripts and roles.
 ## Prerequisites
 
 1. [Install Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html).
+2. Install galaxy collections: `ansible-galaxy collection install -r requirements.yml`
 
 ## Available roles
 

--- a/ansible/prover.yml
+++ b/ansible/prover.yml
@@ -1,6 +1,9 @@
 ---
 - name: Install vlayer prover
   hosts: provers
+  # First, we skip gathering facts because on CI we need to
+  # Save all the known ssh hosts before initiating connections.
+  # Facts are gathered right after that.
   gather_facts: false
 
   pre_tasks:
@@ -16,6 +19,9 @@
         path: ~/.ssh/known_hosts
         name: "{{ inventory_hostname }}"
         key: "{{ inventory_hostname }},{{ ansible_host }} {{ ansible_host_public_key }}"
+    - name: Gather facts
+      ansible.builtin.gather_facts:
 
   roles:
     - role: prover
+    - role: prometheus.prometheus.node_exporter

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,6 @@
+---
+roles: []
+collections:
+  - name: prometheus.prometheus
+    version: 0.19.0
+    source: https://galaxy.ansible.com


### PR DESCRIPTION
Introduces a [node_exporter](https://github.com/prometheus/node_exporter) to our prover servers.

We will use for monitoring the health of the machines.