### PR TITLE
Run playwright tests on self-hosted runners

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "packages/**"
+      - ".github/workflows/playwright.yaml"
   merge_group:
   push:
     branches:
@@ -10,11 +11,15 @@ on:
 jobs:
   test-extension:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: [aws-linux-small]
     steps:
       - uses: oven-sh/setup-bun@v2
         with:
           node-version: lts/*
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Turns out that playwright has a silent (?) dependency on nodejs being installed in the system.