### PR TITLE
Save Rust cache on main only

### DIFF
--- a/.github/actions/rust-prerequisites/action.yml
+++ b/.github/actions/rust-prerequisites/action.yml
@@ -18,6 +18,7 @@ runs:
           rust/services/call/guest_wrapper/risc0_guest
           rust/services/chain/guest_wrapper/risc0_guest
         cache-on-failure: false
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Install cargo binstall
       uses: taiki-e/cache-cargo-install-action@caa6f48d18d42462f9c30df89e2b4f71a42b7c2c # v2.0.1


### PR DESCRIPTION
A follow-up to https://github.com/vlayer-xyz/vlayer/pull/949
I wrote that we Rust save cache only on `main` but somehow I missed comitting this in the PR.

This is because Rust cache created on PRs for different workflows exceeds the available github cache storage.