### PR TITLE
Run E2E against testnet on each PR

### DIFF
--- a/.github/workflows/test_e2e_testnet.yaml
+++ b/.github/workflows/test_e2e_testnet.yaml
@@ -47,6 +47,9 @@ jobs:
         working-directory: ./contracts/vlayer
         run: forge soldeer install
 
+      # Stateful GH Runners have a separate testnet private key on disk,
+      # to allow concurrent runs of the workflow avoiding nonce issues.
+      # Here we load the key into a variable from a location on disk.
       - name: Read testnet private key
         run: |
           EXAMPLES_TEST_PRIVATE_KEY=$(cat ${{ secrets.TESTNET_PRIVATE_KEY_LOCATION }})


### PR DESCRIPTION
Having one testnet key per runner, we can concurrently run this workflow on each PR.