### PR TITLE
Rework examples

### DIFF
--- a/bash/e2e-test.sh
+++ b/bash/e2e-test.sh
@@ -5,6 +5,7 @@ set -ueo pipefail
 # Imports
 VLAYER_HOME=$(git rev-parse --show-toplevel)
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/lib/examples.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/e2e/lib.sh"
 
 # Defaults
@@ -15,13 +16,12 @@ generate_ts_bindings
 build_sdk
 
 echo "::group::Running examples"
-for example in $(find ${VLAYER_HOME}/examples -type d -maxdepth 1 -mindepth 1) ; do
-  export EXAMPLE_NAME=$(basename "${example}")
-    
+for example in $(get_examples); do
+  export EXAMPLE_NAME=$example
   echo Running services...
   source ${VLAYER_HOME}/bash/run-services.sh
 
-  pushd "${example}"
+  pushd "$VLAYER_HOME/examples/$example"
   echo "::group::Running tests of: ${example}"
   silent_unless_fails build_contracts
   run_prover_script

--- a/bash/e2e-web-apps-test.sh
+++ b/bash/e2e-web-apps-test.sh
@@ -3,6 +3,7 @@
 set -ueo pipefail
 
 VLAYER_HOME=$(git rev-parse --show-toplevel)
+source "$(dirname "${BASH_SOURCE[0]}")/lib/examples.sh"
 
 PROVING_MODE=${PROVING_MODE:-dev}
 
@@ -12,14 +13,12 @@ ${VLAYER_HOME}/bash/build-ts-types.sh >/dev/null
 echo Running services...
 source ${VLAYER_HOME}/bash/run-services.sh
 
-for example in $(find ${VLAYER_HOME}/examples -type d -maxdepth 1 -mindepth 1) ; do
-  example_name=$(basename "${example}")
-
+for example in $(get_examples); do
   echo "make snapshot of anvil"
   ANVIL_SNAPSHOT_ID=$(cast rpc evm_snapshot)
 
   echo "::group::Running tests of: ${example}"
-  cd "${example}"
+  cd "$VLAYER_HOME/examples/$example"
   forge soldeer install
   forge clean
   forge build

--- a/bash/lib/examples.sh
+++ b/bash/lib/examples.sh
@@ -1,0 +1,20 @@
+# You can set the $EXAMPLE variable to run a single example
+function get_examples() {
+    local EXAMPLE_LIST=(
+        "simple"
+        "simple_email_proof"
+        "simple_web_proof"
+        "simple_time_travel"
+        "simple_teleport"
+    )
+
+    if [[ -n ${EXAMPLE:-} ]]; then
+        if ! [[ " ${EXAMPLE_LIST[*]} " == *" $EXAMPLE "* ]]; then
+            echo "Error: Invalid EXAMPLE_NAME '$EXAMPLE'. Valid options are: ${EXAMPLE_LIST[*]}" >&2
+            exit 1
+        fi
+        echo $EXAMPLE
+    else
+        echo "${EXAMPLE_LIST[@]}"
+    fi
+}

--- a/bash/lint-fix.sh
+++ b/bash/lint-fix.sh
@@ -3,10 +3,11 @@
 set -ueo pipefail
 
 VLAYER_HOME=$(git rev-parse --show-toplevel)
+source "$(dirname "${BASH_SOURCE[0]}")/lib/examples.sh"
 
