### PR TITLE
Use GuestInputVerifier in call guest (v2)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1939,9 +1939,12 @@ dependencies = [
  "block_header",
  "call_engine",
  "chain",
+ "chain_client",
  "chain_common",
+ "chain_guest_wrapper",
  "mpt",
  "revm",
+ "tokio",
 ]
 
 [[package]]

--- a/rust/chain/src/config.rs
+++ b/rust/chain/src/config.rs
@@ -55,6 +55,7 @@ pub static ETH_MAINNET_CHAIN_SPEC: Lazy<ChainSpec> = Lazy::new(|| {
         Chain::mainnet().id(),
         SpecId::CANCUN,
         BTreeMap::from([
+            (SpecId::FRONTIER, ForkCondition::Block(0)),
             (SpecId::MERGE, ForkCondition::Block(MAINNET_MERGE_BLOCK_NUMBER)),
             (SpecId::SHANGHAI, ForkCondition::Timestamp(1681338455)),
             (SpecId::CANCUN, ForkCondition::Timestamp(1710338135)),
@@ -238,7 +239,7 @@ mod tests {
 
     #[test]
     fn spec_id() {
-        assert_eq!(ETH_MAINNET_CHAIN_SPEC.spec_id(15537393, 0), None);
+        assert_eq!(ETH_MAINNET_CHAIN_SPEC.spec_id(15537393, 0), Some(SpecId::FRONTIER));
         assert_eq!(ETH_MAINNET_CHAIN_SPEC.spec_id(15537394, 0), Some(SpecId::MERGE));
         assert_eq!(ETH_MAINNET_CHAIN_SPEC.spec_id(17034869, 0), Some(SpecId::MERGE));
         assert_eq!(ETH_MAINNET_CHAIN_SPEC.spec_id(0, 1681338455), Some(SpecId::SHANGHAI));

--- a/rust/services/call/engine/src/evm/env/location.rs
+++ b/rust/services/call/engine/src/evm/env/location.rs
@@ -1,11 +1,20 @@
 use alloy_primitives::{BlockNumber, ChainId};
-use derive_new::new;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, new)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ExecutionLocation {
     pub block_number: BlockNumber,
     pub chain_id: ChainId,
+}
+
+impl ExecutionLocation {
+    #[must_use]
+    pub const fn new(block_number: BlockNumber, chain_id: ChainId) -> Self {
+        Self {
+            block_number,
+            chain_id,
+        }
+    }
 }
 
 impl From<(BlockNumber, ChainId)> for ExecutionLocation {

--- a/rust/services/call/engine/src/evm/input.rs
+++ b/rust/services/call/engine/src/evm/input.rs
@@ -6,7 +6,6 @@ use std::{
 
 use alloy_primitives::{BlockHash, BlockNumber, Bytes, ChainId, B256};
 use block_header::{EvmBlockHeader, Hashable};
-use chain_common::ChainProof;
 use derive_more::{From, Into, IntoIterator};
 use derive_new::new;
 use itertools::Itertools;
@@ -83,7 +82,7 @@ where
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, From, Into, IntoIterator, new)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone, From, Into, IntoIterator, new)]
 pub struct MultiEvmInput {
     pub inputs: HashMap<ExecutionLocation, EvmInput>,
 }
@@ -97,28 +96,8 @@ impl MultiEvmInput {
         Self { inputs }
     }
 
-    pub fn assert_coherency(
-        &self,
-        chain_proofs: &HashMap<ChainId, ChainProof>,
-        verify_chain_proofs: bool,
-    ) {
+    pub fn assert_coherency(&self) {
         self.inputs.values().for_each(EvmInput::assert_coherency);
-        if verify_chain_proofs {
-            self.assert_chain_coherence(chain_proofs);
-        }
-    }
-
-    fn assert_chain_coherence(&self, chain_proofs: &HashMap<ChainId, ChainProof>) {
-        for (chain_id, blocks) in self.blocks_by_chain() {
-            let chain_proof = chain_proofs.get(&chain_id).expect("chain proof not found");
-            for (block_number, block_hash) in blocks {
-                let trie_block_hash = chain_proof
-                    .block_trie
-                    .get(block_number)
-                    .expect("block hash not found");
-                assert_eq!(trie_block_hash, block_hash, "block hash mismatch");
-            }
-        }
     }
 
     fn group_blocks<F, T>(&self, f: F) -> HashMap<ChainId, Vec<T>>

--- a/rust/services/call/engine/src/io.rs
+++ b/rust/services/call/engine/src/io.rs
@@ -1,8 +1,7 @@
-use std::collections::HashMap;
-
-use alloy_primitives::{Address, ChainId, FixedBytes, TxKind};
+use alloy_primitives::{Address, FixedBytes, TxKind};
 use alloy_sol_types::SolValue;
-use chain_common::ChainProof;
+use chain_client::ChainProofCache;
+use derive_new::new;
 use revm::{interpreter::CallInputs, primitives::TxEnv};
 use risc0_zkvm::sha::Digest;
 use serde::{Deserialize, Serialize};
@@ -17,9 +16,9 @@ use crate::{
 #[derive(Deserialize, Serialize, Debug)]
 pub struct Input {
     pub multi_evm_input: MultiEvmInput,
-    pub call: Call,
     pub start_execution_location: ExecutionLocation,
-    pub chain_proofs: HashMap<ChainId, ChainProof>,
+    pub chain_proofs: ChainProofCache,
+    pub call: Call,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -76,7 +75,7 @@ pub enum GuestOutputError {
     CannotDecodeCallAssumptions(String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, new)]
 pub struct GuestOutput {
     pub call_assumptions: CallAssumptions,
     pub evm_call_result: Vec<u8>,

--- a/rust/services/call/engine/src/verifier.rs
+++ b/rust/services/call/engine/src/verifier.rs
@@ -1,10 +1,9 @@
 mod chain_proof;
-mod guest_input;
+pub mod guest_input;
 mod zk_proof;
 
 #[cfg(test)]
 mod tests;
 
 pub use chain_proof::{ChainProofError, ChainProofVerifier, ZkChainProofVerifier};
-pub use guest_input::{GuestInputError, GuestInputVerifier, ZkGuestInputVerifier};
 pub use zk_proof::{GuestVerifier, HostVerifier, VerificationError, ZkpVerifier};

--- a/rust/services/call/guest/Cargo.toml
+++ b/rust/services/call/guest/Cargo.toml
@@ -13,9 +13,15 @@ as-any = { workspace = true }
 block_header = { workspace = true }
 call_engine = { workspace = true }
 chain = { workspace = true }
+chain_client = { workspace = true }
 chain_common = { workspace = true }
+chain_guest_wrapper = { workspace = true }
 mpt = { workspace = true }
 revm = { workspace = true }
+
+[dev-dependencies]
+call_engine = { workspace = true, features = ["testing"] }
+tokio = { workspace = true, features = ["rt", "macros"] }
 
 [lints]
 workspace = true

--- a/rust/services/call/guest/src/guest.rs
+++ b/rust/services/call/guest/src/guest.rs
@@ -1,58 +1,26 @@
-use std::collections::HashMap;
-
-use alloy_primitives::ChainId;
 use call_engine::{
-    evm::{
-        env::{cached::CachedEvmEnv, location::ExecutionLocation},
-        input::MultiEvmInput,
-    },
-    io::{Call, GuestOutput},
-    travel_call_executor::TravelCallExecutor,
-    CallAssumptions,
+    io::{GuestOutput, Input},
+    verifier::{guest_input, GuestVerifier, ZkChainProofVerifier},
 };
-use chain_common::ChainProof;
+use chain_client::CachedClient;
+use chain_guest_wrapper::RISC0_CHAIN_GUEST_ID;
+use env::{verify_input, VerifiedEnv};
 
-use crate::db::wrap_state::WrapStateDb;
+mod env;
+#[cfg(test)]
+mod tests;
 
-const VERIFY_CHAIN_PROOFS: bool = false;
-
-pub struct Guest {
-    start_execution_location: ExecutionLocation,
-    evm_envs: CachedEvmEnv<WrapStateDb>,
-}
-
-impl Guest {
-    #[must_use]
-    pub fn new(
-        multi_evm_input: MultiEvmInput,
-        start_execution_location: ExecutionLocation,
-        chain_proofs: &HashMap<ChainId, ChainProof>,
-    ) -> Self {
-        multi_evm_input.assert_coherency(chain_proofs, VERIFY_CHAIN_PROOFS);
-        let multi_evm_env = multi_evm_input.into();
-        let evm_envs = CachedEvmEnv::from_envs(multi_evm_env);
-
-        Guest {
-            evm_envs,
-            start_execution_location,
-        }
-    }
-
-    #[allow(clippy::unused_async)]
-    pub async fn run(self, call: &Call) -> GuestOutput {
-        let evm_call_result = TravelCallExecutor::new(&self.evm_envs)
-            .call(call, self.start_execution_location)
-            .unwrap();
-        let start_evm_env = self
-            .evm_envs
-            .get(self.start_execution_location)
-            .expect("cannot get start evm env");
-        let call_assumptions =
-            CallAssumptions::new(start_evm_env.header(), call.to, call.selector());
-
-        GuestOutput {
-            evm_call_result: evm_call_result.output,
-            call_assumptions,
-        }
-    }
+pub async fn main(
+    Input {
+        multi_evm_input,
+        start_execution_location,
+        chain_proofs,
+        call,
+    }: Input,
+) -> GuestOutput {
+    let chain_client = CachedClient::new(chain_proofs);
+    let chain_proof_verifier = ZkChainProofVerifier::new(RISC0_CHAIN_GUEST_ID, GuestVerifier);
+    let input_verifier = guest_input::ZkVerifier::new(chain_client, chain_proof_verifier);
+    let verified_input = verify_input(input_verifier, multi_evm_input).await;
+    VerifiedEnv::new(verified_input, start_execution_location).exec_call(&call)
 }

--- a/rust/services/call/guest/src/guest/env.rs
+++ b/rust/services/call/guest/src/guest/env.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+
+use call_engine::{
+    evm::{
+        env::{cached::CachedEvmEnv, location::ExecutionLocation, EvmEnv},
+        input::MultiEvmInput,
+    },
+    io::{Call, GuestOutput},
+    travel_call_executor::TravelCallExecutor,
+    verifier::guest_input::Verifier,
+    CallAssumptions,
+};
+
+use crate::db::wrap_state::WrapStateDb;
+
+// Feature flag to be removed when integration tests are ready
+pub const VERIFY_CHAIN_PROOFS: bool = false;
+
+pub struct VerifiedInput(MultiEvmInput);
+
+pub async fn verify_input(
+    verifier: impl Verifier,
+    multi_evm_input: MultiEvmInput,
+) -> VerifiedInput {
+    multi_evm_input.assert_coherency();
+    if VERIFY_CHAIN_PROOFS {
+        verifier
+            .verify(&multi_evm_input)
+            .await
+            .expect("invalid guest input");
+    }
+    VerifiedInput(multi_evm_input)
+}
+
+pub struct VerifiedEnv {
+    multi_evm_env: CachedEvmEnv<WrapStateDb>,
+    start_exec_location: ExecutionLocation,
+}
+
+impl VerifiedEnv {
+    #[must_use]
+    pub fn new(verified_input: VerifiedInput, start_exec_location: ExecutionLocation) -> Self {
+        Self {
+            multi_evm_env: CachedEvmEnv::from_envs(verified_input.0.into()),
+            start_exec_location,
+        }
+    }
+
+    fn get_start_env(&self) -> Arc<EvmEnv<WrapStateDb>> {
+        self.multi_evm_env
+            .get(self.start_exec_location)
+            .expect("cannot get start evm env")
+    }
+
+    #[must_use]
+    pub fn exec_call(self, call: &Call) -> GuestOutput {
+        let evm_call_result = TravelCallExecutor::new(&self.multi_evm_env)
+            .call(call, self.start_exec_location)
+            .expect("travel call execution failed")
+            .output;
+        let start_env = self.get_start_env();
+        let call_assumptions = CallAssumptions::new(start_env.header(), call.to, call.selector());
+        GuestOutput::new(call_assumptions, evm_call_result)
+    }
+}

--- a/rust/services/call/guest/src/guest/tests.rs
+++ b/rust/services/call/guest/src/guest/tests.rs
@@ -1,0 +1,87 @@
+use alloy_primitives::{BlockNumber, ChainId, B256};
+use block_header::{EthBlockHeader, EvmBlockHeader};
+use call_engine::{
+    evm::{
+        env::location::ExecutionLocation,
+        input::{EvmInput, MultiEvmInput},
+    },
+    verifier::{guest_input::Error as GuestInputError, ChainProofError, VerificationError},
+};
+use mpt::MerkleTrie;
+
+use super::*;
+
+const CHAIN_ID: ChainId = 1;
+const BLOCK_NUM: BlockNumber = 0;
+const EXEC_LOCATION: ExecutionLocation = ExecutionLocation::new(BLOCK_NUM, CHAIN_ID);
+
+const fn input_ok(_: &MultiEvmInput) -> Result<(), GuestInputError> {
+    Ok(())
+}
+
+const fn input_invalid(_: &MultiEvmInput) -> Result<(), GuestInputError> {
+    Err(GuestInputError::ChainProof(ChainProofError::Zk(
+        VerificationError::InvalidProof,
+    )))
+}
+
+fn mock_header(state_root: B256) -> Box<dyn EvmBlockHeader> {
+    let header = EthBlockHeader {
+        number: BLOCK_NUM,
+        state_root,
+        ..Default::default()
+    };
+    Box::new(header)
+}
+
+fn mock_evm_input(header: Box<dyn EvmBlockHeader>, state_trie: MerkleTrie) -> EvmInput {
+    EvmInput {
+        header,
+        state_trie,
+        storage_tries: Default::default(),
+        contracts: Default::default(),
+        ancestors: Default::default(),
+    }
+}
+
+fn mock_multi_evm_input(state_trie: MerkleTrie, state_root: B256) -> MultiEvmInput {
+    let header = mock_header(state_root);
+    let evm_input = mock_evm_input(header, state_trie);
+    MultiEvmInput::from_entries([(EXEC_LOCATION, evm_input)])
+}
+
+mod verify_env {
+    use block_header::Hashable;
+    use env::VERIFY_CHAIN_PROOFS;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn ok() {
+        let state_trie = MerkleTrie::new();
+        let state_root = state_trie.hash_slow();
+        let multi_evm_input = mock_multi_evm_input(state_trie, state_root);
+        _ = verify_input(input_ok, multi_evm_input).await;
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "State root mismatch")]
+    async fn state_root_mismatch() {
+        let state_trie = MerkleTrie::new();
+        let state_root = B256::ZERO; // invalid state root hash
+        let multi_evm_input = mock_multi_evm_input(state_trie, state_root);
+        _ = verify_input(input_ok, multi_evm_input).await;
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "invalid guest input")]
+    async fn zk_verification_failed() {
+        if !VERIFY_CHAIN_PROOFS {
+            panic!("invalid guest input");
+        }
+        let state_trie = MerkleTrie::new();
+        let state_root = state_trie.hash_slow();
+        let multi_evm_input = mock_multi_evm_input(state_trie, state_root);
+        _ = verify_input(input_invalid, multi_evm_input).await;
+    }
+}

--- a/rust/services/call/guest/src/lib.rs
+++ b/rust/services/call/guest/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod db;
-pub mod guest;
+mod guest;
+
 pub use call_engine::io::Input;
-pub use guest::Guest;
+pub use guest::main;

--- a/rust/services/call/guest_wrapper/risc0_guest/Cargo.lock
+++ b/rust/services/call/guest_wrapper/risc0_guest/Cargo.lock
@@ -887,9 +887,43 @@ dependencies = [
  "block_header",
  "call_engine",
  "chain",
+ "chain_client",
  "chain_common",
+ "chain_guest_wrapper",
  "mpt",
  "revm",
+]
+
+[[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.23",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -947,6 +981,13 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+]
+
+[[package]]
+name = "chain_guest_wrapper"
+version = "0.1.0"
+dependencies = [
+ "risc0-build",
 ]
 
 [[package]]
@@ -1336,6 +1377,33 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "docker-generate"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf673e0848ef09fa4aeeba78e681cf651c0c7d35f76ee38cec8e55bc32fa111"
 
 [[package]]
 name = "downcast-rs"
@@ -2045,6 +2113,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2469,6 +2547,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "p256"
@@ -2911,6 +2995,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3093,6 +3188,24 @@ dependencies = [
  "risc0-zkvm-platform",
  "serde",
  "tracing",
+]
+
+[[package]]
+name = "risc0-build"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "452836a801f4c304c567f88855184f941d778d971cb94bee25b72d4255b56f09"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "dirs",
+ "docker-generate",
+ "risc0-binfmt",
+ "risc0-zkp",
+ "risc0-zkvm-platform",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -3506,6 +3619,9 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"

--- a/rust/services/call/guest_wrapper/risc0_guest/src/main.rs
+++ b/rust/services/call/guest_wrapper/risc0_guest/src/main.rs
@@ -3,21 +3,13 @@
 risc0_zkvm::guest::entry!(main);
 
 use alloy_sol_types::SolValue;
-use call_guest::{Guest, Input};
 use risc0_zkvm::guest::env;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let Input {
-        multi_evm_input,
-        call,
-        start_execution_location,
-        chain_proofs,
-    } = env::read();
+    let input = env::read();
 
-    let output = Guest::new(multi_evm_input, start_execution_location, &chain_proofs)
-        .run(&call)
-        .await;
+    let output = call_guest::main(input).await;
 
     env::commit_slice(&output.call_assumptions.abi_encode());
     env::commit_slice(&output.evm_call_result);


### PR DESCRIPTION
Verification is blocked behind a feature flag. To be removed when integration tests are fixed.

TODO (in separate PRs):
  - [ ] Fix integration tests,
  - [ ] Refactor `chain_proof` and `zk_proof` in the same way as `guest_input`,
  - [ ] Change the interface of `ChainProofClient` to avoid calling `_ = ..get_chain_proofs()`