### PR TITLE
Introduce Terraform and Ansible for self-hosted Actions runners

### DIFF
--- a/.github/workflows/update_prover_servers.yaml
+++ b/.github/workflows/update_prover_servers.yaml
@@ -22,7 +22,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install ansible galaxy collections
-        run: ansible-galaxy collection install -r requirements.yml
+        run: |
+          ansible-galaxy collection install -r requirements.yml
+          ansible-galaxy role install -r requirements.yml
       - name: Add deployer ssh key and run the Ansible playbook
         run: |
           eval "$(ssh-agent -s)"

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -6,6 +6,7 @@ This is a collection of vlayer ansible scripts and roles.
 
 1. [Install Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html).
 2. Install galaxy collections: `ansible-galaxy collection install -r requirements.yml`
+3. Install galaxy roles: `ansible-galaxy role install -r requirements.yml`
 
 ## Available roles
 
@@ -26,10 +27,17 @@ Host variables may contain sensitive information, like secret API keys.
 
 ## Running playbooks
 
-Currently, there is one playbook for installing the Prover.
-
-To run it:
+1. Prover playbook
 
 ```sh
 ansible-playbook -i hosts.yml prover.yml --ask-vault-pass
+```
+
+2. Github runner playbook
+
+This requires the `PERSONAL_ACCESS_TOKEN` github token with `repo:write` access rights,
+in order to register repository runners.
+
+```sh
+PERSONAL_ACCESS_TOKEN='xxx' ansible-playbook -i ../terraform/github-runners.ini github_runners.yml
 ```

--- a/ansible/github_runners.yml
+++ b/ansible/github_runners.yml
@@ -1,0 +1,47 @@
+---
+- name: Provision github runner
+  hosts: github_runners
+  become: true
+
+  pre_tasks:
+    - name: Install dependencies and utilities
+      ansible.builtin.apt:
+        update_cache: true
+        name:
+          - 'build-essential'
+          - 'libssl-dev'
+          - 'pkg-config'
+          - 'gcc'
+          - 'unzip'
+          - 'clang'
+          - 'llvm'
+          - 'curl'
+          - 'tmux'
+    - name: Install rustup
+      ansible.builtin.shell: |
+        set -ueo pipefail
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable -y
+      args:
+        executable: /bin/bash
+        creates: .cargo/bin/rustup
+
+  roles:
+    # https://galaxy.ansible.com/ui/standalone/roles/geerlingguy/swap
+    - role: geerlingguy.swap
+      vars:
+        swap_file_size_mb: '4096'
+
+    # https://galaxy.ansible.com/ui/standalone/roles/geerlingguy/docker
+    - role: geerlingguy.docker
+      vars:
+        docker_users: "{{ ansible_user }}"
+
+    # https://galaxy.ansible.com/ui/standalone/roles/MonolithProjects/github_actions_runner/
+    - role: MonolithProjects.github_actions_runner
+      vars:
+        runner_user: "{{ ansible_user }}"
+        github_account: vlayer-xyz
+        github_repo: vlayer
+        runner_labels:
+          - "ansible-managed"
+          - "{{ github_runner_tag }}"

--- a/ansible/group_vars/github_runners.yml
+++ b/ansible/group_vars/github_runners.yml
@@ -1,0 +1,1 @@
+ansible_user: ubuntu

--- a/ansible/group_vars/github_runners_medium.yml
+++ b/ansible/group_vars/github_runners_medium.yml
@@ -1,0 +1,1 @@
+github_runner_tag: aws-linux-medium

--- a/ansible/group_vars/github_runners_small.yml
+++ b/ansible/group_vars/github_runners_small.yml
@@ -1,0 +1,1 @@
+github_runner_tag: aws-linux-small

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,5 +1,12 @@
 ---