-for example in $(find ${VLAYER_HOME}/examples -type d -maxdepth 1 -mindepth 1) ; do
+for example in $(get_examples); do
   (
-    cd "${example}/vlayer"
+    cd "$VLAYER_HOME/examples/$example"
 
     bun install --frozen-lockfile --no-save --silent
     bun run --silent eslint . --fix

--- a/bash/lint-solidity-examples.sh
+++ b/bash/lint-solidity-examples.sh
@@ -3,15 +3,13 @@
 set -ueo pipefail
 
 VLAYER_HOME=$(git rev-parse --show-toplevel)
+source "$(dirname "${BASH_SOURCE[0]}")/lib/examples.sh"
 
-for example in $(find ${VLAYER_HOME}/examples -type d -maxdepth 1 -mindepth 1) ; do
-
-  (
+for example in $(get_examples); do (
     echo "Running solhint of: ${example}"
-    cd "${example}/vlayer"
+    cd "$VLAYER_HOME/examples/$example"
 
     bun install --frozen-lockfile
     bun run lint:solidity
-  )
-done
+) done
  

--- a/bash/lint-ts.sh
+++ b/bash/lint-ts.sh
@@ -3,18 +3,16 @@
 set -ueo pipefail
 
 VLAYER_HOME=$(git rev-parse --show-toplevel)
+source "$(dirname "${BASH_SOURCE[0]}")/lib/examples.sh"
 
-for example in $(find ${VLAYER_HOME}/examples -type d -maxdepth 1 -mindepth 1) ; do
-
-  (
+for example in $(get_examples); do (
     echo "Running eslint for: ${example}"
-    cd "${example}/vlayer"
+    cd "$VLAYER_HOME/examples/$example"
 
     bun install --frozen-lockfile
     bun run eslint .
 
-  )
-done
+) done
 
 
 echo "::group::Running eslint for: $VLAYER_HOME/packages"

--- a/bash/pack-examples.sh
+++ b/bash/pack-examples.sh
@@ -3,6 +3,7 @@
 set -uexo pipefail
 
 VLAYER_HOME=$(git rev-parse --show-toplevel)
+source "$(dirname "${BASH_SOURCE[0]}")/lib/examples.sh"
 
 output_dir="${VLAYER_HOME}/out"
 ARCHIVE="${output_dir}/examples.tar"
@@ -18,13 +19,14 @@ touch "${ARCHIVE}"
 (
     cd "${VLAYER_HOME}/examples"
 
-    for example in $(find . -type d -maxdepth 1 -mindepth 1) ; do
+    for example in $(get_examples); do
         echo "::group::Packing example: ${example}"
 
-        scripts="${example}/vlayer"
-        contracts="${example}/src/vlayer"
-        contracts_tests="${example}/test/vlayer"
-        testdata="${example}/testdata"
+        example_path="$VLAYER_HOME/examples/$example"
+        scripts="${example_path}/vlayer"
+        contracts="${example_path}/src/vlayer"
+        contracts_tests="${example_path}/test/vlayer"
+        testdata="${example_path}/testdata"
 
         cp "${VLAYER_HOME}/docker/docker-compose.devnet.yaml" "${scripts}/"
 

--- a/bash/test-release-local-prover.sh
+++ b/bash/test-release-local-prover.sh
@@ -27,19 +27,18 @@ git config --global user.email "test@example.com"
 git config --global user.name "Github Runner"
 
 VLAYER_HOME=$(git rev-parse --show-toplevel)
+source "$(dirname "${BASH_SOURCE[0]}")/lib/examples.sh"
 
-for example in $(find ${VLAYER_HOME}/examples -type d -maxdepth 1 -mindepth 1) ; do
-    example_name=$(basename "${example}"  | tr '_' '-')
-
+for example in $(get_examples); do
     # We're restarting anvils because some examples rely on a clean chain state.
     echo "Restarting anvils"
     docker compose -f ${VLAYER_HOME}/docker/docker-compose.devnet.yaml restart anvil-l1 anvil-l2-op
 
-    echo "::group::Initializing vlayer template: ${example_name}"
+    echo "::group::Initializing vlayer template: ${example}"
     VLAYER_TEMP_DIR=$(mktemp -d -t vlayer-test-release-XXXXXX-)
     cd ${VLAYER_TEMP_DIR}
 
-    vlayer init --template "${example_name}"
+    vlayer init --template "${example}"
     forge build
     vlayer test
 
@@ -50,7 +49,7 @@ for example in $(find ${VLAYER_HOME}/examples -type d -maxdepth 1 -mindepth 1) ;
     bun install --no-cache
     echo '::endgroup::'
 
-    echo "::group::vlayer run prove.ts: ${example_name}"
+    echo "::group::vlayer run prove.ts: ${example}"
     bun run prove:dev
     echo '::endgroup::'
 done

--- a/bash/test-release-remote-prover.sh
+++ b/bash/test-release-remote-prover.sh
@@ -33,15 +33,15 @@ git config --global user.email "test@example.com"
 git config --global user.name "Github Runner"
 
 VLAYER_HOME=$(git rev-parse --show-toplevel)
+source "$(dirname "${BASH_SOURCE[0]}")/lib/examples.sh"
 
-for example in $(find ${VLAYER_HOME}/examples -type d -maxdepth 1 -mindepth 1) ; do
-    example_name=$(basename "${example}"  | tr '_' '-')
+for example in $(get_examples); do
 
-    echo "::group::Initializing vlayer template: ${example_name}"
+    echo "::group::Initializing vlayer template: ${example}"
     VLAYER_TEMP_DIR=$(mktemp -d -t vlayer-test-release-XXXXXX-)
     cd ${VLAYER_TEMP_DIR}
 
-    vlayer init --template "${example_name}"
+    vlayer init --template "${example}"
     forge build
     vlayer test
 
@@ -52,7 +52,7 @@ for example in $(find ${VLAYER_HOME}/examples -type d -maxdepth 1 -mindepth 1) ;
     bun install --no-cache
     echo '::endgroup::'
 
-    echo "::group::vlayer run prove.ts: ${example_name}"
+    echo "::group::vlayer run prove.ts: ${example}"
     bun run prove:testnet
     echo '::endgroup::'
 done

--- a/bash/tsc-examples.sh
+++ b/bash/tsc-examples.sh
@@ -3,6 +3,7 @@
 set -ueo pipefail
 
 VLAYER_HOME=$(git rev-parse --show-toplevel)
+source "$(dirname "${BASH_SOURCE[0]}")/lib/examples.sh"
 
 echo "::group::Installing npm dependencies"
 cd "${VLAYER_HOME}"
@@ -14,13 +15,11 @@ cd "${VLAYER_HOME}/packages/sdk"
 bun run build
 echo '::endgroup::'
 
-for example in $(find ${VLAYER_HOME}/examples -type d -maxdepth 1 -mindepth 1) ; do
-  example_name=$(basename "${example}")
-
-  example="${VLAYER_HOME}/examples/${example_name}"
-
+for example in $(get_examples); do
   echo ""::group::Running tsc for: ${example}""
-  cd "${example}"
+  example_path="${VLAYER_HOME}/examples/${example}"
+  
+  cd $example_path
 
   forge soldeer install
   forge build
@@ -28,7 +27,7 @@ for example in $(find ${VLAYER_HOME}/examples -type d -maxdepth 1 -mindepth 1) ;
   echo Generating typescript bidings ...
   ${VLAYER_HOME}/bash/build-ts-types.sh >/dev/null
 
-  cd ${example}/vlayer
+  cd "${example_path}/vlayer"
 
   bun install --frozen-lockfile
   bun tsc --noEmit

--- a/bash/vlayer-test-examples.sh
+++ b/bash/vlayer-test-examples.sh
@@ -3,10 +3,11 @@
 set -ueo pipefail
 
 VLAYER_HOME=$(git rev-parse --show-toplevel)
+source "$(dirname "${BASH_SOURCE[0]}")/lib/examples.sh"
 
-for example in $(find ${VLAYER_HOME}/examples -type d -maxdepth 1 -mindepth 1) ; do
+for example in $(get_examples); do
   echo "::group::Running vlayer test in: ${example}"
-  cd "${example}"
+  cd "${VLAYER_HOME}/examples/${example}"
   forge soldeer install
   forge clean
   forge build


### PR DESCRIPTION
This PR solves two issues:
* Examples now execute in stable order
* It's easy to run a single example

No more:
```sh
for example in $(find ${VLAYER_HOME}/examples -type d -maxdepth 1 -mindepth 1) ; do
    example_name=$(basename "${example}"  | tr '_' '-')
```
Say welcome to:
```sh
for example in $(get_examples); do
```

Try it for yourself with:
```sh
EXAMPLE=simple \
PROVING_MODE=dev \
CHAIN_ID=31337 \
VLAYER_ENV=dev \
RUN_CHAIN_SERVICES=1 \
BUILD_BINARIES=0 \
./bash/e2e-test.sh
```