### PR TITLE
Upgrade risc0 build dependencies

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8336,9 +8336,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "543230f7117ce0e6b92b4797fbb3da722575973258cc38a48e28af8d3cf3a26d"
+checksum = "9749a29181f87bebd2580b39b3ec0368daaaefbb30429ff429383a7ade360321"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8346,19 +8346,21 @@ dependencies = [
  "risc0-zkp",
  "risc0-zkvm-platform",
  "serde",
+ "syn 2.0.85",
  "tracing",
 ]
 
 [[package]]
 name = "risc0-build"
-version = "1.0.5"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452836a801f4c304c567f88855184f941d778d971cb94bee25b72d4255b56f09"
+checksum = "dc684382e24a8c91331040c33f1c789c755a5c1b0b8a32fefc1730ca36dd7072"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "dirs 5.0.1",
  "docker-generate",
+ "hex",
  "risc0-binfmt",
  "risc0-zkp",
  "risc0-zkvm-platform",
@@ -8369,9 +8371,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-ethereum"
-version = "1.0.0"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64f88dfb7915cf349ed3fcff5cc35904068087b1ffb28d7fbb5fcd94335f10d"
+checksum = "6d8e8421d119e7cdab2b3be263cd28835d5671705553c03f33476cdafd93dc8b"
 dependencies = [
  "anyhow",
  "hex",
@@ -8410,9 +8412,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1714b8968a5e4583a15018dc2ae95878c76f4cdbc643268a34670fde5b08252a"
+checksum = "8fd39ba3f881fcf0197464bde04391602dbbb886f87fddc372a68d79aa9de9d9"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -8440,9 +8442,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285aa3993827b4a646d70e68240e138f71574680a02d2e97ad30b1db80efda80"
+checksum = "15b5525e1f2abaa5954579e50df0d6a5d01b456b0ac6aae0e87cf92f073e12f7"
 dependencies = [
  "anyhow",
  "blake2",
@@ -8494,9 +8496,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6acf0b0d7a55578f892e0460ed1f2ca06d0380e32440531d80ca82530d41272"
+checksum = "57748f1916078b24faed0bc620aa6dfc386e066e6f75a710ec0ac68f7126e7d7"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -101,8 +101,8 @@ rayon = "1.10.0"
 regex = "1.11.1"
 reqwest = { version = "0.12.8", default-features = false }
 revm = { version = "=14.0.3", default-features = false, features = ["optimism"] }
-risc0-build = "=1.0.5"
-risc0-build-ethereum = "=1.0.0"
+risc0-build = "1.1.3"
+risc0-build-ethereum = "1.1.4"
 risc0-zkp = { version = "1.1.2", default-features = false }
 risc0-zkvm = "=1.0.5"
 rlp = "0.6.1"

--- a/rust/services/call/guest_wrapper/risc0_guest/Cargo.lock
+++ b/rust/services/call/guest_wrapper/risc0_guest/Cargo.lock
@@ -3193,28 +3193,31 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.5"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4003dd96f2e323dfef431b21a2aaddee1c6791fc32dea8eb2bff1b438bf5caf6"
+checksum = "9749a29181f87bebd2580b39b3ec0368daaaefbb30429ff429383a7ade360321"
 dependencies = [
  "anyhow",
+ "borsh",
  "elf",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "serde",
+ "syn 2.0.85",
  "tracing",
 ]
 
 [[package]]
 name = "risc0-build"
-version = "1.0.5"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452836a801f4c304c567f88855184f941d778d971cb94bee25b72d4255b56f09"
+checksum = "dc684382e24a8c91331040c33f1c789c755a5c1b0b8a32fefc1730ca36dd7072"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "dirs",
  "docker-generate",
+ "hex",
  "risc0-binfmt",
  "risc0-zkp",
  "risc0-zkvm-platform",
@@ -3254,9 +3257,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1714b8968a5e4583a15018dc2ae95878c76f4cdbc643268a34670fde5b08252a"
+checksum = "8fd39ba3f881fcf0197464bde04391602dbbb886f87fddc372a68d79aa9de9d9"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -3284,9 +3287,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285aa3993827b4a646d70e68240e138f71574680a02d2e97ad30b1db80efda80"
+checksum = "15b5525e1f2abaa5954579e50df0d6a5d01b456b0ac6aae0e87cf92f073e12f7"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3338,9 +3341,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6acf0b0d7a55578f892e0460ed1f2ca06d0380e32440531d80ca82530d41272"
+checksum = "57748f1916078b24faed0bc620aa6dfc386e066e6f75a710ec0ac68f7126e7d7"
 dependencies = [
  "bytemuck",
  "getrandom",


### PR DESCRIPTION
New risc0 build scripts generate methods.rs differently.
Instead of doing:
```rs
pub const NOOP_ELF: &[u8] = [... (Megabytes of inline data to lex, parse, typecheck)];
```
they do:
```rs
pub const NOOP_ELF: &[u8] = include_bytes!("/Users/leonidlogvinov/Dev/ZK/hello-world/target/riscv-guest/riscv32im-risc0-zkvm-elf/release/noop");
```

If you remember - in the previous PR - it took 8.6s to compile `methods.rs`
<img width="1728" alt="Screenshot 2024-11-14 at 15 45 12" src="https://github.com/user-attachments/assets/188b77fd-5d84-4566-8ce1-b26cdb2cdcdf">
It now takes 0.25s.

<img width="1728" alt="Screenshot 2024-11-14 at 15 45 17" src="https://github.com/user-attachments/assets/5bc7e886-ef3a-4141-acdd-49ba179542f8">

Which takes total inc build time on my machine from 21.8 -> 12.0.

# Downsides
You now see a bunch of logs like this:
```rs
failed to get image ID using r0vm: error: unexpected argument '--id' found

Usage: r0vm <--port <PORT>|--elf <ELF>|--image <IMAGE>>

For more information, try '--help'.

```

Those are warnings that look like errors. Risc0 knows about it: https://github.com/risc0/risc0/issues/2439
I feel like those perf gains are worth it. We also don't need to use pinned versions any more at least for those 2 dependencies.