### PR TITLE
Debug logs on prover servers

### DIFF
--- a/ansible/roles/prover/README.md
+++ b/ansible/roles/prover/README.md
@@ -12,3 +12,4 @@ Installs the vlayer Prover server.
 | `vlayer_proof_type` | Type of proof - `fake` or `groth16`. |
 | `vlayer_bonsai_api_url` | API url for Bonsai, required for real proofs. |
 | `vlayer_bonsai_api_key` | API key for Bonsai, required for real proofs. |
+| `vlayer_rust_log_level` | `RUST_LOG` level passed to the binary. Default is `debug`. |

--- a/ansible/roles/prover/templates/vlayer.service.j2
+++ b/ansible/roles/prover/templates/vlayer.service.j2
@@ -14,6 +14,7 @@ StandardError=inherit
 SyslogIdentifier=vlayer
 SyslogFacility=local0
 
+Environment=RUST_LOG={{ vlayer_rust_log_level | default('debug') }}
 Environment=PATH=/home/ubuntu/.cargo/bin/:$PATH
 {% if vlayer_bonsai_api_url is defined %}
 Environment='BONSAI_API_URL={{ vlayer_bonsai_api_url }}'


### PR DESCRIPTION
Add an option to set `RUST_LOG` variable passed to the binary on a prover server, and set it to `debug` by default.