### PR TITLE
Explain why the C headers step is needed on darwin

### DIFF
--- a/.github/actions/darwin-prerequisites/action.yml
+++ b/.github/actions/darwin-prerequisites/action.yml
@@ -3,6 +3,7 @@ description: Prerequisites specific to Darwin
 runs:
   using: "composite"
   steps:
+    # This is necessary for building some crates written in C/C++, such as mdbx-sys.
     - name: Include C headers
       run: |
         sudo mkdir -p /usr/local/include/


### PR DESCRIPTION
A follow-up to https://github.com/vlayer-xyz/vlayer/pull/973