### PR TITLE
Specify `RISC0_DEV_MODE` for chain workers

### DIFF
--- a/ansible/chain_service.yml
+++ b/ansible/chain_service.yml
@@ -55,4 +55,5 @@
         chain_worker_max_back_propagation_blocks: "{{ item.chain_worker_max_back_propagation_blocks }}"
         chain_worker_max_head_blocks: "{{ item.chain_worker_max_head_blocks }}"
         chain_worker_confirmations: "{{ item.chain_worker_confirmations }}"
+        chain_worker_risc0_dev_mode: "{{ item.chain_worker_risc0_dev_mode }}"
       loop: "{{ chain_workers }}"

--- a/ansible/host_vars/prod_fake_chain_service.yml
+++ b/ansible/host_vars/prod_fake_chain_service.yml
@@ -18,6 +18,7 @@ chain_workers:
     chain_worker_max_back_propagation_blocks: 10
     chain_worker_max_head_blocks: 10
     chain_worker_confirmations: 8
+    chain_worker_risc0_dev_mode: 1
   - chain_worker_identifier: base-sepolia
     chain_worker_rpc_url: https://omniscient-flashy-frog.base-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}
     chain_worker_chain_id: 84532
@@ -25,6 +26,7 @@ chain_workers:
     chain_worker_max_back_propagation_blocks: 10
     chain_worker_max_head_blocks: 10
     chain_worker_confirmations: 8
+    chain_worker_risc0_dev_mode: 1
   - chain_worker_identifier: optimism-sepolia
     chain_worker_rpc_url: https://omniscient-flashy-frog.optimism-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}
     chain_worker_chain_id: 11155420
@@ -32,3 +34,4 @@ chain_workers:
     chain_worker_max_back_propagation_blocks: 10
     chain_worker_max_head_blocks: 10
     chain_worker_confirmations: 8
+    chain_worker_risc0_dev_mode: 1

--- a/ansible/roles/chain_worker/README.md
+++ b/ansible/roles/chain_worker/README.md
@@ -17,3 +17,4 @@ Typically, more than 1 chain worker would be installed on a single machine.
 | `chain_worker_max_back_propagation_blocks` | Maximum number of historical blocks prepended in a single batch |
 | `chain_worker_max_head_blocks` | Maximum number of new blocks appended in a single batch |
 | `chain_worker_confirmations` | Minimum number of confirmations required for a block to be appended |
+| `chain_worker_risc0_dev_mode` | Whether to enable [risc0 dev mode](https://dev.risczero.com/api/generating-proofs/dev-mode) |

--- a/ansible/roles/chain_worker/templates/vlayer-chain-worker.service.j2
+++ b/ansible/roles/chain_worker/templates/vlayer-chain-worker.service.j2
@@ -24,6 +24,7 @@ Environment=PROOF_MODE={{ chain_worker_proof_mode }}
 Environment=MAX_BACK_PROPAGATION_BLOCKS={{ chain_worker_max_back_propagation_blocks }}
 Environment=MAX_HEAD_BLOCKS={{ chain_worker_max_head_blocks }}
 Environment=CONFIRMATIONS={{ chain_worker_confirmations }}
+Environment=RISC0_DEV_MODE={{ chain_worker_risc0_dev_mode }}
 ExecStart=/opt/vlayer/chain_worker
 
 [Install]


### PR DESCRIPTION
We had `--proof fake`, but this variable also needs to be set.

Discovered because of `ZK verification error: verification indicates proof is invalid` error after a worker restart.