### PR TITLE
Move http-based dependencies of chain_client behind rpc feature flag

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2122,7 +2122,6 @@ dependencies = [
  "futures",
  "mpt",
  "parking_lot",
- "provider",
  "serde_json",
  "server_utils",
  "thiserror",

--- a/rust/services/call/host/Cargo.toml
+++ b/rust/services/call/host/Cargo.toml
@@ -13,7 +13,7 @@ block_header = { workspace = true }
 call_engine = { workspace = true }
 call_guest_wrapper = { workspace = true }
 chain = { workspace = true }
-chain_client = { workspace = true }
+chain_client = { workspace = true, features = ["rpc"] }
 chain_common = { workspace = true }
 chain_server = { workspace = true }
 derive-new = { workspace = true }

--- a/rust/services/chain/client/Cargo.toml
+++ b/rust/services/chain/client/Cargo.toml
@@ -6,19 +6,23 @@ edition = "2021"
 [dependencies]
 alloy-primitives = { workspace = true }
 async-trait = { workspace = true }
-block_trie = { workspace = true }
 chain_common = { workspace = true }
-chain_server = { workspace = true }
 derive-new = { workspace = true }
 futures = { workspace = true }
-mpt = { workspace = true }
 parking_lot = { workspace = true }
-provider = { workspace = true }
-serde_json = { workspace = true }
-server_utils = { workspace = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }
+
+# RPC dependencies (disabled for guest)
+chain_server = { workspace = true, optional = true }
+mpt = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+server_utils = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+block_trie = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
+
+[features]
+rpc = ["chain_server", "mpt", "serde_json", "server_utils", "tracing"]

--- a/rust/services/chain/client/src/rpc.rs
+++ b/rust/services/chain/client/src/rpc.rs
@@ -1,0 +1,48 @@
+use alloy_primitives::{BlockNumber, ChainId};
+use async_trait::async_trait;
+use chain_common::ChainProof;
+use chain_server::server::ChainProof as RpcChainProof;
+use serde_json::json;
+use server_utils::RpcClient as RawRpcClient;
+use tracing::info;
+
+use crate::{Client, Error};
+
+/// `Client` implementation which fetches proofs from server via JSON RPC.
+pub struct RpcClient {
+    rpc_client: RawRpcClient,
+}
+
+impl RpcClient {
+    pub fn new(base_url: impl AsRef<str>) -> Self {
+        let rpc_client = RawRpcClient::new(base_url.as_ref(), "v_chain");
+        Self { rpc_client }
+    }
+}
+
+#[async_trait]
+impl Client for RpcClient {
+    async fn get_chain_proof(
+        &self,
+        chain_id: ChainId,
+        block_numbers: Vec<BlockNumber>,
+    ) -> Result<ChainProof, Error> {
+        info!(
+            "Fetching chain proof for chain_id: {}, block_numbers.len(): {}",
+            chain_id,
+            block_numbers.len()
+        );
+
+        let params = json!({
+            "chain_id": chain_id,
+            "block_numbers": block_numbers.clone(),
+        });
+
+        let result_value = self.rpc_client.call(&params).await.map_err(Error::from)?;
+
+        let rpc_chain_proof: RpcChainProof = serde_json::from_value(result_value)?;
+        let chain_proof = rpc_chain_proof.try_into()?;
+
+        Ok(chain_proof)
+    }
+}


### PR DESCRIPTION
So the crate can be imported and used in zkVM guest code.