### PR TITLE
Restore ansible lint workflow

### DIFF
--- a/.github/workflows/lint_ansible.yaml
+++ b/.github/workflows/lint_ansible.yaml
@@ -19,6 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@v24.9.2
+        uses: ansible/ansible-lint@v25.1.2
         with:
           working_directory: "ansible"

--- a/ansible/.ansible-lint
+++ b/ansible/.ansible-lint
@@ -1,0 +1,3 @@
+---
+exclude_paths:
+  - .ansible


### PR DESCRIPTION
It was scanning dependencies, still not clear why it started happening.