### PR TITLE
Terraformed prover servers with elastic export

### DIFF
--- a/ansible/host_vars/prod_fake_prover.yml
+++ b/ansible/host_vars/prod_fake_prover.yml
@@ -1,6 +1,6 @@
 ---
-ansible_host: 44.223.25.167
-ansible_host_public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK8uSV/Kr+sbJZMuW2S/kEJ87Rwp+uxBncV/Noe5eo1O
+ansible_host: 18.223.185.235
+ansible_host_public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDhoY9QaIunqLsc3VxUFbk4JHHYF1IK/5nkLPndSkbkG
 ansible_user: ubuntu
 vlayer_prover_host: 127.0.0.1
 vlayer_prover_port: 3000

--- a/ansible/host_vars/prod_groth16_prover.yml
+++ b/ansible/host_vars/prod_groth16_prover.yml
@@ -1,6 +1,6 @@
 ---
-ansible_host: 3.87.178.21
-ansible_host_public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM3zLjdbqkLNdlrunXcSyUkEjWpTSfJ9AIU1tkAUUwZs
+ansible_host: 3.21.204.138
+ansible_host_public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMi0FpLCBApi7E6gzQxjC717BC0nvpav+77Dcg1BeOSN
 ansible_user: ubuntu
 vlayer_prover_host: 127.0.0.1
 vlayer_prover_port: 3000

--- a/ansible/prover.yml
+++ b/ansible/prover.yml
@@ -30,4 +30,3 @@
     - role: prover
     - role: prover_nginx
       become: true
-    - role: prometheus.prometheus.node_exporter

--- a/ansible/roles/prover/files/vlayer-logrotate.conf
+++ b/ansible/roles/prover/files/vlayer-logrotate.conf
@@ -1,0 +1,9 @@
+/var/log/vlayer
+{
+        rotate 7
+        daily
+        missingok
+        notifempty
+        delaycompress
+        compress
+}

--- a/ansible/roles/prover/files/vlayer-rsyslog.conf
+++ b/ansible/roles/prover/files/vlayer-rsyslog.conf
@@ -1,0 +1,2 @@
+if $programname == 'vlayer' then /var/log/vlayer/vlayer.log
+& stop

--- a/ansible/roles/prover/handlers/main.yml
+++ b/ansible/roles/prover/handlers/main.yml
@@ -5,3 +5,10 @@
     name: vlayer
     state: restarted
     daemon_reload: true
+
+- name: Restart rsyslog
+  become: true
+  ansible.builtin.systemd_service:
+    name: rsyslog
+    state: restarted
+    daemon_reload: true

--- a/ansible/roles/prover/tasks/logs.yml
+++ b/ansible/roles/prover/tasks/logs.yml
@@ -1,0 +1,33 @@
+---
+- name: Create log directory
+  become: true
+  ansible.builtin.file:
+    path: /var/log/vlayer
+    state: directory
+    owner: syslog
+    group: adm
+    mode: '755'
+
+- name: Create log file
+  become: true
+  ansible.builtin.file:
+    path: /var/log/vlayer/vlayer.log
+    state: touch
+    owner: syslog
+    group: adm
+    mode: '644'
+
+- name: Install rsyslog configuration
+  become: true
+  ansible.builtin.copy:
+    src: vlayer-rsyslog.conf
+    dest: /etc/rsyslog.d/10-vlayer.conf
+    mode: '644'
+  notify: "Restart rsyslog"
+
+- name: Install logrotate configuration
+  become: true
+  ansible.builtin.copy:
+    src: vlayer-rsyslog.conf
+    dest: /etc/logrotate.d/vlayer
+    mode: '644'

--- a/ansible/roles/prover/tasks/main.yml
+++ b/ansible/roles/prover/tasks/main.yml
@@ -10,6 +10,9 @@
     creates: ~/.vlayer/bin/vlayerup
     executable: /bin/bash
 
+- name: Install log configuration
+  ansible.builtin.import_tasks: logs.yml
+
 # We're installing a most-recent nightly version every time.
 - name: Install vlayer
   ansible.builtin.shell: |

--- a/ansible/roles/prover/templates/vlayer.service.j2
+++ b/ansible/roles/prover/templates/vlayer.service.j2
@@ -8,6 +8,12 @@ Type=simple
 Restart=on-failure
 RestartSec=10
 User=ubuntu
+
+StandardOutput=syslog
+StandardError=inherit
+SyslogIdentifier=vlayer
+SyslogFacility=local0
+
 Environment=PATH=/home/ubuntu/.cargo/bin/:$PATH
 {% if vlayer_bonsai_api_url is defined %}
 Environment='BONSAI_API_URL={{ vlayer_bonsai_api_url }}'


### PR DESCRIPTION
Companion to https://github.com/vlayer-xyz/infra/pull/1 - Using new prover servers which are terraformed, replacing prometheus metrics exports with Elastic.