### PR TITLE
Drop support for unsupported testnets

### DIFF
--- a/contracts/vlayer/src/proof_verifier/ChainId.sol
+++ b/contracts/vlayer/src/proof_verifier/ChainId.sol
@@ -12,10 +12,7 @@ library ChainIdLibrary {
     function isTestnet() internal view returns (bool) {
         return block.chainid == 11155111 // Ethereum Sepolia
             || block.chainid == 11155420 // Optimism Sepolia
-            || block.chainid == 84532 // Base Sepolia
-            || block.chainid == 80002 // Polygon Amoy
-            || block.chainid == 421614 // Arbitrum Sepolia
-            || block.chainid == 300; // zkSync Sepolia
+            || block.chainid == 84532; // Base Sepolia
     }
 
     function isMainnet() internal view returns (bool) {


### PR DESCRIPTION
As per DoR requirements of https://www.notion.so/vlayer/Stable-Sepolia-Verifier-135fdaece2678046bb06c5799563ae8a?pvs=4, I'm dropping support for testnets on which we do not have officially deployed verifiers.