### PR TITLE
Add missing 'conditions'

### DIFF
--- a/examples/simple-email-proof/vlayer/package.json
+++ b/examples/simple-email-proof/vlayer/package.json
@@ -5,13 +5,13 @@
   "scripts": {
     "devnet": "docker compose --file docker-compose.devnet.yaml up -d",
     "lint:solidity": "solhint '../src/**/*.sol'",
-    "deploy:dev": "VLAYER_ENV=dev bun run deploy.ts",
+    "deploy:dev": "VLAYER_ENV=dev bun run --conditions=development deploy.ts",
     "deploy:testnet": "VLAYER_ENV=testnet bun run deploy.ts",
-    "prove:dev": "VLAYER_ENV=dev bun run prove.ts",
+    "prove:dev": "VLAYER_ENV=dev bun run --conditions=development prove.ts",
     "prove:testnet": "VLAYER_ENV=testnet bun run prove.ts",
-    "web:dev": "VLAYER_ENV=dev bun run --conditions development deploy.ts && vite",
+    "web:dev": "VLAYER_ENV=dev bun run --conditions=development deploy.ts && vite",
     "web:testnet": "VLAYER_ENV=testnet bun run deploy.ts && vite",
-    "test:dev": "VLAYER_ENV=dev bun run playwright test",
+    "test:dev": "VLAYER_ENV=dev bun run --conditions=development playwright test",
     "test:testnet": "echo \"No tests specified yet\""
   },
   "dependencies": {

--- a/examples/simple-web-proof/vlayer/package.json
+++ b/examples/simple-web-proof/vlayer/package.json
@@ -10,12 +10,12 @@
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",
     "prove:testnet": "VLAYER_ENV=testnet bun run prove.ts",
-    "prove:dev": "VLAYER_ENV=dev bun run prove.ts",
+    "prove:dev": "VLAYER_ENV=dev bun run --conditions=development prove.ts",
     "deploy:testnet": "VLAYER_ENV=testnet bun run deploy.ts",
-    "deploy:dev": "VLAYER_ENV=dev bun run deploy.ts",
-    "test:dev": "VLAYER_ENV=dev bun run playwright test",
+    "deploy:dev": "VLAYER_ENV=dev bun run --conditions=development deploy.ts",
+    "test:dev": "VLAYER_ENV=dev bun run --conditions=development  playwright test",
     "test:testnet": "VLAYER_ENV=testnet bun run playwright test",
-    "web:dev": "VLAYER_ENV=dev bun run deploy.ts && vite",
+    "web:dev": "VLAYER_ENV=dev bun run --conditions=development deploy.ts && vite",
     "web:testnet": "VLAYER_ENV=testnet bun run deploy.ts && vite"
   },
   "dependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -62,6 +62,7 @@
   },
   "files": [
     "dist/",
+    "src/",
     "package.json",
     "README.md"
   ]


### PR DESCRIPTION
I will place a word of explanation here at it was not, but should be, added to the previous related commit. 
How it works. So lets take a look at the command 

```    "web:dev": "VLAYER_ENV=dev bun run --conditions=development deploy.ts && vite",```  

this makes sure that when it comes to resolve import from sdk ( or any other package) then the condition `development` will be used and that way we can import directly from source. But, there are two commands connected with `&&` second is vite. When we call `vite (without specifing mode like in `vite --mode staging`) it sets `conditions` to be development by default (surprise!). To have everything consistent consequence is that we have (at least for now) include /src in published npm package. In ideal world with some prebpublish step we could avpoid that by changing package.json before publish. This day will come... one day. 