### PR TITLE
Book: Side menu not visible even when reader is authenticated 

### DIFF
--- a/book/src/middleware.js
+++ b/book/src/middleware.js
@@ -137,7 +137,7 @@ const setAuthCookie = async (login) => {
 
   const hash = await hashString(`${login}${COOKIE_SALT}`);
 
-  responseCookies.set('authenticated', `${login}|${hash}`, {
+  responseCookies.set('isAuthenticated', `${login}|${hash}`, {
     httpOnly: false, 
     maxAge: 60 * 60 * 24
   }) // make cookie persistent for 24h
@@ -148,9 +148,9 @@ const setAuthCookie = async (login) => {
 const isAuthCookieValid = async (headers) => {
   try {
     const cookies = new RequestCookies(headers)
-    if(!cookies.has('authenticated')) return false;
+    if(!cookies.has('isAuthenticated')) return false;
     
-    const [login, cookieHash] = cookies.get('authenticated')?.value.split('|');
+    const [login, cookieHash] = cookies.get('isAuthenticated')?.value.split('|');
     const validHash = await hashString(`${login}${COOKIE_SALT}`);
   
     return cookieHash === validHash;

--- a/book/src/static/appendixMenu.js
+++ b/book/src/static/appendixMenu.js
@@ -7,7 +7,7 @@ function getCookie(name) {
 }
 
 document.addEventListener("DOMContentLoaded", function() {
-  if(!getCookie('authenticated')) {
+  if(!getCookie('isAuthenticated')) {
     const spacerElement = document.querySelector('.spacer');
     if (spacerElement) {
       let nextElement = spacerElement.nextElementSibling;


### PR DESCRIPTION
Problem:
We changed the cookie setting to httpOnly: false so that JavaScript can control the display of the appendix menu. Previously, logged-in users couldn’t see this menu because the old httpOnly cookie was still stored in their browsers.

Fix:
Rename the cookie so that every browser will use the updated cookie after login, ensuring the menu displays correctly.