### PR TITLE
Add `nodelay` option to rate limiting

### DIFF
--- a/ansible/roles/prover_nginx/templates/vlayer-prover.conf.j2
+++ b/ansible/roles/prover_nginx/templates/vlayer-prover.conf.j2
@@ -5,7 +5,7 @@ server {
   ssl_certificate /etc/ssl/certs/prover.vlayer.xyz.pem;
   ssl_certificate_key /etc/ssl/private/prover.vlayer.xyz.key;
   location / {
-    limit_req zone=requestlimit burst={{- prover_nginx_ip_rate_limit_burst }};
+    limit_req zone=requestlimit burst={{- prover_nginx_ip_rate_limit_burst }} nodelay;
     proxy_pass http://127.0.0.1:{{- vlayer_prover_port if vlayer_prover_port is defined else '3000' }};
   }
 }


### PR DESCRIPTION
Generally recommended to add it, it means that requests in a burst queue can be forwarded right away.
https://blog.nginx.org/blog/rate-limiting-nginx