### PR TITLE
call_server: fix incorrectly implemented custom spans in async code

### DIFF
--- a/rust/services/call/server_lib/src/handlers/v_call.rs
+++ b/rust/services/call/server_lib/src/handlers/v_call.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::ChainId;
 use call_host::{Error as HostError, Host};
 use provider::Address;
-use tracing::info;
+use tracing::{info, info_span, Instrument};
 use types::{Call, CallContext, CallHash, Result as VCallResult};
 
 use super::{Params, SharedConfig, SharedProofs};
@@ -39,8 +39,7 @@ pub async fn v_call(
 
     if !found_existing {
         tokio::spawn(async move {
-            let span = tracing::info_span!("http", id = params.req_id.to_string());
-            let _enter = span.enter();
+            let span = info_span!("http", id = params.req_id.to_string());
             proof::generate(
                 call,
                 host,
@@ -49,6 +48,7 @@ pub async fn v_call(
                 call_hash,
                 config.chain_proof_config(),
             )
+            .instrument(span)
             .await
         });
     }

--- a/rust/services/call/server_lib/src/handlers/v_get_proof_receipt.rs
+++ b/rust/services/call/server_lib/src/handlers/v_get_proof_receipt.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use tracing::{info, info_span};
+use tracing::{info, instrument};
 use types::{CallResult, Error, Result};
 
 use super::SharedProofs;
@@ -8,12 +8,9 @@ use crate::v_call::CallHash;
 
 pub mod types;
 
+#[instrument(name = "proof", skip_all, fields(hash = %hash))]
 pub fn v_get_proof_receipt(proofs: &SharedProofs, hash: CallHash) -> Result<CallResult> {
-    let span = info_span!("proof", hash = tracing::field::display(hash));
-    let _enter = span.enter();
-
     info!("Getting proof receipt");
-
     Ok(proofs
         .get(&hash)
         .ok_or(Error::HashNotFound(hash))?

--- a/rust/services/call/server_lib/src/proof.rs
+++ b/rust/services/call/server_lib/src/proof.rs
@@ -1,7 +1,7 @@
 use call_engine::Call as EngineCall;
 use call_host::Host;
 use dashmap::Entry;
-use tracing::{error, info, info_span};
+use tracing::{error, info, instrument};
 
 pub use crate::proving::RawData;
 use crate::{
@@ -83,6 +83,7 @@ fn set_metrics(
     entry.and_modify(|res| res.metrics = metrics)
 }
 
+#[instrument(name = "proof", skip_all, fields(hash = %call_hash))]
 pub async fn generate(
     call: EngineCall,
     host: Host,
@@ -91,9 +92,6 @@ pub async fn generate(
     call_hash: CallHash,
     chain_proof_config: Option<ChainProofConfig>,
 ) {
-    let span = info_span!("proof", id = tracing::field::display(call_hash));
-    let _enter = span.enter();
-
     let prover = host.prover();
     let call_guest_id = host.call_guest_id();
     let mut metrics = Metrics::default();


### PR DESCRIPTION
Heeding the warnings in [tracing::Span](https://docs.rs/tracing/latest/tracing/struct.Span.html#in-asynchronous-code) documentation, `Span::enter` should never be used due to its incompatibility with async code. Namely, `Span::enter` lasts until the guard is dropped, which typically is at the end of current block/function. In async code, however, yields happen at `.await` points when the current scope is exited but the values are not dropped. Therefore, `Span::enter` should not be used in async code. Instead, we should use the `instrument` derive macro or `Future::instrument` combinator.