### PR TITLE
ci: install required musl toolchain in release build-release step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,6 @@ jobs:
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          target: x86_64-unknown-linux-musl
           cache-workspaces: |
             rust
             rust/services/call/guest_wrapper/risc0_guest
@@ -107,6 +106,7 @@ jobs:
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          target: x86_64-unknown-linux-musl
           cache-workspaces: |
             rust
             rust/services/call/guest_wrapper/risc0_guest


### PR DESCRIPTION
Originally I added additional target installation in the wrong GH job. Apologies!