### PR TITLE
Seal ZkpVerifier & ChainProofVerifier interfaces

### DIFF
--- a/rust/services/call/engine/Cargo.toml
+++ b/rust/services/call/engine/Cargo.toml
@@ -13,7 +13,6 @@ alloy-primitives = { workspace = true, features = ["rlp", "serde"] }
 alloy-rlp = { workspace = true }
 alloy-sol-types = { workspace = true }
 anyhow = { workspace = true }
-auto_impl = { workspace = true }
 bincode = { workspace = true }
 block_header = { workspace = true }
 chain = { workspace = true }
@@ -39,6 +38,7 @@ web_proof = { workspace = true }
 
 [dev-dependencies]
 alloy-trie = { workspace = true }
+auto_impl = { workspace = true }
 block_trie = { workspace = true }
 bytemuck = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/services/call/engine/src/verifier/zk_proof.rs
+++ b/rust/services/call/engine/src/verifier/zk_proof.rs
@@ -1,10 +1,20 @@
+#[cfg(test)]
 use auto_impl::auto_impl;
 use risc0_zkp::verify::VerificationError;
 use risc0_zkvm::{guest, sha::Digest, Receipt};
 use static_assertions::assert_obj_safe;
 
-#[auto_impl(Fn)]
-pub trait ZkpVerifier: Send + Sync + 'static {
+mod seal {
+    // This trait prevents adding new implementations of ZkpVerifier
+    pub trait Sealed {}
+
+    // Useful to mock verifier in tests
+    #[cfg(test)]
+    impl<F: Fn(&super::Receipt, super::Digest) -> Result<(), super::VerificationError>> Sealed for F {}
+}
+
+#[cfg_attr(test, auto_impl(Fn))]
+pub trait ZkpVerifier: seal::Sealed + Send + Sync + 'static {
     fn verify(&self, receipt: &Receipt, elf_id: Digest) -> Result<(), VerificationError>;
 }
 
@@ -12,6 +22,7 @@ assert_obj_safe!(ZkpVerifier);
 
 pub struct GuestVerifier;
 
+impl seal::Sealed for GuestVerifier {}
 impl ZkpVerifier for GuestVerifier {
     fn verify(&self, receipt: &Receipt, elf_id: Digest) -> Result<(), VerificationError> {
         guest::env::verify(elf_id, receipt.journal.as_ref()).expect("infallible");
@@ -21,6 +32,7 @@ impl ZkpVerifier for GuestVerifier {
 
 pub struct HostVerifier;
 
+impl seal::Sealed for HostVerifier {}
 impl ZkpVerifier for HostVerifier {
     fn verify(&self, receipt: &Receipt, elf_id: Digest) -> Result<(), VerificationError> {
         receipt.verify(elf_id)

--- a/rust/services/call/guest_wrapper/risc0_guest/Cargo.lock
+++ b/rust/services/call/guest_wrapper/risc0_guest/Cargo.lock
@@ -849,7 +849,6 @@ dependencies = [
  "alloy-rlp",
  "alloy-sol-types",
  "anyhow",
- "auto_impl",
  "bincode",
  "block_header",
  "chain",

--- a/rust/zkvm-benchmarks/runner/risc0_guest/Cargo.lock
+++ b/rust/zkvm-benchmarks/runner/risc0_guest/Cargo.lock
@@ -843,7 +843,6 @@ dependencies = [
  "alloy-rlp",
  "alloy-sol-types",
  "anyhow",
- "auto_impl",
  "bincode",
  "block_header",
  "chain",


### PR DESCRIPTION
To make sure nobody ever mocks them in production code.