### PR TITLE
ci: temporarily use run-services.sh in e2e tests

### DIFF
--- a/.github/workflows/test_e2e_web_flow.yaml
+++ b/.github/workflows/test_e2e_web_flow.yaml
@@ -25,6 +25,21 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        working-directory: ./packages
+      - name: Build sdk
+        run: bun run build
+        working-directory: ./packages/sdk
+      - name: Install dependencies of test-web-app
+        run: bun install --frozen-lockfile
+        working-directory: ./packages/test-web-app
+      - name: Build extension
+        run: bun run build
+        working-directory: ./packages/browser-extension
+      - name: Install Playwright Browsers
+        run: bunx playwright install --with-deps chromium
+        working-directory: ./packages/browser-extension
       - name: Install Rust prerequisites
         uses: ./.github/actions/rust-prerequisites
       - name: Install contracts prerequisites
@@ -33,6 +48,9 @@ jobs:
         with:
           compose-file: docker/web-proof/docker-compose-release.yaml
           up-flags: "--build"
+          services: |
+            websockify
+            notary-server
       - name: Run playwright tests
         run: bash/playwright-test.sh
       - uses: actions/upload-artifact@v4

--- a/bash/playwright-test.sh
+++ b/bash/playwright-test.sh
@@ -7,36 +7,21 @@ VLAYER_HOME=$(git rev-parse --show-toplevel)
 echo Run services
 source ${VLAYER_HOME}/bash/run-services.sh
 
-echo Install dependencies
-cd ${VLAYER_HOME}/packages && bun install --frozen-lockfile && cd -
-
-echo Build SDK
-cd ${VLAYER_HOME}/packages/sdk && bun run build && cd -
-
-echo Install dependencies of test-web-app
-cd ${VLAYER_HOME}/packages/test-web-app && bun install --frozen-lockfile && cd -
-
-echo Build extension
-cd ${VLAYER_HOME}/packages/browser-extension && bun run build && cd -
-
-echo Install playwright browsers
-cd ${VLAYER_HOME}/packages/browser-extension && bunx playwright install --with-deps chromium && cd -
-
 echo Mock ImageId.sol
 source ${VLAYER_HOME}/bash/mock-imageid.sh
 
 echo Run Forge build vlayer
-cd ${VLAYER_HOME}/contracts/vlayer
+pushd ${VLAYER_HOME}/contracts/vlayer
 forge soldeer install
 forge build --sizes
-cd -
+popd
 
 echo Run Forge build fixtures
-cd ${VLAYER_HOME}/contracts/fixtures
+pushd ${VLAYER_HOME}/contracts/fixtures
 forge soldeer install
 forge build --sizes
-cd -
+popd
 
 echo Run playwright tests
-cd ${VLAYER_HOME}/packages && bun run test:headless && cd -
+pushd ${VLAYER_HOME}/packages && bun run test:headless && popd
 

--- a/docker/web-proof/docker-compose-release.yaml
+++ b/docker/web-proof/docker-compose-release.yaml
@@ -11,4 +11,17 @@ services:
       - "7047:7047"
     volumes:
       - ./notary-config:/root/.notary-server/config
+  anvil:
+    build:
+      dockerfile: ../anvil/Dockerfile
+    platform: linux/amd64
+    ports:
+      - "8545:8545"
+  vlayer:
+    build:
+      context: ../../
+      dockerfile: ./docker/vlayer/Dockerfile.nightly
+    command: "serve --proof fake --host 0.0.0.0 --rpc-url 31337:http://anvil:8545"
+    ports:
+      - "3000:3000"
 


### PR DESCRIPTION
With this change, we forego Docker for composing vlayer in e2e tests. Instead, we build vlayer from source using our existing machinery, and use run-services.sh to bring it up.