### PR TITLE
Downgrade remote prover to risc0 1.2.0

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,2 +1,2 @@
 ---
-vlayer_risc0_version: '1.2.1-rc.1'
+vlayer_risc0_version: '1.2.0'


### PR DESCRIPTION
Follow-up to https://github.com/vlayer-xyz/vlayer/pull/1538