### PR TITLE
Add vlayer to path to lint fix in examples

### DIFF
--- a/bash/lint-fix.sh
+++ b/bash/lint-fix.sh
@@ -7,7 +7,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib/examples.sh"
 
 for example in $(get_examples); do
   (
-    cd "$VLAYER_HOME/examples/$example"
+    cd "$VLAYER_HOME/examples/$example/vlayer"
 
     bun install --frozen-lockfile --no-save --silent
     bun run --silent eslint . --fix


### PR DESCRIPTION
`vlayer` was omitted here: https://github.com/vlayer-xyz/vlayer/commit/4fe5e9fc3af8bdea06cee2458bcd7e7beebbd602#diff-f95e6b97747ccba0f6a3c46751a97ff0d507418d81903f537d6355334d511d3d I think by mistake. It doesn't work without it.