### PR TITLE
Ansible: Run local `.ssh` modifications in sequence

### DIFF
--- a/ansible/.ansible-lint-ignore
+++ b/ansible/.ansible-lint-ignore
@@ -1,3 +1,0 @@
-# Because we're always installing a latest nightly version of vlayer.
-roles/prover/tasks/main.yml no-changed-when
-roles/verifiable_dns/tasks/main.yml no-changed-when

--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,0 +1,1 @@
+.ansible

--- a/ansible/chain_service.yml
+++ b/ansible/chain_service.yml
@@ -9,7 +9,7 @@
   pre_tasks:
     - name: Ensure .ssh exists
       delegate_to: 127.0.0.1
-      run_once: true
+      run_once: true # noqa: run-once[task]
       ansible.builtin.file:
         path: ~/.ssh
         state: directory

--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -6,7 +6,7 @@
   pre_tasks:
     - name: Ensure .ssh exists
       delegate_to: 127.0.0.1
-      run_once: true
+      run_once: true # noqa: run-once[task]
       ansible.builtin.file:
         path: ~/.ssh
         state: directory

--- a/ansible/prover.yml
+++ b/ansible/prover.yml
@@ -9,7 +9,7 @@
   pre_tasks:
     - name: Ensure .ssh exists
       delegate_to: 127.0.0.1
-      run_once: true
+      run_once: true # noqa: run-once[task]
       ansible.builtin.file:
         path: ~/.ssh
         state: directory

--- a/ansible/roles/prover/tasks/main.yml
+++ b/ansible/roles/prover/tasks/main.yml
@@ -15,7 +15,7 @@
   ansible.builtin.import_tasks: logs.yml
 
 # We're installing a most-recent nightly version every time.
-- name: Install vlayer
+- name: Install vlayer # noqa: no-changed-when
   ansible.builtin.shell: |
     export PATH="$PATH:~/.foundry/bin"
     ~/.vlayer/bin/vlayerup

--- a/ansible/roles/verifiable_dns/tasks/main.yml
+++ b/ansible/roles/verifiable_dns/tasks/main.yml
@@ -14,7 +14,7 @@
   ansible.builtin.import_tasks: logs.yml
 
 # We're installing a most-recent nightly version every time.
-- name: Install dns service binary
+- name: Install dns service binary # noqa: no-changed-when
   ansible.builtin.shell: |
     export PATH="$PATH:~/.foundry/bin"
     ~/.vlayer/bin/vlayerup

--- a/ansible/verifiable_dns_service.yml
+++ b/ansible/verifiable_dns_service.yml
@@ -9,7 +9,7 @@
   pre_tasks:
     - name: Ensure .ssh exists
       delegate_to: 127.0.0.1
-      run_once: true
+      run_once: true # noqa: run-once[task]
       ansible.builtin.file:
         path: ~/.ssh
         state: directory


### PR DESCRIPTION
What's going on:

The Ansible deployment playbooks run on `ubuntu-latest`, so they have no history of `~/.ssh/known_hosts`.
The playbooks begin with adding, well, known hosts to this file.
It is possible to skip host verification, but since we know the hosts' public ssh keys ahead of time, we can check them.

So, the playbooks populate the `~/.ssh/known_hosts` file. I suspect that there is a problem when we try to add entries for 2 provers at the same time - likely one overwrites the other.

Similarly, there is no need to ensure `~/.ssh` exists locally N times for each target, so I'm adding `run_once`.