### PR TITLE
call_host: extract proving functionality from Host::main

### DIFF
--- a/rust/services/call/engine/src/lib.rs
+++ b/rust/services/call/engine/src/lib.rs
@@ -8,7 +8,7 @@ pub mod sol;
 pub mod travel_call_executor;
 pub mod utils;
 pub use db::seed_cache_db_with_trusted_data;
-pub use io::{Call, GuestOutput, GuestOutputError, HostOutput, Input};
+pub use io::{Call, CallGuestId, GuestOutput, GuestOutputError, HostOutput, Input};
 pub use sol::{
     call_assumptions::CallAssumptions,
     proof::Proof,

--- a/rust/services/call/server/src/handlers/v_call.rs
+++ b/rust/services/call/server/src/handlers/v_call.rs
@@ -26,6 +26,11 @@ pub async fn v_call(config: Arc<ServerConfig>, params: Params) -> Result<CallRes
         .hash_slow()
         .into();
     info!("Calculated hash: {}", call_hash);
-    let host_output = host.main(call).await?;
+
+    let prover = host.prover();
+    let call_guest_id = host.call_guest_id();
+    let preflight_result = host.preflight(call).await?;
+    let host_output = Host::prove(&prover, call_guest_id, preflight_result)?;
+
     Ok(CallResult::try_new(call_hash, host_output)?)
 }


### PR DESCRIPTION
Simple refactor which splits preflight from proving. We will need this to orchestrate update calls to the gas meter.