### PR TITLE
Email Example: Add  dns service url configuration

### DIFF
--- a/examples/simple-email-proof/vlayer/.env.dev
+++ b/examples/simple-email-proof/vlayer/.env.dev
@@ -1,5 +1,6 @@
 CHAIN_NAME=anvil
 PROVER_URL=http://127.0.0.1:3000
 JSON_RPC_URL=http://127.0.0.1:8545
+DNS_SERVICE_URL=http://127.0.0.1:3002/dns-query
 # this is anvil test private key for testing purpose only
 EXAMPLES_TEST_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80

--- a/examples/simple-email-proof/vlayer/.env.testnet
+++ b/examples/simple-email-proof/vlayer/.env.testnet
@@ -1,4 +1,5 @@
 CHAIN_NAME=optimismSepolia
 PROVER_URL=https://test-prover.vlayer.xyz
 JSON_RPC_URL=https://sepolia.optimism.io
+DNS_SERVICE_URL=https://test-dns.vlayer.xyz/dns-query
 USE_WINDOW_ETHEREUM_TRANSPORT=true

--- a/examples/simple-email-proof/vlayer/deploy.ts
+++ b/examples/simple-email-proof/vlayer/deploy.ts
@@ -23,6 +23,7 @@ writeEnvVariables(".env", {
   VITE_PROVER_URL: config.proverUrl,
   VITE_JSON_RPC_URL: config.jsonRpcUrl,
   VITE_PRIVATE_KEY: config.privateKey,
+  VITE_DNS_SERVICE_URL: config.dnsServiceUrl,
   VITE_USE_WINDOW_ETHEREUM_TRANSPORT:
     process.env.USE_WINDOW_ETHEREUM_TRANSPORT || "",
 });

--- a/examples/simple-email-proof/vlayer/prove.ts
+++ b/examples/simple-email-proof/vlayer/prove.ts
@@ -17,6 +17,7 @@ const {
   ethClient,
   account: john,
   proverUrl,
+  dnsServiceUrl,
   confirmations,
 } = await createContext(config);
 
@@ -27,6 +28,10 @@ const { prover, verifier } = await deployVlayerContracts({
   verifierArgs: [],
 });
 
+if (!dnsServiceUrl) {
+  throw new Error("DNS service URL is not set");
+}
+
 console.log("Proving...");
 const vlayer = createVlayerClient({
   url: proverUrl,
@@ -36,10 +41,7 @@ const hash = await vlayer.prove({
   proverAbi: proverSpec.abi,
   functionName: "main",
   chainId: chain.id,
-  args: [
-    await preverifyEmail(mimeEmail, "http://127.0.0.1:3002/dns-query"),
-    john.address,
-  ],
+  args: [await preverifyEmail(mimeEmail, dnsServiceUrl), john.address],
   token: config.token,
 });
 const result = await vlayer.waitForProvingResult({ hash });

--- a/examples/simple-email-proof/vlayer/src/shared/hooks/useEmailProofVerification.ts
+++ b/examples/simple-email-proof/vlayer/src/shared/hooks/useEmailProofVerification.ts
@@ -75,7 +75,10 @@ export const useEmailProofVerification = () => {
       : (connectedAddr as Address);
 
     const eml = await getStrFromFile(uploadedEmlFile);
-    const email = await preverifyEmail(eml, "http://127.0.0.1:3002/dns-query");
+    const email = await preverifyEmail(
+      eml,
+      import.meta.env.VITE_DNS_SERVICE_URL,
+    );
     await callProver([email, claimerAddr]);
     setCurrentStep("Waiting for proof...");
   };

--- a/packages/sdk/src/config/getConfig.ts
+++ b/packages/sdk/src/config/getConfig.ts
@@ -52,6 +52,7 @@ const envSchema = z.object({
   CHAIN_NAME: z.string(),
   PROVER_URL: z.string().url(),
   JSON_RPC_URL: z.string().url(),
+  DNS_SERVICE_URL: z.string().url().optional(),
   L2_JSON_RPC_URL: z.string().url().optional(),
   EXAMPLES_TEST_PRIVATE_KEY: z
     .string()

--- a/packages/sdk/src/config/types.ts
+++ b/packages/sdk/src/config/types.ts
@@ -11,6 +11,7 @@ export type EnvConfig = {
   proverUrl: string;
   jsonRpcUrl: string;
   l2JsonRpcUrl?: string;
+  dnsServiceUrl?: string;
   privateKey: `0x${string}`;
   token?: string;
   deployConfig: DeployConfig;
@@ -27,6 +28,7 @@ export type VlayerContextConfig = {
   proverUrl: string;
   wsProxyUrl?: string;
   notaryUrl?: string;
+  dnsServiceUrl?: string;
   privateKey?: `0x${string}`;
   deployConfig?: DeployConfig;
 };

--- a/packages/test-web-app/.env.dev
+++ b/packages/test-web-app/.env.dev
@@ -1,5 +1,6 @@
 CHAIN_NAME=anvil
 PROVER_URL=http://127.0.0.1:3000
 JSON_RPC_URL=http://127.0.0.1:8545
+DNS_SERVICE_URL=http://127.0.0.1:3002/dns-query
 # this is anvil test private key for testing purpose only
 EXAMPLES_TEST_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80


### PR DESCRIPTION
Problem: 
- hardcoded dns service (localhost:3002) results with error for `prove:testnet`

Solution:
- for testnet usecases it should use deployed dns service url instead. 