### PR TITLE
Reduce level of logs on deployed prover servers

### DIFF
--- a/ansible/group_vars/provers.yml
+++ b/ansible/group_vars/provers.yml
@@ -1,2 +1,5 @@
 ---
 vlayer_risc0_version: '1.0.5'
+vlayer_rust_log:
+  - info
+  - call_engine=debug

--- a/ansible/roles/prover/README.md
+++ b/ansible/roles/prover/README.md
@@ -12,4 +12,4 @@ Installs the vlayer Prover server.
 | `vlayer_proof_type` | Type of proof - `fake` or `groth16`. |
 | `vlayer_bonsai_api_url` | API url for Bonsai, required for real proofs. |
 | `vlayer_bonsai_api_key` | API key for Bonsai, required for real proofs. |
-| `vlayer_rust_log_level` | `RUST_LOG` level passed to the binary. Default is `debug`. |
+| `vlayer_rust_log` | An array of log levels for constructing [`RUST_LOG`](https://rust-lang-nursery.github.io/rust-cookbook/development_tools/debugging/config_log.html). |

--- a/ansible/roles/prover/templates/vlayer.service.j2
+++ b/ansible/roles/prover/templates/vlayer.service.j2
@@ -14,7 +14,7 @@ StandardError=inherit
 SyslogIdentifier=vlayer
 SyslogFacility=local0
 
-Environment=RUST_LOG={{ vlayer_rust_log_level | default('debug') }}
+Environment=RUST_LOG={{ vlayer_rust_log | join(',') }}
 Environment=PATH=/home/ubuntu/.cargo/bin/:$PATH
 {% if vlayer_bonsai_api_url is defined %}
 Environment='BONSAI_API_URL={{ vlayer_bonsai_api_url }}'


### PR DESCRIPTION
Instead of debug-logging everything  (too much logs), we explicitly specify debug levels for our code. Currently, only `call_engine` does any debug logging and it seems valuable to collect.