### PR TITLE
Add codeowners for audited files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -73,7 +73,7 @@ rust/mpt/src/node/constructors.rs @marekkirejczyk
 rust/mpt/src/node/insert/entry.rs @marekkirejczyk
 rust/mpt/src/node/insert/from_two_entries.rs @marekkirejczyk
 rust/mpt/src/node/insert/insert_entry_into_branch.rs @marekkirejczyk
-rust/mpt/src/node/insert/insert_entry_into_extension/ @marekkirejczykfrom_extension_and_entry_empty_common_prefix.rs @marekkirejczyk
+rust/mpt/src/node/insert/insert_entry_into_extension/from_extension_and_entry_empty_common_prefix.rs @marekkirejczyk
 rust/mpt/src/node/insert/insert_entry_into_extension.rs @marekkirejczyk
 rust/mpt/src/node/insert/utils.rs @marekkirejczyk
 rust/mpt/src/node/insert.rs @marekkirejczyk


### PR DESCRIPTION
This is a list of all 177 files (and only those files) that went into the scope of the audit on 07 Feb 2025, from [this commit](https://github.com/vlayer-xyz/vlayer/commit/a76361451c47dbef25db03f61d2b0e26e0c5d940).