### PR TITLE
update json rpc nodes to quick node

### DIFF
--- a/ansible/host_vars/prod_fake_prover.yml
+++ b/ansible/host_vars/prod_fake_prover.yml
@@ -15,12 +15,12 @@ vlayer_alchemy_api_key: !vault |
   63343030643438373066326432356565363534623131306166383939656563623537656535626161
   6164386166343532386262626237643763623366376537663030
 vlayer_prover_rpc_urls:
- - "11155111:https://eth-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "11155420:https://opt-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
+ - "11155111:https://omniscient-flashy-frog.ethereum-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
+ - "11155420:https://omniscient-flashy-frog.optimism-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
  - "1:https://eth-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "8453:https://base-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "10:https://opt-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "84532:https://base-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
+ - "84532:https://omniscient-flashy-frog.base-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
  - "80002:https://polygon-amoy.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "421614:https://arb-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "300:https://zksync-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"


### PR DESCRIPTION
Problem: 
Jump from sepolia  => opSepolia didn't work due to unsupported json rpc call (alchemy). Had to switch it to quick node. 

@rzadp Can I use the same quick node url (but with different network name) for other networks? 

