### PR TITLE
Improve cli msg for missing priv key

### DIFF
--- a/examples/web_proof/vlayer/config.ts
+++ b/examples/web_proof/vlayer/config.ts
@@ -13,7 +13,7 @@ const ensureEnvVariable = (envVar: string) => {
     if (envVar === "PRIVATE_KEY") {
       throw new Error(
         chalk.bgBlue(
-          `${envVar} is not set. Please set it in your .env.local file`,
+          `${envVar} missing. Add a HEX private key with ETH in .env.local for deploy and verify transactions.`,
         ),
       );
     }


### PR DESCRIPTION
Added minor improvement to cli error msg. I think we should not add there faucet details as it vary depending on chosen chain. Developer will acknowledge when wallet is empty. 