### PR TITLE
Update simple web proof error message

### DIFF
--- a/.github/actions/ts-prerequisites/action.yml
+++ b/.github/actions/ts-prerequisites/action.yml
@@ -10,5 +10,3 @@ runs:
         registry-url: "https://registry.npmjs.org"  
     - name: Install Bun
       uses: oven-sh/setup-bun@v2
-      with:
-        bun-version: 1.1.34


### PR DESCRIPTION
Extracted the main change from https://github.com/vlayer-xyz/vlayer/pull/1852, so it could be merged without being blocked on extension linting.