### PR TITLE
Skip the release workflow if a github release already exists

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,14 +15,14 @@ jobs:
     steps:
       - name: Check if release exists
         id: check_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if gh release view "nightly-${{ github.sha }}" --repo "${{ github.repository }}" > /dev/null 2>&1; then
             echo "release_exists=true" >> $GITHUB_OUTPUT
           else
             echo "release_exists=false" >> $GITHUB_OUTPUT
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-release:
     needs: [check-if-release-exists]


### PR DESCRIPTION
We have a cron-based release, so if there are no PRs merged, there is no need to run it again.
It would also currently fail because we don't handle an error from soldeer about release already existing.