### PR TITLE
call_server: create a dynamic object implementing gas_meter::Client trait

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2037,6 +2037,7 @@ dependencies = [
  "anyhow",
  "assert-json-diff",
  "async-trait",
+ "auto_impl",
  "axum",
  "axum-jrpc",
  "block_header",

--- a/rust/services/call/server/Cargo.toml
+++ b/rust/services/call/server/Cargo.toml
@@ -10,6 +10,7 @@ alloy-rlp = { workspace = true }
 alloy-sol-types = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+auto_impl = { workspace = true }
 axum = { workspace = true, features = ["macros"] }
 axum-jrpc = { workspace = true }
 call_engine = { workspace = true }

--- a/rust/services/call/server/src/gas_meter.rs
+++ b/rust/services/call/server/src/gas_meter.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use auto_impl::auto_impl;
 use derive_new::new;
 use serde::{Deserialize, Serialize};
 use server_utils::rpc::{Client as RawRpcClient, Method, Result};
@@ -43,7 +44,8 @@ pub struct Config {
 }
 
 #[async_trait]
-pub trait Client: Send {
+#[auto_impl(Box)]
+pub trait Client: Send + Sync {
     async fn allocate(&self, gas_limit: u64) -> Result<()>;
     async fn refund(&self, stage: ComputationStage, gas_used: u64) -> Result<()>;
 }

--- a/rust/services/call/server/src/handlers/v_call.rs
+++ b/rust/services/call/server/src/handlers/v_call.rs
@@ -55,7 +55,7 @@ pub async fn v_call(
 async fn generate_proof(
     call: EngineCall,
     host: Host,
-    gas_meter_client: Box<dyn GasMeterClient>,
+    gas_meter_client: impl GasMeterClient,
 ) -> Result<HostOutput, AppError> {
     let prover = host.prover();
     let call_guest_id = host.call_guest_id();


### PR DESCRIPTION
Then, pass around `Box<dyn Client>` where `Client` can either be a concrete implementation such as `gas_meter::DefaultClient` or a dummy noop client `gas_meter::NoOpClient`. The former is actually initialised from the server config, while the latter is noop in case such config is missing.