### PR TITLE
Add repository constraint for cron-based workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,9 +8,11 @@ concurrency:
   cancel-in-progress: false
 jobs:
   build-release:
+    if: github.repository == 'vlayer-xyz/vlayer'
     uses: ./.github/workflows/build_rust_release.yaml
 
   build-examples:
+    if: github.repository == 'vlayer-xyz/vlayer'
     name: Build examples
     runs-on: ubuntu-latest
     steps:
@@ -29,6 +31,7 @@ jobs:
           retention-days: 3
 
   build-extension:
+    if: github.repository == 'vlayer-xyz/vlayer'
     name: Build browser extension
     needs: [build-release]
     runs-on: ubuntu-latest
@@ -41,6 +44,7 @@ jobs:
           version_name: ${{ needs.build-release.outputs.vlayer_build }}
 
   push-contracts:
+    if: github.repository == 'vlayer-xyz/vlayer'
     name: Push vlayer contracts
     needs: [build-release]
     runs-on: ubuntu-latest
@@ -104,6 +108,7 @@ jobs:
           retention-days: 3
 
   create-release:
+    if: github.repository == 'vlayer-xyz/vlayer'
     name: Create GH releases
     runs-on: ubuntu-latest
     needs: [build-examples, build-extension, push-contracts]
@@ -134,6 +139,7 @@ jobs:
           artifacts: "./dist/*"
 
   push-artifacts-to-s3:
+    if: github.repository == 'vlayer-xyz/vlayer'
     name: Push artifacts to AWS S3
     runs-on: ubuntu-latest
     needs: [build-release, build-examples, build-extension, push-contracts]
@@ -192,6 +198,7 @@ jobs:
           REMOTE_FILE: ""
 
   publish-sdk-to-npm:
+    if: github.repository == 'vlayer-xyz/vlayer'
     name: Publish SDK to NPM
     needs: [build-release, build-examples, build-extension, push-contracts]
     runs-on: ubuntu-latest
@@ -222,6 +229,7 @@ jobs:
           npm publish --access public ${PACKAGE_NAME}
 
   publish-react-hooks-to-npm:
+    if: github.repository == 'vlayer-xyz/vlayer'
     name: Publish React hooks to NPM
     needs: [build-release, publish-sdk-to-npm]
     runs-on: ubuntu-latest
@@ -253,6 +261,7 @@ jobs:
           npm publish --access public ${PACKAGE_NAME}
 
   push-docker-image:
+    if: github.repository == 'vlayer-xyz/vlayer'
     name: Push docker image to github registry
     needs: [build-release, push-artifacts-to-s3]
     runs-on: ubuntu-latest


### PR DESCRIPTION
When someone makes a fork, they will have a daily cron-based job failing and sending emails to him, annoying him

I'm adding an additional constraint for those jobs.
Added an `if` to all jobs in here just for safety, if `needs:` is removed for example.