### PR TITLE
e2e-testnet: upload logs instead of displaying them

### DIFF
--- a/.github/workflows/test_e2e_testnet.yaml
+++ b/.github/workflows/test_e2e_testnet.yaml
@@ -75,11 +75,11 @@ jobs:
         run: bash/e2e-test.sh
 
       # Teardown
-      - name: Display Logs
+      - name: Upload logs for previewing
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         if: always()
-        run: |
-          for log_file in $(find ./artifacts/logs -type f); do
-            echo "=== Contents of $log_file ==="
-            cat "$log_file"
-            echo "============================="
-          done
+        with:
+          name: logs
+          path: ./artifacts/logs/
+          if-no-files-found: error
+          retention-days: 1


### PR DESCRIPTION
E2E testnet step takes 17m instead of 40m.