### PR TITLE
Update to safe hashbrown dependency

### DIFF
--- a/rust/guest_wrapper/risc0_call_guest/Cargo.lock
+++ b/rust/guest_wrapper/risc0_call_guest/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "foldhash",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "indexmap 2.6.0",
  "itoa",
  "k256",
@@ -2287,7 +2287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "serde",
 ]
 

--- a/rust/guest_wrapper/risc0_chain_guest/Cargo.lock
+++ b/rust/guest_wrapper/risc0_chain_guest/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "foldhash",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "indexmap",
  "itoa",
  "k256",

--- a/rust/zkvm-benchmarks/runner/risc0_guest/Cargo.lock
+++ b/rust/zkvm-benchmarks/runner/risc0_guest/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "foldhash",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "indexmap 2.6.0",
  "itoa",
  "k256",
@@ -2097,7 +2097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "serde",
 ]
 


### PR DESCRIPTION
Meant to fix [this](https://github.com/vlayer-xyz/vlayer/security/dependabot/50) alert