### PR TITLE
Header redaction support

### DIFF
--- a/rust/web_proof/src/errors.rs
+++ b/rust/web_proof/src/errors.rs
@@ -21,4 +21,7 @@ pub enum ParsingError {
 
     #[error("IO error: {0}")]
     StdIoError(#[from] std::io::Error),
+
+    #[error("Header name contains redacted characters")]
+    HeaderNameContainsRedactedCharacters,
 }


### PR DESCRIPTION
This is a first PR that handles `Check that no header name is redacted` requirement. In the next PR I will add support for `Check that every header value is either fully redacted or not at all`