### PR TITLE
bump rustc to 1.84 and temporarily disable LTO in release

### DIFF
--- a/.github/actions/rust-prerequisites/action.yml
+++ b/.github/actions/rust-prerequisites/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Set up Rust
       uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
       with:
-        toolchain: nightly,1.83
+        toolchain: nightly,1.84
         components: clippy,rustfmt
         cache: false
         target: ${{ inputs.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,8 @@ members = [
 ]
 
 [profile.release]
-debug = 1
-lto = true
+debug = "full"
+lto = false # debug + LTO leads to ICE in 1.84: https://github.com/rust-lang/rust/issues/135332
 
 [workspace.dependencies]
 alloy-chains = "0.1.42"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.83"
+channel = "1.84"
 components = ["rustfmt", "rust-src", "rust-analyzer", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
A combination of LTO + debuginfo leads to ICE. I propose we temporarily disable LTO until ICE is fixed in upstream. Without LTO enabled we lose a little bit of runtime perf and probably emit slightly larger binaries, but otherwise there is no change in functionality (panics will generate correct full-featured backtraces).