### PR TITLE
ci: pin stable rust to 1.83 matching rust-toolchain.yml

### DIFF
--- a/.github/actions/rust-prerequisites/action.yml
+++ b/.github/actions/rust-prerequisites/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Set up Rust
       uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
       with:
-        toolchain: nightly,stable
+        toolchain: nightly,1.83
         components: clippy,rustfmt
         cache: false
         target: ${{ inputs.target }}


### PR DESCRIPTION
I wanted to not have to do that since theoretically setup-rust-toolchain action reads `rust-toolchain.yml` file in the root of the repo, however I have encountered two serious issues with our setup:
1. in our self-hosted runners we install rustup in a global location that is shared between jobs leading to all sorts of delicious race conditions
2. setup-rust-toolchain does a legacy check on rustup which looks like this
    ```rustup show active-toolchain || rustup toolchain install```
    and because of 1. the first part will return whatever the current override on the directory currently is set up to

cc @rzadp