### PR TITLE
Print function signature in unsupported tests

### DIFF
--- a/rust/test_runner/src/forked/contract_runner.rs
+++ b/rust/test_runner/src/forked/contract_runner.rs
@@ -463,7 +463,7 @@ fn warn_about_unsupported_tests(functions: &[&Function]) {
     println!(
         "{}: {}",
         "Warning".yellow().bold(),
-        "This test types are not supported yet:".bold()
+        "Only unit tests are currently supported. The following test were not run:".bold()
     );
 
     for func in unsupported_functions {


### PR DESCRIPTION
<img width="709" alt="image" src="https://github.com/user-attachments/assets/41137799-dc0a-4ff8-8243-276d65e6a904">

Removed one empty line at the end