### PR TITLE
Disable `Swatinem/rust-cache`

### DIFF
--- a/.github/actions/rust-prerequisites/action.yml
+++ b/.github/actions/rust-prerequisites/action.yml
@@ -22,16 +22,6 @@ runs:
         cache: false
         target: ${{ inputs.target }}
 
-    - name: Setup Rust Caching
-      uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
-      with:
-        workspaces: |
-          .
-          rust/guest_wrapper/risc0_call_guest
-          rust/guest_wrapper/risc0_chain_guest
-        cache-on-failure: false
-        save-if: ${{ github.ref == 'refs/heads/main' }}
-
     - name: Install sccache
       uses: taiki-e/cache-cargo-install-action@caa6f48d18d42462f9c30df89e2b4f71a42b7c2c # v2.0.1
       with:


### PR DESCRIPTION
Currently, we have two caching mechanisms:

- [`rust-cache`](https://github.com/Swatinem/rust-cache), which is designed NOT to cache own code, only dependencies.
- [`sccache`](https://github.com/mozilla/sccache), which is able to cache the compilation of both dependencies and own code.

We have some problems with `rust-cache` - it only works with github's cache, which is limited to 10GB.
So we run into problems with cache eviction.
Not only that, but turns out that it takes us around the same time to recompile dependencies, than to download the cache.

---

Consider the following jobs:

Test Rust, `Swatinem/rust-cache` is enabled:

https://github.com/vlayer-xyz/vlayer/actions/runs/13333029280/job/37241606872

![Screenshot 2025-02-14 at 17 57 19](https://github.com/user-attachments/assets/3a00181e-417a-4165-8192-01732b3ace2e)

Test Rust, `Swatinem/rust-cache` is disabled:

https://github.com/vlayer-xyz/vlayer/actions/runs/13333527604/job/37243274695

![Screenshot 2025-02-14 at 17 58 12](https://github.com/user-attachments/assets/647ead67-32e9-446a-be37-c7fecf97ecc9)

---

Or, the following:

Lint Rust, `Swatinem/rust-cache` is enabled:

https://github.com/vlayer-xyz/vlayer/actions/runs/13333029303/job/37241606937

![Screenshot 2025-02-14 at 17 58 37](https://github.com/user-attachments/assets/be74a59e-403f-4d83-8873-b1202fea3ecf)

Lint Rust, `Swatinem/rust-cache` is disabled:

https://github.com/vlayer-xyz/vlayer/actions/runs/13333527610/job/37243274368

![Screenshot 2025-02-14 at 17 59 08](https://github.com/user-attachments/assets/1bf81be6-ce9e-41a3-a8e4-766b02e2bd9d)

---

Funny enough, the total job times are up to a second identical :D But this is not always the case.
I've run multiple experiments and I think we can try out disabling the `Swatinem/rust-cache` action - maybe revisiting this approach with some modifications, if we can do the equivalent but not using github's native cache. We could experiment with different approaches separately, but at this moment I think disabling this action is beneficial.

Note that this result was achieved after increasing the sccache's default max storage size: https://github.com/vlayer-xyz/infra/pull/26