### PR TITLE
Separate private key for post release tests, and conditional anvil restart

### DIFF
--- a/.github/workflows/test_release.yaml
+++ b/.github/workflows/test_release.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Test release
         env:
           VLAYER_ENV: testnet
-          EXAMPLES_TEST_PRIVATE_KEY: ${{ secrets.EXAMPLES_TEST_PRIVATE_KEY }}
+          EXAMPLES_TEST_PRIVATE_KEY: ${{ secrets.EXAMPLES_TEST_RELEASE_PRIVATE_KEY }}
           JSON_RPC_URL: "https://opt-sepolia.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}"
         run: bash/test-release.sh
   test-release-js-sdk:

--- a/bash/test-release.sh
+++ b/bash/test-release.sh
@@ -43,9 +43,11 @@ for example in $(find ${VLAYER_HOME}/examples -type d -maxdepth 1 -mindepth 1) ;
         continue
     fi
 
-    echo "Restarting anvil"
-    # We're restarting anvil because some examples rely on a clean chain state.
-    docker compose -f ${VLAYER_HOME}/docker/web-proof/docker-compose-release.yaml restart anvil
+    if [ "$VLAYER_ENV" = "dev" ]; then
+      # We're restarting anvil because some examples rely on a clean chain state.
+      echo "Restarting anvil"
+      docker compose -f ${VLAYER_HOME}/docker/web-proof/docker-compose-test-release.yaml restart 
+    fi
 
     echo "::group::Initializing vlayer template: ${example_name}"
     VLAYER_TEMP_DIR=$(mktemp -d -t vlayer-test-release-XXXXXX-)


### PR DESCRIPTION
- Change private key which is already used in another workflow and causes nonce issues.
- Change docker-compose file path, and use it only when running in dev mode.