### PR TITLE
Add missing web:* scripts ...

### DIFF
--- a/examples/simple_web_proof/vlayer/package.json
+++ b/examples/simple_web_proof/vlayer/package.json
@@ -3,7 +3,6 @@
   "type": "module",
   "scripts": {
     "lint:solidity": "solhint '../src/**/*.sol'",
-    "dev": "vite --port 5174",
     "test": "VLAYER_ENV=test bun run prove.ts",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
@@ -13,7 +12,9 @@
     "prove:dev": "VLAYER_ENV=dev bun run prove.ts",
     "deploy:testnet": "VLAYER_ENV=testnet bun run deploy.ts",
     "deploy:dev": "VLAYER_ENV=dev bun run deploy.ts",
-    "test:dev": "echo \"No tests specified yet\""
+    "test:dev": "echo \"No tests specified yet\"",
+    "web:dev": "VLAYER_ENV=dev bun run deploy.ts && vite",
+    "web:testnet": "VLAYER_ENV=testnet bun run deploy.ts && vite"
   },
   "dependencies": {
     "@noble/hashes": "^1.4.0",


### PR DESCRIPTION
... in simple_web_proof example.  Current `dev` failed in runtime because contract are not deployed. 
Ideally It should be catched compile time but we have cast here https://github.com/vlayer-xyz/vlayer/blob/main/packages/sdk/src/config/createContext.ts#L16. The source of this problem is fact that we provide chain by its name and there is no export from viem of hashmap of  all the chains. 