### PR TITLE
Add ansible installation in chain services deployment workflow

### DIFF
--- a/.github/workflows/deploy_chain_services.yaml
+++ b/.github/workflows/deploy_chain_services.yaml
@@ -23,6 +23,10 @@ jobs:
         uses: ./.github/actions/rust-prerequisites
       - name: Install contracts prerequisites
         uses: ./.github/actions/contracts-prerequisites
+      - name: Install Ansible
+        uses: alex-oleshkevich/setup-ansible@b77f1a5e01dbcf520c28b545fa37c8f022c1803a
+        with:
+          version: "11.2.0"
 
       # Needed until we have those binaries released.
       - name: Build chain service binaries


### PR DESCRIPTION
We don't have it on other workflows, because ansible comes preloaded on `ubuntu-latest`.