### PR TITLE
Don't push to soldeer if the given version was already released

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,26 +7,8 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 jobs:
-  check-if-release-exists:
-    if: github.repository == 'vlayer-xyz/vlayer'
-    runs-on: ubuntu-latest
-    outputs:
-      release_exists: ${{ steps.check_release.outputs.release_exists }}
-    steps:
-      - name: Check if release exists
-        id: check_release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh release view "nightly-${{ github.sha }}" --repo "${{ github.repository }}" > /dev/null 2>&1; then
-            echo "release_exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "release_exists=false" >> $GITHUB_OUTPUT
-          fi
-
   build-release:
-    needs: [check-if-release-exists]
-    if: github.repository == 'vlayer-xyz/vlayer' && needs.check-if-release-exists.outputs.release_exists != 'true'
+    if: github.repository == 'vlayer-xyz/vlayer'
     uses: ./.github/workflows/build_rust_release.yaml
 
   build-examples:


### PR DESCRIPTION
Don't try to push, if installation is successful - which means version was already released.