### PR TITLE
Replace Arc<Box<...>> with Arc<...> to avoid redundant allocation

### DIFF
--- a/rust/provider/src/multi.rs
+++ b/rust/provider/src/multi.rs
@@ -9,7 +9,7 @@ use call_engine::utils::InteriorMutabilityCache;
 use super::{factory::ProviderFactory, BlockingProvider};
 use crate::factory::ProviderFactoryError;
 
-type MultiProvider = HashMap<ChainId, Arc<Box<dyn BlockingProvider>>>;
+type MultiProvider = HashMap<ChainId, Arc<dyn BlockingProvider>>;
 
 pub struct CachedMultiProvider {
     cache: RwLock<MultiProvider>,
@@ -27,7 +27,7 @@ impl CachedMultiProvider {
     pub fn get(
         &self,
         chain_id: ChainId,
-    ) -> Result<Arc<Box<dyn BlockingProvider>>, ProviderFactoryError> {
+    ) -> Result<Arc<dyn BlockingProvider>, ProviderFactoryError> {
         self.cache
             .try_get_or_insert(chain_id, || self.factory.create(chain_id))
     }
@@ -61,8 +61,7 @@ mod get {
     #[test]
     fn gets_cached_provider() -> anyhow::Result<()> {
         let path_buf = PathBuf::from("testdata/cache.json");
-        let provider =
-            Arc::new(Box::new(CachedProvider::from_file(&path_buf)?) as Box<dyn BlockingProvider>);
+        let provider = Arc::new(CachedProvider::from_file(&path_buf)?) as Arc<dyn BlockingProvider>;
 
         let cache = RwLock::new(HashMap::from([(Chain::mainnet().id(), Arc::clone(&provider))]));
 

--- a/rust/services/call/host/src/db/proof.rs
+++ b/rust/services/call/host/src/db/proof.rs
@@ -63,7 +63,7 @@ impl DatabaseRef for ProofDb {
 }
 
 impl ProofDb {
-    pub(crate) fn new(provider: Arc<Box<dyn BlockingProvider>>, block_number: u64) -> Self {
+    pub(crate) fn new(provider: Arc<dyn BlockingProvider>, block_number: u64) -> Self {
         let state = RwLock::new(State::default());
         Self {
             state,

--- a/rust/services/call/host/src/db/provider.rs
+++ b/rust/services/call/host/src/db/provider.rs
@@ -24,7 +24,7 @@ pub enum ProviderDbError {
 
 /// A revm [Database] backed by a [Provider].
 pub(crate) struct ProviderDb {
-    pub(crate) provider: Arc<Box<dyn BlockingProvider>>,
+    pub(crate) provider: Arc<dyn BlockingProvider>,
     pub(crate) block_number: u64,
 
     /// Cache for code hashes to contract addresses.
@@ -33,7 +33,7 @@ pub(crate) struct ProviderDb {
 
 impl ProviderDb {
     /// Creates a new [ProviderDb] with the given provider and block number.
-    pub(crate) fn new(provider: Arc<Box<dyn BlockingProvider>>, block_number: u64) -> Self {
+    pub(crate) fn new(provider: Arc<dyn BlockingProvider>, block_number: u64) -> Self {
         Self {
             provider,
             block_number,


### PR DESCRIPTION
One would expect this to be caught by [clippy::redundant_allocation](https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_allocation), but actually there are some cases when `Arc<Box<dyn Trait>>` is desired to make the pointer smaller and limit the stack size, so [it's a feature](https://github.com/rust-lang/rust-clippy/issues/7487). Implementing a custom lint for this would require some significant amount of work, so I'd skip that for now.