### PR TITLE
Use bun to build extension

### DIFF
--- a/.github/workflows/build_extension.yaml
+++ b/.github/workflows/build_extension.yaml
@@ -21,15 +21,15 @@ jobs:
 
       - name: Install dependencies
         working-directory: packages/browser-extension
-        run: npm install
+        run: bun install --frozen-lockfile 
       - name: Update extension version
         working-directory: packages/browser-extension
         env: 
           VLAYER_BUILD: '0.0.0-test'
-        run: npm version "${VLAYER_BUILD}"
+        run: npm version "${VLAYER_BUILD}" --no-workspaces-update 
       - name: Build and compress
         working-directory: packages/browser-extension
         run: |
-          npm run build
+          bun run build
           mv dist browser-extension
           tar -czvf browser-extension.tar.gz browser-extension

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -236,23 +236,21 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+      - name: Install TypeScript prerequisites
+      uses: ./.github/actions/ts-prerequisites
 
       - name: Install dependencies
         working-directory: packages/browser-extension
-        run: npm install
+        run: bun install --frozen-lockfile
       - name: Update extension version
         working-directory: packages/browser-extension
         env: 
           VLAYER_BUILD: ${{ needs.build-release.outputs.vlayer_build }}
-        run: npm version "${VLAYER_BUILD}"
+          run: npm version "${VLAYER_BUILD}" --no-workspaces-update
       - name: Build and compress
         working-directory: packages/browser-extension
         run: |
-          npm run build
+          bun run build
           mv dist browser-extension
           tar -czvf browser-extension.tar.gz browser-extension
 


### PR DESCRIPTION
Npm is still used for `npm version` as tere is no corresponding command in bun. However it should be done using own script to make sure its side effect free. 