### PR TITLE
Simplify sdk types

### DIFF
--- a/packages/sdk/src/api/lib/types/vlayer.ts
+++ b/packages/sdk/src/api/lib/types/vlayer.ts
@@ -1,6 +1,5 @@
 import {
   Abi,
-  AbiFunction,
   AbiStateMutability,
   Address,
   ContractFunctionArgs,
@@ -46,10 +45,7 @@ export interface VCallResponse {
 }
 
 export type VlayerClient = {
-  prove: <
-    T extends readonly [AbiFunction, ...Abi[number][]],
-    F extends ContractFunctionName<T>,
-  >(args: {
+  prove: <T extends Abi, F extends ContractFunctionName<T>>(args: {
     address: Hex;
     proverAbi: T;
     functionName: F;

--- a/packages/sdk/src/api/lib/types/webProofProvider.ts
+++ b/packages/sdk/src/api/lib/types/webProofProvider.ts
@@ -1,4 +1,4 @@
-import { AbiFunction, Hex, Abi, ContractFunctionName } from "viem";
+import { Hex, Abi, ContractFunctionName } from "viem";
 import type { ContractFunctionArgsWithout } from "./viem";
 import { Branded, WebProof, WebProofStep } from "../../../web-proof-commons";
 
@@ -15,7 +15,7 @@ export type WebProofSetup = Branded<
 >;
 
 export type ProverCallCommitment<
-  T extends readonly [AbiFunction, ...Abi[number][]],
+  T extends Abi,
   F extends ContractFunctionName<T>,
 > = {
   address: Hex;
@@ -26,17 +26,14 @@ export type ProverCallCommitment<
 };
 
 export type GetWebProofArgs<
-  T extends readonly [AbiFunction, ...Abi[number][]],
+  T extends Abi,
   F extends ContractFunctionName<T>,
 > = {
   proverCallCommitment: ProverCallCommitment<T, F>;
 } & WebProofSetupInput;
 
 export type WebProofProvider = {
-  getWebProof: <
-    T extends readonly [AbiFunction, ...Abi[number][]],
-    F extends ContractFunctionName<T>,
-  >(
+  getWebProof: <T extends Abi, F extends ContractFunctionName<T>>(
     args: GetWebProofArgs<T, F>,
   ) => Promise<WebProof>;
 };

--- a/packages/sdk/src/api/prover.ts
+++ b/packages/sdk/src/api/prover.ts
@@ -1,6 +1,5 @@
 import {
   type Abi,
-  AbiFunction,
   AbiStateMutability,
   type Address,
   ContractFunctionArgs,
@@ -12,10 +11,7 @@ import { type CallContext, type CallParams } from "types/vlayer";
 import { v_call } from "./v_call";
 import { foundry } from "viem/chains";
 
-export async function prove<
-  T extends readonly [AbiFunction, ...Abi[number][]],
-  F extends ContractFunctionName<T>,
->(
+export async function prove<T extends Abi, F extends ContractFunctionName<T>>(
   prover: Address,
   abi: T,
   functionName: F,


### PR DESCRIPTION
This type
``` ts
T extends readonly [AbiFunction, ...Abi[number][]],
```
was originally designed to ensure that the first entry in the contract ABI is a function. However, in some cases, the first entry could also be a constructor. Additionally, all contracts inheriting from Prover already include the three methods: "proof" | "setBlock" | "setChain". Therefore, simply checking that the contract contains at least one method is not sufficient.