### PR TITLE
Use newest version of json import

### DIFF
--- a/packages/sdk/src/api/prover.ts
+++ b/packages/sdk/src/api/prover.ts
@@ -18,7 +18,7 @@ import { v_getProofReceipt } from "./v_getProofReceipt";
 import { foundry } from "viem/chains";
 import { v_versions } from "./v_versions";
 import { checkVersionCompatibility } from "./utils/versions";
-import meta from "../../package.json" assert { type: "json" };
+import meta from "../../package.json" with { type: "json" };
 const sdkVersion = meta.version;
 
 export interface ProveOptions {


### PR DESCRIPTION
Till node version 22 there was still experimental support for https://github.com/tc39/proposal-import-attributes with `assert` syntax. It should be `with`. 