### PR TITLE
Fix zk proving notifications

### DIFF
--- a/packages/sdk/src/api/lib/client.test.ts
+++ b/packages/sdk/src/api/lib/client.test.ts
@@ -4,14 +4,13 @@ import {
   it,
   vi,
   beforeEach,
-  beforeAll,
   type MockInstance,
 } from "vitest";
 
 import { createExtensionWebProofProvider } from "../webProof";
 import { createVlayerClient } from "./client";
 import { type BrandedHash, type VlayerClient } from "types/vlayer";
-import { ZkProvingStatus } from "src/web-proof-commons";
+import { ZkProvingStatus } from "../../web-proof-commons";
 import createFetchMock from "vitest-fetch-mock";
 
 declare const global: {
@@ -50,7 +49,7 @@ describe("Success zk-proving", () => {
   let zkProvingSpy: MockInstance<(status: ZkProvingStatus) => void>;
   let vlayer: VlayerClient;
 
-  beforeAll(() => {
+  beforeEach(() => {
     hashStr = generateRandomHash();
     const webProofProvider = createExtensionWebProofProvider();
     zkProvingSpy = vi.spyOn(webProofProvider, "notifyZkProvingStatus");
@@ -74,10 +73,26 @@ describe("Success zk-proving", () => {
     });
 
     expect(result.hash).toBe(hashStr);
-    expect(zkProvingSpy).toBeCalledTimes(2);
+    expect(zkProvingSpy).toBeCalledTimes(1);
     expect(zkProvingSpy).toHaveBeenNthCalledWith(1, ZkProvingStatus.Proving);
   });
   it("should send message to extension that zkproving is done", async () => {
+    fetchMocker.mockResponseOnce(() => {
+      return {
+        body: JSON.stringify({
+          result: hashStr,
+        }),
+      };
+    });
+
+    await vlayer.prove({
+      address: `0x${"a".repeat(40)}`,
+      functionName: "main",
+      proverAbi: [],
+      args: [],
+      chainId: 42,
+    });
+
     fetchMocker.mockResponseOnce(() => {
       return {
         body: JSON.stringify({
@@ -94,6 +109,21 @@ describe("Success zk-proving", () => {
 
     expect(zkProvingSpy).toBeCalledTimes(2);
     expect(zkProvingSpy).toHaveBeenNthCalledWith(2, ZkProvingStatus.Done);
+  });
+  it("should notify that zk-proving failed", async () => {
+    fetchMocker.mockResponseOnce(() => {
+      throw new Error("test");
+    });
+
+    const hash = { hash: hashStr } as BrandedHash<[], string>;
+    try {
+      await vlayer.waitForProvingResult({ hash });
+    } catch (e) {
+      console.log("Error waiting for proving result", e);
+    }
+
+    expect(zkProvingSpy).toBeCalledTimes(1);
+    expect(zkProvingSpy).toHaveBeenNthCalledWith(1, ZkProvingStatus.Error);
   });
 });
 

--- a/packages/sdk/src/api/v_call.ts
+++ b/packages/sdk/src/api/v_call.ts
@@ -14,6 +14,9 @@ function v_callBody(call: CallParams, context: CallContext) {
   };
 }
 
+const log = (...args: unknown[]) => {
+  console.log("v_call: ", ...args);
+};
 export async function v_call(
   call: CallParams,
   context: CallContext,
@@ -24,12 +27,12 @@ export async function v_call(
     body: JSON.stringify(v_callBody(call, context)),
     headers: { "Content-Type": "application/json" },
   });
-  console.log("response", response);
+  log("response", response);
   if (!response.ok) {
     throw new Error(`HTTP error! status: ${response.status}`);
   }
   const response_json = await response.json();
-  console.log("response_json", response_json);
+  log("response_json", response_json);
   assertObject(response_json);
   if ("error" in response_json) {
     throw parseVCallResponseError(

--- a/packages/sdk/src/api/v_getProofReceipt.ts
+++ b/packages/sdk/src/api/v_getProofReceipt.ts
@@ -13,6 +13,10 @@ function v_getProofReceiptBody(params: VGetProofReceiptParams) {
   };
 }
 
+const log = (...args: unknown[]) => {
+  console.log("v_getProofReceipt: ", ...args);
+};
+
 export async function v_getProofReceipt(
   params: VGetProofReceiptParams,
   url: string = "http://127.0.0.1:3000",
@@ -22,12 +26,12 @@ export async function v_getProofReceipt(
     body: JSON.stringify(v_getProofReceiptBody(params)),
     headers: { "Content-Type": "application/json" },
   });
-  console.log("response", response);
+  log("response", response);
   if (!response.ok) {
     throw new Error(`HTTP error! status: ${response.status}`);
   }
   const response_json = await response.json();
-  console.log("response_json", response_json);
+  log("response_json", response_json);
   assertObject(response_json);
   if ("error" in response_json) {
     throw parseVCallResponseError(


### PR DESCRIPTION
This PR fixes implementation as well as tests ( that should catch it before :/ ) of zk proving result notification between SDK and extension. Current `main` version sends `ZkProvingStatus.Done` without waiting for proving result. 