### PR TITLE
Disable rust analyzer features

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,6 @@
   },
   "rust-analyzer.check.command": "clippy",
   "rust-analyzer.cargo.allTargets": true,
-  "rust-analyzer.cargo.features": ["http", "testing"],
   "[rust]": {
     "editor.defaultFormatter": "rust-lang.rust-analyzer",
     "editor.formatOnSave": true


### PR DESCRIPTION
I've initially added this config as I was working on a crate that uses those features. I was unaware that rust analyzer fails if you work on a crate that does not. In that case - it's better to have them off by default. It would be perfect to have smth like allFeatures but because people often have non-additive features - rust analyzer decided not to have this option.

This does not impact compilation or CI. Only a VsCode config