### PR TITLE
Remove alchemy from devnet tests

### DIFF
--- a/.github/workflows/test_e2e_devnet.yaml
+++ b/.github/workflows/test_e2e_devnet.yaml
@@ -8,7 +8,7 @@ on:
       - "examples/**"
       - "packages/**"
       - "bash/**"
-      - "test_e2e_devnet.yaml"
+      - ".github/workflows/test_e2e_devnet.yaml"
       - "contracts/**"
   merge_group:
   push:


### PR DESCRIPTION
Because the devnet means anvil, so alchemy does not fit here.