### PR TITLE
Cleanup chain worker logs

### DIFF
--- a/rust/services/chain/host/src/host.rs
+++ b/rust/services/chain/host/src/host.rs
@@ -96,10 +96,10 @@ where
 
     #[instrument(skip(self))]
     pub async fn poll_commit(&mut self) -> Result<(), HostError> {
-        let Some(chain_update) = self.poll().await? {
+        if let Some(chain_update) = self.poll().await? {
             info!("Chain update: {chain_update:?}");
             self.db.update_chain(self.chain_id, chain_update)?;
-        else {
+        } else {
             sleep(SLEEP_IF_FULLY_SYNCED).await;
         };
         Ok(())


### PR DESCRIPTION
I've noticed while running dockers that chain worker is needlessly talkative when nothing happens.
This PR adds a short-circuit and now it waits more quietly and also sleeps for 1s if it has nothing to do

Also cleaned up tests using poll_commit()
<img width="852" alt="Screenshot 2025-01-10 at 16 21 35" src="https://github.com/user-attachments/assets/52ed9ed7-d9ca-442e-bb93-2a8cceaed051" />

