### PR TITLE
useCallProver: Make hash null by default

### DIFF
--- a/packages/sdk-hooks/src/useCallProver/useCallProver.test.ts
+++ b/packages/sdk-hooks/src/useCallProver/useCallProver.test.ts
@@ -38,7 +38,7 @@ describe("useCallProver", () => {
     expect(result.current).toMatchObject({
       status: ProverStatus.Idle,
       error: null,
-      data: { hash: "" },
+      data: null,
       isIdle: true,
       isPending: false,
       isReady: false,

--- a/packages/sdk-hooks/src/useCallProver/useCallProver.ts
+++ b/packages/sdk-hooks/src/useCallProver/useCallProver.ts
@@ -30,9 +30,7 @@ export const useCallProver = (
   // state
   const [status, setStatus] = useState<ProverStatus>(ProverStatus.Idle);
   const [error, setError] = useState<Error | null>(null);
-  const [hash, setHash] = useState<BrandedHash<Abi, string>>({
-    hash: "",
-  } as BrandedHash<Abi, string>);
+  const [hash, setHash] = useState<BrandedHash<Abi, string> | null>(null);
 
   const callProver = async (
     args: ContractFunctionArgs<Abi, AbiStateMutability, string>,


### PR DESCRIPTION
empty string triggers call to json rpc. Setting it to null by default prevents hook to make call. 