### PR TITLE
Allow burst traffic in nginx rate limiting

### DIFF
--- a/ansible/roles/prover_nginx/defaults/main.yml
+++ b/ansible/roles/prover_nginx/defaults/main.yml
@@ -1,1 +1,2 @@
 prover_nginx_ip_rate_limit_per_minute: 30
+prover_nginx_ip_rate_limit_burst: 5

--- a/ansible/roles/prover_nginx/templates/vlayer-prover.conf.j2
+++ b/ansible/roles/prover_nginx/templates/vlayer-prover.conf.j2
@@ -5,7 +5,7 @@ server {
   ssl_certificate /etc/ssl/certs/prover.vlayer.xyz.pem;
   ssl_certificate_key /etc/ssl/private/prover.vlayer.xyz.key;
   location / {
-    limit_req zone=requestlimit;
+    limit_req zone=requestlimit burst={{- prover_nginx_ip_rate_limit_burst }};
     proxy_pass http://127.0.0.1:{{- vlayer_prover_port if vlayer_prover_port is defined else '3000' }};
   }
 }


### PR DESCRIPTION
We need to allow some burst traffic, at the very least to allow an OPTIONS request in the browser immediately preceding a POST request.