### PR TITLE
precompiles: fix import scoping within generate_precompiles macro

### DIFF
--- a/rust/services/call/precompiles/src/helpers.rs
+++ b/rust/services/call/precompiles/src/helpers.rs
@@ -39,10 +39,12 @@ macro_rules! generate_precompiles {
     };
     (($address:literal, $func:ident, $base_cost:literal, $byte_cost:literal)) => {{
         use alloy_primitives::Bytes;
-        use helpers::gas_used;
         use revm::precompile::{
             u64_to_address, Precompile, PrecompileOutput, PrecompileResult, PrecompileWithAddress,
         };
+
+        use crate::helpers::gas_used;
+
         fn run(input: &Bytes, gas_limit: u64) -> PrecompileResult {
             let gas_used = gas_used(input.len(), gas_limit, $base_cost, $byte_cost)?;
             let bytes = $func(input)?;
@@ -51,3 +53,5 @@ macro_rules! generate_precompiles {
         PrecompileWithAddress(u64_to_address($address), Precompile::Standard(run))
     }};
 }
+
+pub(super) use generate_precompiles;

--- a/rust/services/call/precompiles/src/lib.rs
+++ b/rust/services/call/precompiles/src/lib.rs
@@ -1,12 +1,12 @@
-#[macro_use]
-mod helpers;
 pub mod email_proof;
+mod helpers;
 mod json;
 mod regex;
 pub mod url_pattern;
 mod web_proof;
 
 use email_proof::verify as email_proof;
+use helpers::generate_precompiles;
 use json::{
     get_array_length as json_get_array_length, get_bool as json_get_bool, get_int as json_get_int,
     get_string as json_get_string,


### PR DESCRIPTION
Use new method (since Rust 1.32) for exporting the macro (in this case, within the crate only).