-roles: []
+roles:
+  - name: geerlingguy.swap
+    version: 1.2.0
+  - name: geerlingguy.docker
+    version: 7.4.1
+  - name: MonolithProjects.github_actions_runner
+    version: 1.18.7
+
 collections:
   - name: prometheus.prometheus
     version: 0.19.0

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.72.0"
+  constraints = "~> 5.72.0"
+  hashes = [
+    "h1:g7DtrWPK6KyZgqy6ZxYsSNhiVu/iPNLWnV7LKsJn/Q8=",
+    "zh:1a5e979b0c68063e1cdde592864fbfd0566f81c2125f811e96c9d85815d9a5fb",
+    "zh:2c1cd5f43748ab9cf4127fcc7cb73535b01ebb0408b14edf4f0e9475521ab8ea",
+    "zh:32749d892279fb14ce2a02ca4f7d25891983464f6696ed62e4a4350ee7931d02",
+    "zh:32ece5073409de4a25ca7b35e246117da7915683eb6317797b0c98e8b9b4cfbd",
+    "zh:3b7bb7be87e2ab432c0a30d085ef9a06b87def29f69cf5154bfc07bec7811db4",
+    "zh:5f986460e947675c9f85cc233c68b9af16385ac2e66c0ae22ed3501cd482abf5",
+    "zh:6ac164504e04d1b6d83762f50896005362c250a69203e5f25313b410711e826b",
+    "zh:6e639b8ddc44a299fef194d5792f6df69b26e350e44185600bbac8e1a8b2fbd3",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b396ba2682256f5321162306d2bea5c276b8cd1a5f877599746518804554e80",
+    "zh:ab0688723e14acdd9d9f244086be7c22e2b938add611b814ce7b1662484e5d08",
+    "zh:c2a6453f223b7a2491a75481ef30421bc15e1983530e082467bcfa99553dca51",
+    "zh:d794b429ef1c259188a31626725af18e6ac8a9bbe1478484f8d0a0db57703335",
+    "zh:d86fb03571f8446928659efad065a235dda6320fdf893b575c54ae9df5adfda8",
+    "zh:ec27eddf86ee2f2003ae87faf269fac379311531394cf5292b9c31d011b9a873",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.2"
+  hashes = [
+    "h1:IyFbOIO6mhikFNL/2h1iZJ6kyN3U00jgkpCLUCThAfE=",
+    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
+    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
+    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
+    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
+    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
+    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
+    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
+    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
+    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
+    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,18 @@
+# Terraform
+
+This is a collection of Terraform modules and configurations for infrastracture.
+
+## Prerequisites
+
+1. [Install AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
+2. [Install Terraform](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html).
+
+## State
+
+The Terraform state is [stored remotely](https://developer.hashicorp.com/terraform/language/state/remote) in S3 with locks.
+
+## Applying changes
+
+First, run `terraform plan` (a dry run).
+
+Next, run `terraform apply` to apply planned changes.

--- a/terraform/github-runners.ini.j2
+++ b/terraform/github-runners.ini.j2
@@ -1,0 +1,15 @@
+# Managed by Terraform
+
+[github_runners_medium]
+%{ for runner in github_runners_medium ~}
+${runner}
+%{ endfor ~}
+
+[github_runners_small]
+%{ for runner in github_runners_small ~}
+${runner}
+%{ endfor ~}
+
+[github_runners:children]
+github_runners_medium
+github_runners_small

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,62 @@
+provider "aws" {
+  region = "us-east-2"
+  default_tags {
+    tags = {
+      project = "vlayer"
+      owner   = "devops"
+    }
+  }
+}
+
+resource "aws_security_group" "ssh_security_group" {
+  egress = [
+    {
+      cidr_blocks      = ["0.0.0.0/0", ]
+      description      = "ALL Outbound"
+      from_port        = 0
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      protocol         = "-1"
+      security_groups  = []
+      self             = false
+      to_port          = 0
+    }
+  ]
+  ingress = [
+    {
+      cidr_blocks      = ["0.0.0.0/0", ]
+      description      = "SSH Inbound"
+      from_port        = 22
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      protocol         = "tcp"
+      security_groups  = []
+      self             = false
+      to_port          = 22
+    }
+  ]
+}
+
+module "github_runners_medium" {
+  source            = "./modules/github_runners"
+  runner_count      = 2
+  instance_type     = "t2.xlarge"
+  security_group_id = aws_security_group.ssh_security_group.id
+}
+
+module "github_runners_small" {
+  source            = "./modules/github_runners"
+  runner_count      = 2
+  instance_type     = "t2.large"
+  security_group_id = aws_security_group.ssh_security_group.id
+}
+
+resource "local_file" "github_runners_inventory" {
+  content = templatefile("./github-runners.ini.j2",
+    {
+      github_runners_medium = flatten(module.github_runners_medium.*.instance_ips),
+      github_runners_small = flatten(module.github_runners_small.*.instance_ips)
+    }
+  )
+  filename = "./github-runners.ini"
+}

--- a/terraform/modules/github_runners/main.tf
+++ b/terraform/modules/github_runners/main.tf
@@ -1,0 +1,26 @@
+variable "runner_count" { type = number }
+variable "instance_type" { type = string }
+variable "ami" { default = "ami-0ea3c35c5c3284d82" } # ubuntu-24.04
+variable "security_group_id" { type = string }
+variable "volume_size" { default = 80 }
+
+resource "aws_instance" "github_runner_server" {
+  count = var.runner_count
+
+  ami               = var.ami
+  instance_type     = var.instance_type
+  vpc_security_group_ids = [var.security_group_id]
+
+  root_block_device {
+    volume_size = var.volume_size
+  }
+
+  key_name = "aws-infra"
+  tags = {
+    module = "vlayer-github-runners"
+  }
+}
+
+output "instance_ips" {
+  value = aws_instance.github_runner_server.*.public_ip
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.72.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "vlayer-tfstate"
+    key            = "state/terraform.tfstate"
+    region         = "us-east-2"
+    encrypt        = true
+    dynamodb_table = "vlayer_tf_lockid"
+  }
+}


### PR DESCRIPTION
This introduces:

- Terraform module which can create an AWS instance for self-hosted runners.
  - We create two types of machnies - `aws-linux-medium` and `aws-linux-small`.
  - The Terraform outputs the IPs grouped into an inventory Ansible can read.
- Ansible playbook, which takes the Terraformed inventory and installs self-hosted runners on it.