### PR TITLE
Use root user for chain services docker images

### DIFF
--- a/docker/chain_server/Dockerfile.nightly
+++ b/docker/chain_server/Dockerfile.nightly
@@ -2,10 +2,8 @@ FROM --platform=linux/amd64 ubuntu:24.04 AS vlayer-builder
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends curl ca-certificates dumb-init
 
-RUN useradd -m -s /bin/bash -u 1001 vlayer
-USER vlayer
-WORKDIR /home/vlayer
+WORKDIR /root
 
 RUN curl -L https://vlayer-releases.s3.eu-north-1.amazonaws.com/latest/nightly-linux-amd64.tar.gz -o nightly-linux-amd64.tar.gz
 RUN tar -xvf nightly-linux-amd64.tar.gz
-ENTRYPOINT ["/usr/bin/dumb-init", "--", "/home/vlayer/bin/chain_server"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/root/bin/chain_server"]

--- a/docker/chain_worker/Dockerfile.nightly
+++ b/docker/chain_worker/Dockerfile.nightly
@@ -15,4 +15,5 @@ RUN rzup install cargo-risczero v1.1.3
 
 RUN curl -L https://vlayer-releases.s3.eu-north-1.amazonaws.com/latest/nightly-linux-amd64.tar.gz -o nightly-linux-amd64.tar.gz
 RUN tar -xvf nightly-linux-amd64.tar.gz
+USER root
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/home/vlayer/bin/worker"]


### PR DESCRIPTION
I defaulted to a non-root user in docker images we were creating, but turns out that most of the docker images out there use `root` for a reason.

I found it very hard to elegantly re-use a volume between chain server and chain workers - it would require some hacks/workarounds.

So I'm proposing a change to `root`.