### PR TITLE
Remove `aws-linux-small` label

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,5 @@
 self-hosted-runner:
   labels:
-    - aws-linux-small
     - aws-linux-medium
 paths:
   .github/workflows/**/*.yaml:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,7 +93,7 @@ jobs:
 
   create-release:
     name: Create GH releases
-    runs-on: aws-linux-small
+    runs-on: ubuntu-latest
     needs: [build-examples, build-extension, push-contracts]
     steps:
       - name: Checkout repository

--- a/.github/workflows/test_contracts.yaml
+++ b/.github/workflows/test_contracts.yaml
@@ -24,7 +24,7 @@ env:
 jobs:
   test-contracts:
     name: Test contracts
-    runs-on: aws-linux-small
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
There are now only 2 places where we use `aws-linux-small`.
I think it would be simpler to just use `ubuntu-latest` there - we still have github-hosted minutes included in our plan and we're within limits, so we won't increase our bill by using github-hosted runners on those two quick jobs.