### PR TITLE
sdk: increase timeout to 15minutes when fetching proof receipt

### DIFF
--- a/book/src/javascript/javascript.md
+++ b/book/src/javascript/javascript.md
@@ -83,7 +83,7 @@ Wait for the proving to be finished, and then retrieve the result along with Pro
 const result = await vlayer.waitForProvingResult({ hash });
 ```
 
-By default, the `waitForProvingResult` function polls the server for a proof for 2 minutes. This is achieved through 120 retries with a polling interval of 1 second.
+By default, the `waitForProvingResult` function polls the server for a proof for 15 minutes. This is achieved through 900 retries with a polling interval of 1 second.
 You can customize this behavior by specifying the following optional parameters:
 - `numberOfRetries`: The total number of polling attempts.
 - `sleepDuration`: The delay (in ms) between each polling attempt.

--- a/examples/simple-web-proof/vlayer/prove.ts
+++ b/examples/simple-web-proof/vlayer/prove.ts
@@ -51,11 +51,7 @@ async function testSuccessProvingAndVerification() {
     chainId: chain.id,
     token: config.token,
   });
-  const result = await vlayer.waitForProvingResult({
-    hash,
-    numberOfRetries: 900,
-    sleepDuration: 1000,
-  });
+  const result = await vlayer.waitForProvingResult({ hash });
   const [proof, twitterHandle, address] = result;
   console.log("Has Proof");
 

--- a/packages/sdk/src/api/lib/client.ts
+++ b/packages/sdk/src/api/lib/client.ts
@@ -74,7 +74,7 @@ export const createVlayerClient = (
       F extends ContractFunctionName<T>,
     >({
       hash,
-      numberOfRetries = 240,
+      numberOfRetries = 900,
       sleepDuration = 1000,
     }: {
       hash: BrandedHash<T, F>;

--- a/packages/sdk/src/api/prover.ts
+++ b/packages/sdk/src/api/prover.ts
@@ -100,7 +100,7 @@ export async function waitForProof<
 >(
   hash: BrandedHash<T, F>,
   url: string,
-  numberOfRetries: number = 240,
+  numberOfRetries: number = 900,
   sleepDuration: number = 1000,
 ): Promise<ProofDataWithMetrics> {
   for (let retry = 0; retry < numberOfRetries; retry++) {


### PR DESCRIPTION
~~Currently, increased the timeout for simple-web-proof example only, however, if we want to do that for all examples it might be a good time to introduce some config file, or add some env vars to `getConfig.ts`.~~ It feels more logical to increase the default timeout to 15mins in the SDK so that's what this PR accomplishes.