### PR TITLE
Disable setUp in vlayer test

### DIFF
--- a/book/src/advanced/tests.md
+++ b/book/src/advanced/tests.md
@@ -47,6 +47,14 @@ In general, `callProver()` **should only be used if you want to generate a proof
 
 </div>
 
+### Differences against Forge
+
+There are a few forge functionalities that are explicitly disabled in the vlayer tests:
+
+- Having `setUp()` function in the test contract. Currently, every unit test needs to set up the environment on its own. It's still possible to create a separate function and call it at the beginning of each test.
+- Watch mode
+- Forking the blockchain
+
 ### Example Usage
 
 ```solidity

--- a/contracts/vlayer/src/testing/VTest.sol
+++ b/contracts/vlayer/src/testing/VTest.sol
@@ -25,6 +25,10 @@ contract VTest is Test {
         );
     }
 
+    function setUp() internal {
+        // setUp is not allowed in VTest tests
+    }
+
     function callProver() internal {
         ICheatCodes(CHEATCODES).callProver();
     }


### PR DESCRIPTION
So the issue is that setup is called in a different call than the unit test itself, which means the state of it is comitted into the Backend and PendingStateProvider doesn't have access to it. Disabling it is a temporary solution, until we migrate to fake fake proofs

Edit: first approach was to disable it in the test runner code, but that would mean that existing forge tests wouldn't work with vlayer test, and it would be nice if they worked. I put an empty setUp into the VTest to disallow overriding it and throwing the error on compile time