### PR TITLE
fix(audit): check cheatcode unchecked-return

### DIFF
--- a/contracts/vlayer/src/Prover.sol
+++ b/contracts/vlayer/src/Prover.sol
@@ -16,11 +16,11 @@ contract Prover {
     ITraveler private constant TRAVELER = ITraveler(address(uint160(uint256(keccak256("vlayer.traveler")))));
 
     function setBlock(uint256 blockNo) public {
-        TRAVELER.setBlock(blockNo);
+        require(TRAVELER.setBlock(blockNo), "Failed cheatcode invocation");
     }
 
     function setChain(uint256 chainId, uint256 blockNo) public {
-        TRAVELER.setChain(chainId, blockNo);
+        require(TRAVELER.setChain(chainId, blockNo), "Failed cheatcode invocation");
     }
 
     function proof() public pure returns (Proof memory) {


### PR DESCRIPTION
Fix to the following:

> Tool: vanguard
> Severity: medium
> Description: Unchecked result of a call in Prover.setBlock
> Unchecked return value found in Prover.setBlock @ dependencies/vlayer-0.1.0-nightly-20250210-ae0a1dd/src/Prover.sol:18:5-20:5
> 
> The return value of an external call to setBlock(uint256) is never used
> 
> @ Prover.setBlock @ dependencies/vlayer-0.1.0-nightly-20250210-ae0a1dd/src/Prover.sol:19:9
> 
> Possible callee(s) with non-void return type include: ITraveler.setBlock
> 
> Note: the following function(s) have the same selector but returns void. If this call is to one of these function(s), then you can ignore this warning.
> 
> Prover.setBlock
> 
> Affected contracts: Prover @ dependencies/vlayer-0.1.0-nightly-20250210-ae0a1dd/src/Prover.sol:13:1-29:1 SimpleProver @ src/vlayer/SimpleProver.sol:8:1-20:1