### PR TITLE
Rust caching improvements

### DIFF
--- a/.github/actions/rust-prerequisites/action.yml
+++ b/.github/actions/rust-prerequisites/action.yml
@@ -4,16 +4,36 @@ runs:
   using: "composite"
   steps:
     - name: Set up Rust
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
       with:
-        cache-workspaces: |
-          rust
-          rust/call/guest_wrapper/risc0_guest
-          rust/chain/guest_wrapper/risc0_guest
+        toolchain: nightly,stable
+        components: clippy,rustfmt
+        cache: false
 
-    - uses: cargo-bins/cargo-binstall@main
+    - name: Setup Rust Caching
+      uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
+      with:
+        workspaces: |
+          rust
+          rust/services/call/guest_wrapper/risc0_guest
+          rust/services/chain/guest_wrapper/risc0_guest
+        cache-on-failure: false
+
+    - name: Install cargo binstall
+      uses: taiki-e/cache-cargo-install-action@caa6f48d18d42462f9c30df89e2b4f71a42b7c2c # v2.0.1
+      with:
+        tool: cargo-binstall@1.10.8
+          
+    - name: Install cargo sort
+      uses: taiki-e/cache-cargo-install-action@caa6f48d18d42462f9c30df89e2b4f71a42b7c2c # v2.0.1
+      with:
+        tool: cargo-sort@1.0.9
+
     - name: Install risc0 toolchain
+      uses: taiki-e/cache-cargo-install-action@caa6f48d18d42462f9c30df89e2b4f71a42b7c2c # v2.0.1
+      with:
+        tool: cargo-risczero@1.0.5
+
+    - name: Initialize risc0 toolchain
       shell: bash
-      run: |
-        cargo binstall -y cargo-risczero@1.0.5 --force
-        cargo risczero install
+      run: rustup toolchain list -v | grep -q 'risc0' || cargo risczero install

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,12 +29,6 @@ jobs:
       - name: Install contracts prerequisites
         uses: ./.github/actions/contracts-prerequisites
 
-      - name: Install nightly rustfmt
-        run: rustup toolchain install nightly -c rustfmt
-
-      - name: Install cargo sort
-        run: cargo install --force cargo-sort
-          
       - name: Run Host lints
         working-directory: rust
         env:
@@ -42,7 +36,7 @@ jobs:
         run: |
           cargo +nightly fmt --check
           cargo sort --check --grouped --workspace
-          cargo clippy --all-targets --all-features
+          cargo clippy --all-targets --all-features --locked
 
       - name: Run Risc0 Call Guest lints
         working-directory: rust/services/call/guest_wrapper/risc0_guest
@@ -51,7 +45,7 @@ jobs:
         run: |
           cargo +nightly fmt --check
           cargo sort --check --grouped
-          cargo clippy --all-targets --all-features
+          cargo clippy --all-targets --all-features --locked
       
       - name: Run Risc0 Chain Guest lints
         working-directory: rust/services/chain/guest_wrapper/risc0_guest
@@ -60,4 +54,4 @@ jobs:
         run: |
           cargo +nightly fmt --check
           cargo sort --check --grouped
-          cargo clippy --all-targets --all-features
+          cargo clippy --all-targets --all-features --locked

--- a/.github/workflows/vlayer_test.yaml
+++ b/.github/workflows/vlayer_test.yaml
@@ -41,4 +41,4 @@ jobs:
         working-directory: ./contracts
         run: |
           # vlayer test
-          cargo run --manifest-path ../rust/Cargo.toml --package cli -- test -vvv
+          cargo run --locked --manifest-path ../rust/Cargo.toml --package cli -- test -vvv


### PR DESCRIPTION
An attempt to improve our Rust caching.

## What's inside

- Fix paths to `guest_wrapper` - we had a typo.
- Separate `actions-rust-lang/setup-rust-toolchain` from `Swatinem/rust-cache` (which was called indirectly) - so we have more control over it.
- Save cache only on `main`. We were running over cache space limits.
- Use a dedicated action to install stuff some tools - which cache nicely (but are sloow on the first, uncached run).
- Only run `cargo risczero install` if necessary - additionally saves time.