### PR TITLE
Add concurrency group to workflows using same private key

### DIFF
--- a/.github/workflows/test_e2e_testnet.yaml
+++ b/.github/workflows/test_e2e_testnet.yaml
@@ -19,7 +19,7 @@ on:
       - ".github/workflows/test_e2e_testnet.yaml"
   workflow_dispatch:
 concurrency:
-# Same group for all jobs using EXAMPLES_TEST_PRIVATE_KEY key.
+  # Same group for all jobs using EXAMPLES_TEST_PRIVATE_KEY key.
   group: e2e-testnet
   cancel-in-progress: false
 

--- a/.github/workflows/test_e2e_web_apps_testnet.yaml
+++ b/.github/workflows/test_e2e_web_apps_testnet.yaml
@@ -16,7 +16,7 @@ on:
       - ".github/workflows/test_e2e_web_apps_testnet.yaml"
   workflow_dispatch:
 concurrency:
-# Same group for all jobs using WEB_APPS_TEST_PRIVATE_KEY key.
+  # Same group for all jobs using WEB_APPS_TEST_PRIVATE_KEY key.
   group: web-apps-testnet-e2e
   cancel-in-progress: false
 


### PR DESCRIPTION
Follow-up to https://github.com/vlayer-xyz/vlayer/pull/1620 cc @wgromniak2 

There was a workflow introduced, which:
- reused same private key as existing workflow (so caused nonce issues if the workflows run at the same time)
- Run on PRs (so caused nonce issues if PRs ran at the same time)

Adding one concurrency as a quick fix, and will be work on a different solution (allowing concurrent runs) next.