### PR TITLE
fix: take chain from context

### DIFF
--- a/examples/simple_web_proof/vlayer/src/prove.ts
+++ b/examples/simple_web_proof/vlayer/src/prove.ts
@@ -1,7 +1,5 @@
 import webProofProver from "../../out/WebProofProver.sol/WebProofProver";
 
-import { foundry } from "viem/chains";
-
 import {
   createVlayerClient,
   type PresentationJSON,
@@ -57,7 +55,7 @@ export const setupProveWebButton = (element: HTMLButtonElement) => {
     const hash = await vlayer.proveWeb({
       address: import.meta.env.VITE_PROVER_ADDRESS,
       proverAbi: webProofProver.abi,
-      chainId: foundry.id,
+      chainId: chain.id,
       functionName: "main",
       token: import.meta.env.VITE_VLAYER_API_TOKEN,
       args: [webProofRequest, twitterUserAddress],


### PR DESCRIPTION
This pull request fixes [regression  from 4 weeks ago](https://github.com/vlayer-xyz/vlayer/pull/1332/files#diff-295b5467b78845222abd2a8faedb3084d5405dbc5aeb986c9be6385a24dad6f1L84). 

Foundry mistakenly used instead of chain specified with ENV. 

(proving on vercel still not working, but doe L1Beat error that team is aware of)