### PR TITLE
Allow updates to the tagged nightly release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,6 +110,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: nightly-${{ github.sha }}
+          allowUpdates: true
           artifacts: "./dist/*"
 
       - name: Release nightly-latest


### PR DESCRIPTION
Currently, the release job fails if there are no new commits on `main` and the cron-based release runs again.
This happens during holidays etc.

This is a quick fix to stop the failures - allowing updates.
We could also use `skipIfReleaseExists`.

Another approach would be to check if release exists, and skip the whole workflow.