### PR TITLE
run-web-example: contracts are deployed twice

### DIFF
--- a/bash/run-web-example.sh
+++ b/bash/run-web-example.sh
@@ -8,11 +8,6 @@ function run_services {
     source ${VLAYER_HOME}/bash/run-services.sh 
 }
 
-function deploy_contracts {
-    cd ${VLAYER_HOME}/examples/simple_web_proof/vlayer
-    bun run deploy.ts 
-}
-
 function run_web_app {
     cd ${VLAYER_HOME}/examples/simple_web_proof/vlayer
     bun run web:dev &
@@ -30,6 +25,5 @@ function install_deps {
 
 install_deps
 run_services
-deploy_contracts
 run_web_app
 run_browser_extension


### PR DESCRIPTION
As `bun run web:dev` already deploys contracts, so it is not necessary to deploy them separately