### PR TITLE
book: update getting-started with existing project template

### DIFF
--- a/book/src/getting-started/first-steps.md
+++ b/book/src/getting-started/first-steps.md
@@ -18,7 +18,7 @@ cd ./your-project && vlayer init --existing
 ### Example project
 To initialize vlayer project with example prover and verifier contracts use `--template` flag:
 ```bash
-vlayer init my-airdrop --template private-airdrop
+vlayer init simple --template simple
 ``` 
 
 ## Directory structure


### PR DESCRIPTION
Turns out `private-airdrop` example no longer exists.