### PR TITLE
Change nightly release time to 06:00 UTC.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Release vlayer artifacts
 on: 
   schedule:
-    - cron: '0 22 * * 1-5' # Mon-Fri at 22:00 UTC
+    - cron: '0 6 * * 1-5' # Mon-Fri at 06:00 UTC (07:00 CET / 08:00 CEST)
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
After discussing with @rzadp, we propose moving nightly release time to 06:00 UTC (07:00 Warsaw winter time and 08:00 Warsaw summer time) in order to be able to react quicker to potential release issues.