### PR TITLE
New fake prover server with risc0 installation

### DIFF
--- a/.github/workflows/update_prover_servers.yaml
+++ b/.github/workflows/update_prover_servers.yaml
@@ -22,7 +22,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install ansible galaxy collections
-        run: ansible-galaxy collection install -r requirements.yml
+        run: |
+          ansible-galaxy collection install -r requirements.yml
+          ansible-galaxy role install -r requirements.yml
       - name: Add deployer ssh key and run the Ansible playbook
         run: |
           eval "$(ssh-agent -s)"

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -6,6 +6,7 @@ This is a collection of vlayer ansible scripts and roles.
 
 1. [Install Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html).
 2. Install galaxy collections: `ansible-galaxy collection install -r requirements.yml`
+3. Install galaxy roles: `ansible-galaxy role install -r requirements.yml`
 
 ## Available roles
 

--- a/ansible/group_vars/provers.yml
+++ b/ansible/group_vars/provers.yml
@@ -1,0 +1,2 @@
+---
+vlayer_risc0_version: '1.0.5'

--- a/ansible/host_vars/prod_fake_prover.yml
+++ b/ansible/host_vars/prod_fake_prover.yml
@@ -1,6 +1,6 @@
 ---
-ansible_host: 54.175.221.188
-ansible_host_public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINo/MK9nQ3Xy7iCdw6kcewjFdIagBC8HzS/L2tqgmUjc
+ansible_host: 44.223.25.167
+ansible_host_public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK8uSV/Kr+sbJZMuW2S/kEJ87Rwp+uxBncV/Noe5eo1O
 ansible_user: ubuntu
 vlayer_prover_host: 0.0.0.0
 vlayer_prover_port: 3000

--- a/ansible/prover.yml
+++ b/ansible/prover.yml
@@ -23,5 +23,9 @@
       ansible.builtin.gather_facts:
 
   roles:
+    - role: geerlingguy.swap
+      become: true
+      vars:
+        swap_file_size_mb: '4096'
     - role: prover
     - role: prometheus.prometheus.node_exporter

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,5 +1,8 @@
 ---
-roles: []
+roles:
+  - name: geerlingguy.swap
+    version: 1.2.0
+
 collections:
   - name: prometheus.prometheus
     version: 0.19.0

--- a/ansible/roles/prover/tasks/prerequisites.yml
+++ b/ansible/roles/prover/tasks/prerequisites.yml
@@ -11,3 +11,26 @@
   args:
     executable: /bin/bash
     creates: ~/.foundry/bin/forge
+
+- name: Install rustup
+  ansible.builtin.shell: |
+    set -ueo pipefail
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable -y
+  args:
+    executable: /bin/bash
+    creates: .cargo/bin/rustup
+- name: Install Cargo binstall
+  ansible.builtin.shell: |
+    set -ueo pipefail
+    curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+  args:
+    executable: /bin/bash
+    creates: ~/.cargo/bin/cargo-binstall
+- name: Install risc0
+  ansible.builtin.shell: |
+    set -ueo pipefail
+    ~/.cargo/bin/cargo binstall -y cargo-risczero@{{ vlayer_risc0_version }} --force
+    ~/.cargo/bin/cargo risczero install
+  args:
+    executable: /bin/bash
+    creates: ~/.cargo/bin/r0vm


### PR DESCRIPTION
This fixes a problem run into with fake proofs - missing risc0 installation, and a machine not powerful enough.

I created a more powerful machine, automated risc0 installation in Ansible (to be removed in the future when we finish compiling risc0 into the `vlayer` binary, if I understand correctly) - this has unblocked @Chmarusso with his example using the fake prover server.