### PR TITLE
Include C headers in darwin build

### DIFF
--- a/.github/actions/darwin-prerequisites/action.yml
+++ b/.github/actions/darwin-prerequisites/action.yml
@@ -1,0 +1,10 @@
+name: Darwin prerequisites
+description: Prerequisites specific to Darwin
+runs:
+  using: "composite"
+  steps:
+    - name: Include C headers
+      run: |
+        sudo mkdir -p /usr/local/include/
+        sudo ln -s /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/* /usr/local/include/
+      shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,6 +90,10 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Darwin prerequisites
+        uses: ./.github/actions/darwin-prerequisites
+        if: matrix.platform == 'darwin' 
+
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -128,12 +132,6 @@ jobs:
         with:
           name: guest-artifacts
           path: rust/call_guest_replacement
-
-      - name: Include C headers
-        if: matrix.platform == 'darwin' 
-        run: |
-          sudo mkdir -p /usr/local/include/
-          sudo ln -s /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/* /usr/local/include/
 
       - name: "Build binaries"
         env:


### PR DESCRIPTION
Aims to fix a broken release.

It turns out that he had a problem with mdbx build on darwin, but it surfaced recently because it started being required to build `cli` package.

A successful build on a branch: https://github.com/vlayer-xyz/vlayer/actions/runs/11556634741/job/32164776569