### PR TITLE
chain_server: move config.clone() into block returning handler

### DIFF
--- a/rust/services/chain/server_lib/src/server.rs
+++ b/rust/services/chain/server_lib/src/server.rs
@@ -22,16 +22,18 @@ async fn handle_jrpc(
 
 pub fn server(chain_db: ChainDb) -> axum::Router {
     let chain_db = Arc::new(RwLock::new(chain_db));
-    let chain_db_ = chain_db.clone();
     let mut jrpc_router = server_utils::Router::default();
-    jrpc_router.add_handler("v_chain", move |params| -> Pin<Box<dyn Future<Output = _> + Send>> {
+    jrpc_router.add_handler("v_chain", {
         let chain_db = chain_db.clone();
-        Box::pin(v_chain(chain_db, params))
+        move |params| -> Pin<Box<dyn Future<Output = _> + Send>> {
+            let chain_db = chain_db.clone();
+            Box::pin(v_chain(chain_db, params))
+        }
     });
     jrpc_router.add_handler(
         "v_sync_status",
         move |params| -> Pin<Box<dyn Future<Output = _> + Send>> {
-            let chain_db = chain_db_.clone();
+            let chain_db = chain_db.clone();
             Box::pin(v_sync_status(chain_db, params))
         },
     );


### PR DESCRIPTION
This makes it easier to add more handlers in the future without having to resort to an anti-pattern like the following:

```rust
let config_ = config.clone();
let config__ = config.clone();
```