### PR TITLE
Pack entire docker-compose to example.

### DIFF
--- a/bash/pack-examples.sh
+++ b/bash/pack-examples.sh
@@ -28,6 +28,9 @@ touch "${ARCHIVE}"
         testdata="${example}/testdata"
 
         cp "${VLAYER_HOME}/docker/docker-compose.devnet.yaml" "${scripts}/"
+        cp "${VLAYER_HOME}/docker/anvil.yaml" "${scripts}/"
+        cp "${VLAYER_HOME}/docker/vdns.yaml" "${scripts}/"
+        cp "${VLAYER_HOME}/docker/web.yaml" "${scripts}/"
 
         tar --append --file=$ARCHIVE --strip 1 --exclude-from "${VLAYER_HOME}/examples/.gitignore" --dereference "${contracts}"
         tar --append --file=$ARCHIVE --strip 1 --exclude-from "${VLAYER_HOME}/examples/.gitignore" --dereference "${scripts}"


### PR DESCRIPTION
`bun run devnet` in examples currently fails due to the fact that some files are missing - this PR adds them to the example. This is a tmp solution. Long term, IMO, we need each example to contain it's own docker compose file.