### PR TITLE
Make test-wsproxy default in SDK.

### DIFF
--- a/packages/sdk/src/api/webProof/providers/extension.ts
+++ b/packages/sdk/src/api/webProof/providers/extension.ts
@@ -191,7 +191,7 @@ export const validateWebProofRequest = (
 
 export const createExtensionWebProofProvider = ({
   notaryUrl = "https://test-notary.vlayer.xyz",
-  wsProxyUrl = "wss://notary.pse.dev/proxy",
+  wsProxyUrl = "wss://test-wsproxy.vlayer.xyz",
 }: WebProofProviderSetup = {}): WebProofProvider => {
   return new ExtensionWebProofProvider(notaryUrl, wsProxyUrl);
 };


### PR DESCRIPTION
It has already been the default in sdk-hooks, making it default in SDK too.