### PR TITLE
Omit rust release building on merge queue

### DIFF
--- a/.github/workflows/build_rust_release.yaml
+++ b/.github/workflows/build_rust_release.yaml
@@ -10,7 +10,6 @@ on:
       - ".github/actions/build-guest-artifacts/action.yml"
       - ".github/actions/replace-guest-artifacts/action.yml"
       - ".github/workflows/build_rust_release.yaml"
-  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
For those reasons:

https://github.com/vlayer-xyz/vlayer/blob/140c7843cd106d7c386cf5b4f1ca713cdf51a004/.github/workflows/build_rust_release.yaml#L16-L18