### PR TITLE
Update broken link to forked soldeer

### DIFF
--- a/rust/cli/src/commands/init.rs
+++ b/rust/cli/src/commands/init.rs
@@ -45,7 +45,7 @@ lazy_static! {
         SoldeerDep {
             name: "risc0-ethereum".into(),
             version: "1.1.4".into(),
-            url: Some("https://github.com/vlayer-xyz/risc0-ethereum/releases/download/v1.1.4-soldeer-no-remappings/contracts.zip".into()),
+            url: Some("https://github.com/vlayer-xyz/risc0-ethereum/releases/download/v1.1.4-soldeer/contracts.zip".into()),
             remapping: Some("risc0-ethereum-1.1.4".into()),
         },
         SoldeerDep {


### PR DESCRIPTION
I have no idea why we have this forked, so I might be missing something, I only know that the link is broken and `init` is failing.