### PR TITLE
Run post-release tests in a separate workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -434,19 +434,3 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
-
-  test-release:
-    name: Test release
-    needs: [push-artifacts-to-s3, publish-sdk-to-npm, push-docker-image]
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: hoverkraft-tech/compose-action@v2.0.2
-        with:
-          compose-file: docker/web-proof/docker-compose-test-release.yaml
-      - name: Test release
-        run: bash/test-release.sh
-

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1,0 +1,28 @@
+name: Test Release
+on: 
+  workflow_run:
+    workflows: ["Release vlayer artifacts"]
+    types: [completed]
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/test-release.yaml"
+      - "docker/web-proof/docker-compose-test-release.yaml"
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+jobs:
+  test-release:
+    name: Test release
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: hoverkraft-tech/compose-action@v2.0.2
+        with:
+          compose-file: docker/web-proof/docker-compose-test-release.yaml
+      - name: Test release
+        run: bash/test-release.sh


### PR DESCRIPTION
This is a proposal to change the way the post-release tests are run.

I'm proposing a separate workflow, so that we separate the release workflow failing from post-test failing.
We can also run those tests on a PR when changing it.