### PR TITLE
Cleanup logs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -186,6 +186,7 @@
         "@types/ramda": "^0.30.2",
         "@vlayer/extension-hooks": "file:../extension-hooks",
         "comlink": "^4.4.1",
+        "debug": "^4.4.0",
         "fp-ts": "^2.16.9",
         "framer-motion": "^11.11.1",
         "playwright": "1.48.0",
@@ -2801,6 +2802,8 @@
 
     "@vlayer/browser-extension/@vlayer/extension-hooks": ["@vlayer/extension-hooks@file:packages/extension-hooks", { "dependencies": { "@types/react": "^18.3.5", "vitest": "^2.1.4" }, "devDependencies": { "@types/bun": "latest", "jsdom": "^25.0.1", "webextension-polyfill": "^0.12.0" }, "peerDependencies": { "react": "^18.3.1", "typescript": "^5.0.0" } }],
 
+    "@vlayer/extension-hooks/@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
+
     "@vlayer/react/@types/bun": ["@types/bun@1.2.3", "", { "dependencies": { "bun-types": "1.2.3" } }, "sha512-054h79ipETRfjtsCW9qJK8Ipof67Pw9bodFWmkfkaUaRiIQ1dIV2VTlheshlBx3mpKr0KeK8VqnMMCtgN9rQtw=="],
 
     "@vlayer/sdk/@types/bun": ["@types/bun@1.2.3", "", { "dependencies": { "bun-types": "1.2.3" } }, "sha512-054h79ipETRfjtsCW9qJK8Ipof67Pw9bodFWmkfkaUaRiIQ1dIV2VTlheshlBx3mpKr0KeK8VqnMMCtgN9rQtw=="],
