### PR TITLE
Get rid of unique symbol usage

### DIFF
--- a/packages/web-proof-commons/utils.ts
+++ b/packages/web-proof-commons/utils.ts
@@ -1,5 +1,4 @@
-declare const __brand: unique symbol;
-type Brand<B> = { [__brand]: B };
+type Brand<B> = { __brand: B };
 export type Branded<T, B> = T & Brand<B>;
 
 export function isDefined<T>(


### PR DESCRIPTION
Using `unique symboi` for branding is standard to address two requirements 
- `__brand` should be hidden in intellisense to avoid confusion 
-  collision should be impossible 

Both above are not critical while with current code base, where we use `common-types` symlinked this approach causes serious problems. Symlinking file in two places ( two packages that depends on on another) leads to two `unique symbols` and as consequence type incompatibility. This leads to need to reexport types from packages, which shouldnd be the case. 
We will be back to`unique symbol` usage while migration out of bun is properly finished. 

Here is related document on notion. 

https://www.notion.so/vlayer/Migrating-out-of-bun-plan-165fdaece26780f6904adaf9c8d8652c?pvs=4