@@ -3099,6 +3102,10 @@
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 
+    "@vlayer/browser-extension/@vlayer/extension-hooks/@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
+
+    "@vlayer/extension-hooks/@types/bun/bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
+
     "@vlayer/react/@types/bun/bun-types": ["bun-types@1.2.3", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-P7AeyTseLKAvgaZqQrvp3RqFM3yN9PlcLuSTe7SoJOfZkER73mLdT2vEQi8U64S1YvM/ldcNiQjn0Sn7H9lGgg=="],
 
     "@vlayer/sdk/@types/bun/bun-types": ["bun-types@1.2.3", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-P7AeyTseLKAvgaZqQrvp3RqFM3yN9PlcLuSTe7SoJOfZkER73mLdT2vEQi8U64S1YvM/ldcNiQjn0Sn7H9lGgg=="],
@@ -3354,6 +3361,8 @@
     "@manypkg/find-root/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "@vlayer/browser-extension/@vlayer/extension-hooks/@types/bun/bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
 
     "@vlayer/sdk/viem/@scure/bip32/@scure/base": ["@scure/base@1.1.9", "", {}, "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="],
 

--- a/packages/browser-extension/package.json
+++ b/packages/browser-extension/package.json
@@ -36,6 +36,7 @@
     "@types/ramda": "^0.30.2",
     "@vlayer/extension-hooks": "file:../extension-hooks",
     "comlink": "^4.4.1",
+    "debug": "^4.4.0",
     "fp-ts": "^2.16.9",
     "framer-motion": "^11.11.1",
     "playwright": "1.48.0",

--- a/packages/browser-extension/src/background.ts
+++ b/packages/browser-extension/src/background.ts
@@ -14,7 +14,8 @@ import {
 import { WebProverSessionContextManager } from "./state/webProverSessionContext";
 import { match, P } from "ts-pattern";
 import { zkProvingStatusStore } from "./state/zkProvingStatusStore.ts";
-
+import debug from "debug";
+const log = debug("extension:background");
 let port: browser.Runtime.Port | undefined = undefined;
 let openedTabId: number | undefined = undefined;
 
@@ -42,11 +43,11 @@ browser.runtime.onMessage.addListener(async (message: ExtensionMessage) => {
         ),
       },
       () => {
-        console.log("sending message to webpage", message);
+        log("sending message to webpage", message);
         try {
           port?.postMessage(message);
         } catch (e) {
-          console.log("Could not send message to webpage", e);
+          console.error("Could not send message to webpage", e);
         }
       },
     )

--- a/packages/browser-extension/src/hooks/tlsnProve/tlsnProve.ts
+++ b/packages/browser-extension/src/hooks/tlsnProve/tlsnProve.ts
@@ -6,6 +6,8 @@ import { Reveal, Method } from "tlsn-wasm";
 import { type RedactionConfig } from "../../web-proof-commons";
 import { redact } from "./redaction/redact";
 import { HTTPMethod } from "lib/HttpMethods";
+import debug from "debug";
+const log = debug("extension:tlsnProve");
 type ProverConfig = {
   serverDns: string;
   maxSentData?: number;
@@ -79,15 +81,15 @@ export async function tlsnProve(
     throw new Error("Authentication failed. Please restart the process.");
   }
 
-  console.log("Received response", res);
+  log("Received response", res);
 
   const transcript = await prover.transcript();
 
-  console.log("Transcript", transcript);
+  log("Transcript", transcript);
 
   const commit = redact(transcript, redactionConfig);
 
-  console.log("Commit", commit);
+  log("Commit", commit);
   const notarizationOutputs = await prover.notarize(commit);
 
   const presentation = await new Presentation({
@@ -100,13 +102,13 @@ export async function tlsnProve(
 
   const presentationJson = await presentation.json();
   const decodedProof = await presentation.verify();
-  console.log("Decoded proof", decodedProof);
+  log("Decoded proof", decodedProof);
 
   const decodedTranscript = new Transcript({
     sent: decodedProof?.transcript.sent,
     recv: decodedProof?.transcript.recv,
   });
-  console.log("Decoded transcript", decodedTranscript);
+  log("Decoded transcript", decodedTranscript);
   return {
     presentationJson,
     decodedTranscript: {

--- a/packages/eslint.config.js
+++ b/packages/eslint.config.js
@@ -10,6 +10,7 @@ export default [
   {
     rules: {
       curly: "error",
+      "no-console": ["warn", { allow: ["warn", "error"] }],
     },
     languageOptions: {
       globals: {

--- a/packages/test-json-server/src/index.ts
+++ b/packages/test-json-server/src/index.ts
@@ -34,7 +34,6 @@ new Elysia({
   })
   .put("/update_resource", ({ request }) => {
     const { name } = request.body;
-    console.log("Update resource request", request);
     return { success: true, updatedName: name };
   })
   .use(cors())

--- a/packages/test-web-app/src/DappProveWeb.tsx
+++ b/packages/test-web-app/src/DappProveWeb.tsx
@@ -14,7 +14,6 @@ import lotrApiProver from "../../../contracts/fixtures/out/LotrApiProver.sol/Lot
 
 const PROVER_ADDRESS = import.meta.env
   .VITE_LOTR_API_PROVER_ADDRESS as `0x${string}`;
-console.log(PROVER_ADDRESS);
 
 function DappProveWeb() {
   const [zkProof, setZkProof] = useState<boolean>();

--- a/packages/test-web-app/src/DappPut.tsx
+++ b/packages/test-web-app/src/DappPut.tsx
@@ -8,7 +8,7 @@ import {
   startPage,
 } from "@vlayer/react";
 
-import React, { useEffect } from "react";
+import React from "react";
 import { Abi } from "viem";
 
 const webProofConfig: GetWebProofArgs<Abi, string> = {
@@ -48,11 +48,6 @@ const webProofConfig: GetWebProofArgs<Abi, string> = {
 function DappPutContent() {
   const { requestWebProof, webProof } = useWebProof(webProofConfig);
 
-  useEffect(() => {
-    if (webProof) {
-      console.log("webProof ready", webProof);
-    }
-  }, [webProof]);
   return (
     <div
       style={{ display: "flex", flexDirection: "column", alignItems: "center" }}

--- a/packages/test-web-app/src/Dashboard.tsx
+++ b/packages/test-web-app/src/Dashboard.tsx
@@ -22,13 +22,9 @@ function Dashboard() {
           fetch("https://lotr-api.online:3011/update_resource", {
             method: "PUT",
             body: JSON.stringify({ name: "John Doe" }),
-          })
-            .then((res) => {
-              console.log("Update resource response", res);
-            })
-            .catch((err) => {
-              console.error("Update resource error", err);
-            });
+          }).catch((err) => {
+            console.error("Update resource error", err);
+          });
         }}
       >
         Update resource

--- a/packages/test-web-app/src/Email.tsx
+++ b/packages/test-web-app/src/Email.tsx
@@ -26,14 +26,13 @@ const useEmailFileUpload = () => {
       str,
       "http://127.0.0.1:3002/dns-query",
     );
-    const x = await vlayer.prove({
+    await vlayer.prove({
       address: PROVER_ADDRESS,
       proverAbi: proverSpec.abi,
       functionName: "main",
       chainId: foundry.id,
       args: [unverifiedEmail],
     });
-    console.log("c", x);
   }, []);
 };
 
@@ -46,7 +45,6 @@ export default function Email() {
         name="file"
         type="file"
         onChange={(evt) => {
-          console.log("File changed");
           void handleFileChange(evt);
         }}
       />

--- a/packages/test-web-app/src/main.tsx
+++ b/packages/test-web-app/src/main.tsx
@@ -11,8 +11,6 @@ import Email from "./Email";
 import { DappProveWeb } from "./DappProveWeb";
 import { DappPut } from "./DappPut";
 
-console.log("Dapp", Dapp);
-
 const router = createBrowserRouter([
   // dapp is the app developer used and launched using the sdk
   {


### PR DESCRIPTION
As first step towards covering edges of extension we should improve tooling. 
this commit contains : 
- console.log marked as `warn` on eslint level, this shouldnt be use for debug. 
- [debug](https://www.npmjs.com/package/debug) previously launched in sdk is added to browser extension 
- cleanup of `console.log` left here and there in code
