### PR TITLE
Handle clearing storage and extension closing. 

### DIFF
--- a/packages/browser-extension/src/background.ts
+++ b/packages/browser-extension/src/background.ts
@@ -29,6 +29,12 @@ browser.runtime.onConnectExternal.addListener((connectedPort) => {
       .with({ action: ExtensionAction.NotifyZkProvingStatus }, (msg) => {
         void handleProvingStatusNotification(msg);
       })
+      .with({ action: ExtensionAction.OpenSidePanel }, () => {
+        void handleOpenSidePanel();
+      })
+      .with({ action: ExtensionAction.CloseSidePanel }, () => {
+        void handleCloseSidePanel();
+      })
       .exhaustive();
   });
 });
@@ -72,15 +78,40 @@ browser.runtime.onMessage.addListener(async (message: ExtensionMessage) => {
 browser.runtime.onMessageExternal.addListener(
   (message: MessageToExtension, sender) => {
     return match(message)
-      .with({ action: ExtensionAction.RequestWebProof }, (msg) =>
-        handleProofRequest(msg, sender),
+      .with(
+        { action: ExtensionAction.RequestWebProof },
+        async (msg) => await handleProofRequest(msg, sender),
       )
-      .with({ action: ExtensionAction.NotifyZkProvingStatus }, (msg) =>
-        handleProvingStatusNotification(msg),
+      .with(
+        { action: ExtensionAction.NotifyZkProvingStatus },
+        async (msg) => await handleProvingStatusNotification(msg),
+      )
+      .with(
+        { action: ExtensionAction.OpenSidePanel },
+        async () => await handleOpenSidePanel(sender),
+      )
+      .with({ action: ExtensionAction.CloseSidePanel }, () =>
+        handleCloseSidePanel(),
       )
       .exhaustive();
   },
 );
+
+const handleOpenSidePanel = async (sender?: browser.Runtime.MessageSender) => {
+  if (chrome.sidePanel && sender?.tab?.windowId) {
+    await chrome.sidePanel.open({ windowId: sender.tab?.windowId });
+  }
+};
+
+const handleCloseSidePanel = () => {
+  void browser.runtime.sendMessage(ExtensionMessageType.CloseSidePanel);
+};
+
+const cleanProvingSessionStorageOnClose = () => {
+  void browser.runtime.sendMessage(
+    ExtensionMessageType.CleanProvingSessionStorageOnClose,
+  );
+};
 
 const handleProofRequest = async (
   message: Extract<
@@ -110,6 +141,9 @@ const handleProvingStatusNotification = async (
   >,
 ) => {
   await zkProvingStatusStore.setProvingStatus(message.payload);
+  if (message.payload.status === ZkProvingStatus.Done) {
+    cleanProvingSessionStorageOnClose();
+  }
 };
 
 const validateProofRequest = (

--- a/packages/browser-extension/src/components/organisms/ErrorCallout.test.tsx
+++ b/packages/browser-extension/src/components/organisms/ErrorCallout.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ErrorCalloutPresentational } from "./ErrorCallout";
 import React from "react";
-import { SidePanelContent } from "components/pages/SidePanelContent";
+import { SidePanelContainer } from "components/pages/SidePanelContent";
 
 const mocks = vi.hoisted(() => ({
   useTlsnProver: vi.fn(),
@@ -43,7 +43,7 @@ describe("ErrorCalloutPresentational", () => {
 
   it("renders when tlsn fails to start", () => {
     mocks.useTlsnProver.mockReturnValue({ error: "Test error message" });
-    render(<SidePanelContent />);
+    render(<SidePanelContainer />);
     expect(screen.getByText("Test error message")).toBeInTheDocument();
   });
 });

--- a/packages/browser-extension/src/components/pages/SidePanel.tsx
+++ b/packages/browser-extension/src/components/pages/SidePanel.tsx
@@ -1,7 +1,7 @@
 import { TlsnProofContextProvider } from "hooks/useTlsnProver";
 import { Grid, Theme } from "@radix-ui/themes";
 import React, { FC } from "react";
-import { SidePanelContent } from "./SidePanelContent";
+import { SidePanelContainer } from "./SidePanelContent";
 import styles from "./SidePanel.module.css";
 export const SidePanel: FC = () => {
   return (
@@ -9,7 +9,7 @@ export const SidePanel: FC = () => {
       <Theme accentColor="violet">
         <Grid columns="10" gapY="4" top="16" className={styles.grid}>
           <div className={styles.container}>
-            <SidePanelContent />
+            <SidePanelContainer />
           </div>
         </Grid>
       </Theme>

--- a/packages/browser-extension/src/components/pages/SidePanelContent.tsx
+++ b/packages/browser-extension/src/components/pages/SidePanelContent.tsx
@@ -1,5 +1,8 @@
 import { useProvingSessionConfig } from "hooks/useProvingSessionConfig";
-import { isEmptyWebProverSessionConfig } from "../../web-proof-commons";
+import {
+  isEmptyWebProverSessionConfig,
+  WebProverSessionConfig,
+} from "../../web-proof-commons";
 
 import * as React from "react";
 import { LOADING } from "@vlayer/extension-hooks";
@@ -7,22 +10,30 @@ import { EmptyFlowCard } from "components/molecules/EmptyFlow";
 import { HelpSection } from "components/organisms";
 import { Steps } from "components/organisms";
 import { ErrorCallout } from "components/organisms/ErrorCallout";
-export const SidePanelContent = () => {
+import { useCleanStorageOnClose } from "hooks/useCleanStorageOnClose";
+import { useCloseSidePanelOnRequest } from "hooks/useCloseSidePanelOnRequest";
+import { match } from "ts-pattern";
+
+export const SidePanelContent = ({
+  config,
+}: {
+  config: WebProverSessionConfig | typeof LOADING;
+}) => {
+  return match(config)
+    .with(LOADING, () => <div>Loading...</div>)
+    .when(isEmptyWebProverSessionConfig, () => <EmptyFlowCard />)
+    .otherwise(() => (
+      <>
+        <Steps />
+        <ErrorCallout />
+        <HelpSection />
+      </>
+    ));
+};
+
+export const SidePanelContainer = () => {
+  useCleanStorageOnClose();
+  useCloseSidePanelOnRequest();
   const [config] = useProvingSessionConfig();
-
-  if (config === LOADING) {
-    return <div>Loading...</div>;
-  }
-
-  if (isEmptyWebProverSessionConfig(config)) {
-    return <EmptyFlowCard />;
-  }
-
-  return (
-    <>
-      <Steps />
-      <ErrorCallout />
-      <HelpSection />
-    </>
-  );
+  return <SidePanelContent config={config} />;
 };

--- a/packages/browser-extension/src/components/pages/StepPanelContent.test.tsx
+++ b/packages/browser-extension/src/components/pages/StepPanelContent.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { SidePanelContent } from "./SidePanelContent";
+import { SidePanelContainer } from "./SidePanelContent";
 import * as React from "react";
 import { ZkProvingStatus } from "src/web-proof-commons";
 import { LOADING } from "@vlayer/extension-hooks";
@@ -38,7 +38,7 @@ describe("SidePanelContent", () => {
     mocks.isEmptyWebProverSessionConfig.mockReturnValue(false);
     mocks.ZkProvingStatus.mockReturnValue(ZkProvingStatus.NotStarted);
 
-    render(<SidePanelContent />);
+    render(<SidePanelContainer />);
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
@@ -46,7 +46,7 @@ describe("SidePanelContent", () => {
     vi.resetAllMocks();
     mocks.useProvingSessionConfig.mockReturnValue([]);
     mocks.isEmptyWebProverSessionConfig.mockReturnValue(true);
-    render(<SidePanelContent />);
+    render(<SidePanelContainer />);
     expect(screen.getByTestId("empty-flow-card")).toBeInTheDocument();
   });
 
@@ -58,7 +58,7 @@ describe("SidePanelContent", () => {
     mocks.useTlsnProver.mockReturnValue({
       error: null,
     });
-    render(<SidePanelContent />);
+    render(<SidePanelContainer />);
     expect(screen.getByTestId("steps")).toBeInTheDocument();
     //help section
     expect(screen.getByText("Having Trouble?")).toBeInTheDocument();

--- a/packages/browser-extension/src/hooks/useCleanStorageOnClose.ts
+++ b/packages/browser-extension/src/hooks/useCleanStorageOnClose.ts
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+import { provingSessionStorageConfig } from "src/state/config";
+import { ExtensionMessageType } from "src/web-proof-commons";
+import browser from "webextension-polyfill";
+
+// Listen to clean storage request where window is available
+
+export const useCleanStorageOnClose = () => {
+  useEffect(() => {
+    browser.runtime.onMessage.addListener((message) => {
+      if (message === ExtensionMessageType.CleanProvingSessionStorageOnClose) {
+        window.addEventListener("beforeunload", () => {
+          resetProvingSessionStorage();
+        });
+      }
+    });
+  }, []);
+};
+
+const resetProvingSessionStorage = () => {
+  const keys = Object.values(provingSessionStorageConfig.storageKeys);
+  for (const key of keys) {
+    void browser.storage.session.remove(key);
+  }
+};

--- a/packages/browser-extension/src/hooks/useCloseSidePanelOnRequest.ts
+++ b/packages/browser-extension/src/hooks/useCloseSidePanelOnRequest.ts
@@ -1,0 +1,15 @@
+import { ExtensionMessageType } from "src/web-proof-commons";
+import browser from "webextension-polyfill";
+import { useEffect } from "react";
+
+// Listen to close side panel request where window is available
+
+export const useCloseSidePanelOnRequest = () => {
+  useEffect(() => {
+    browser.runtime.onMessage.addListener((message) => {
+      if (message === ExtensionMessageType.CloseSidePanel) {
+        window.close();
+      }
+    });
+  }, []);
+};

--- a/packages/browser-extension/src/state/config.ts
+++ b/packages/browser-extension/src/state/config.ts
@@ -1,0 +1,21 @@
+import browser from "webextension-polyfill";
+
+export enum StorageKeys {
+  // config passed from SDK, should survive extension close/reopen
+  webProverSessionConfig = "webProverSessionConfig",
+  // proof computed by the extension, once proof is ready it should survive extension close/reopen
+  // other tlsn related data is ephemeral as we have to wait for the proof to be computed in request-response flow
+  tlsnProof = "tlsn.proof",
+  // browsing history, should survive extension close/reopen
+  browsingHistory = "browsingHistory",
+  // zk proving status, it will be cleared just after its added
+  zkProvingStatus = "zkProvingStatus",
+}
+
+export const provingSessionStorageConfig: {
+  storage: browser.Storage.StorageArea;
+  storageKeys: typeof StorageKeys;
+} = {
+  storage: browser.storage.session,
+  storageKeys: StorageKeys,
+};

--- a/packages/browser-extension/src/state/history.ts
+++ b/packages/browser-extension/src/state/history.ts
@@ -2,6 +2,7 @@ import { Store } from "./store";
 import browser from "webextension-polyfill";
 import { webProverSessionContextManager } from "./webProverSessionContext";
 import { HTTPMethod } from "lib/HttpMethods";
+import { provingSessionStorageConfig } from "./config";
 
 export type BrowsingHistoryItem = {
   url: string;
@@ -24,7 +25,7 @@ export class HistoryContextManager {
   private updateLock: Promise<void> = Promise.resolve();
 
   constructor() {
-    this.store = new Store<History>(browser.storage.session);
+    this.store = new Store<History>(provingSessionStorageConfig.storage);
   }
 
   public static get instance(): HistoryContextManager {
@@ -45,7 +46,9 @@ export class HistoryContextManager {
     this.updateLock = this.updateLock.then(async () => {
       let newItem = item;
       let history =
-        (await historyContextManager.store.get("browsingHistory")) || [];
+        (await historyContextManager.store.get(
+          provingSessionStorageConfig.storageKeys.browsingHistory,
+        )) || [];
       const existingItemIndex = history.findIndex((i) => i.url === item.url);
       // Add cookies and headers and mark eventually as ready
       if (existingItemIndex !== -1) {
@@ -62,7 +65,10 @@ export class HistoryContextManager {
       } else {
         history = [...history, newItem];
       }
-      await historyContextManager.store.set("browsingHistory", history);
+      await historyContextManager.store.set(
+        provingSessionStorageConfig.storageKeys.browsingHistory,
+        history,
+      );
     });
     return this.updateLock;
   }

--- a/packages/browser-extension/src/state/index.ts
+++ b/packages/browser-extension/src/state/index.ts
@@ -1,0 +1,4 @@
+export * from "./config";
+export * from "./history";
+export * from "./zkProvingStatusStore";
+export * from "./webProverSessionContext";

--- a/packages/browser-extension/src/state/webProverSessionContext.ts
+++ b/packages/browser-extension/src/state/webProverSessionContext.ts
@@ -1,10 +1,13 @@
 import { Store } from "./store";
 import browser from "webextension-polyfill";
 import { WebProverSessionConfig } from "../web-proof-commons";
+import { provingSessionStorageConfig } from "./config";
 
 type WebProverSessionContext = {
   webProverSessionConfig: WebProverSessionConfig;
 };
+
+//this belongs to the service worker so it does not use react under the hood
 
 export class WebProverSessionContextManager extends Store<WebProverSessionContext> {
   static #instance: WebProverSessionContextManager;
@@ -16,7 +19,7 @@ export class WebProverSessionContextManager extends Store<WebProverSessionContex
   public static get instance(): WebProverSessionContextManager {
     if (!this.#instance) {
       this.#instance = new WebProverSessionContextManager(
-        browser.storage.session,
+        provingSessionStorageConfig.storage,
       );
     }
     return this.#instance;
@@ -25,11 +28,16 @@ export class WebProverSessionContextManager extends Store<WebProverSessionContex
   async setWebProverSessionConfig(
     config: WebProverSessionConfig,
   ): Promise<void> {
-    await this.set("webProverSessionConfig", config);
+    await this.set(
+      provingSessionStorageConfig.storageKeys.webProverSessionConfig,
+      config,
+    );
   }
 
   async getWebProverSessionConfig(): Promise<WebProverSessionConfig> {
-    return await this.get("webProverSessionConfig");
+    return await this.get(
+      provingSessionStorageConfig.storageKeys.webProverSessionConfig,
+    );
   }
 }
 

--- a/packages/browser-extension/src/state/zkProvingStatusStore.ts
+++ b/packages/browser-extension/src/state/zkProvingStatusStore.ts
@@ -1,6 +1,9 @@
 import { Store } from "./store";
 import browser from "webextension-polyfill";
 import { ZkProvingStatus } from "../web-proof-commons";
+import { provingSessionStorageConfig } from "./config";
+
+//this belongs to the service worker so it does not use react under the hood
 
 export class ZkProvingStatusStore extends Store<{
   zkProvingStatus: ZkProvingStatus;
@@ -13,7 +16,9 @@ export class ZkProvingStatusStore extends Store<{
 
   public static get instance(): ZkProvingStatusStore {
     if (!this.#instance) {
-      this.#instance = new ZkProvingStatusStore(browser.storage.session);
+      this.#instance = new ZkProvingStatusStore(
+        provingSessionStorageConfig.storage,
+      );
     }
     return this.#instance;
   }
@@ -23,11 +28,16 @@ export class ZkProvingStatusStore extends Store<{
   }: {
     status: ZkProvingStatus;
   }): Promise<void> {
-    await this.set("zkProvingStatus", status);
+    await this.set(
+      provingSessionStorageConfig.storageKeys.zkProvingStatus,
+      status,
+    );
   }
 
   async getProvingStatus(): Promise<ZkProvingStatus> {
-    return await this.get("zkProvingStatus");
+    return await this.get(
+      provingSessionStorageConfig.storageKeys.zkProvingStatus,
+    );
   }
 }
 

--- a/packages/playwright-tests/extension.cleanOnClose.spec.ts
+++ b/packages/playwright-tests/extension.cleanOnClose.spec.ts
@@ -1,0 +1,25 @@
+import { test } from "./config";
+import { waitForExtension } from "./pom/extension";
+import { Webpage } from "./pom/webpage";
+test("Cleanup of storage on extension close", async ({ page, context }) => {
+  await test.step("Web-app should open sidepanel via SDK call", async () => {
+    await page.goto("/dapp-new-way");
+    const webpage = new Webpage(page);
+    await webpage.clickButton("Request proof of beeing a wizard");
+    let extension = await waitForExtension(context);
+    const newPage = await extension.redirect();
+    await newPage.waitForURL("/login");
+    await newPage.clickButton("Login");
+    await newPage.waitForURL("/dashboard");
+    await webpage.closeExtension();
+    await webpage.openExtension();
+    extension = await waitForExtension(context);
+    await extension.startPageStepShouldBeCompleted();
+    await extension.expectUrlStepShouldBeCompleted();
+    await webpage.finishZkProof();
+    await webpage.closeExtension();
+    await webpage.openExtension();
+    extension = await waitForExtension(context);
+    await extension.expectSessionStorageToBeCleaned();
+  });
+});

--- a/packages/playwright-tests/pom/extension.ts
+++ b/packages/playwright-tests/pom/extension.ts
@@ -1,0 +1,49 @@
+import { BrowserContext, expect, Page } from "@playwright/test";
+import { Webpage } from "./webpage";
+import { sidePanel } from "../helpers";
+
+export class Extension {
+  constructor(
+    private readonly page: Page,
+    private readonly context: BrowserContext,
+  ) {
+    this.page = page;
+    this.context = context;
+  }
+
+  getRedirectButton() {
+    return this.page.getByRole("button", { name: "Redirect" });
+  }
+
+  async redirect() {
+    const button = this.getRedirectButton();
+    const [newPage] = await Promise.all([
+      this.context.waitForEvent("page"),
+      button.click(),
+    ]);
+    return new Webpage(newPage);
+  }
+  async startPageStepShouldBeCompleted() {
+    const startPageStep = this.page.getByTestId("step-startPage");
+    const status = await startPageStep.getAttribute("data-status");
+    expect(status).toEqual("completed");
+  }
+
+  async expectUrlStepShouldBeCompleted() {
+    const expectUrlStep = this.page.getByTestId("step-expectUrl").nth(0);
+    const status = await expectUrlStep.getAttribute("data-status");
+    expect(status).toEqual("completed");
+  }
+  async expectSessionStorageToBeCleaned() {
+    const sessionStorage = await this.page.evaluate(() =>
+      chrome.storage.session.get(),
+    );
+    expect(sessionStorage).toEqual({});
+  }
+}
+
+export const waitForExtension = async (context: BrowserContext) => {
+  const extensionPage = await sidePanel(context);
+  const extension = new Extension(extensionPage, context);
+  return extension;
+};

--- a/packages/playwright-tests/pom/webpage.ts
+++ b/packages/playwright-tests/pom/webpage.ts
@@ -1,0 +1,46 @@
+import { Page } from "@playwright/test";
+import { ExtensionAction, ZkProvingStatus } from "../web-proof-commons";
+
+const extensionId = "jbchhcgphfokabmfacnkafoeeeppjmpl";
+//Webpage acts as a webpage that uses SDK to communicate with extension
+export class Webpage {
+  constructor(private readonly page: Page) {
+    this.page = page;
+  }
+  async waitForURL(url: string) {
+    await this.page.waitForURL(url);
+  }
+  clickButton(name?: string) {
+    return this.page.getByRole("button", { name }).click();
+  }
+  private sendMessageToExtension(action: string, payload?: object) {
+    return this.page.evaluate(
+      ({
+        action,
+        extensionId,
+        payload,
+      }: {
+        action: string;
+        extensionId: string;
+        payload?: object;
+      }) => {
+        void chrome.runtime.sendMessage(extensionId, {
+          action,
+          ...payload,
+        });
+      },
+      { action, extensionId, payload },
+    );
+  }
+  openExtension() {
+    return this.sendMessageToExtension(ExtensionAction.OpenSidePanel);
+  }
+  closeExtension() {
+    return this.sendMessageToExtension(ExtensionAction.CloseSidePanel);
+  }
+  finishZkProof() {
+    return this.sendMessageToExtension(ExtensionAction.NotifyZkProvingStatus, {
+      payload: { status: ZkProvingStatus.Done },
+    });
+  }
+}

--- a/packages/playwright-tests/web-proof-commons
+++ b/packages/playwright-tests/web-proof-commons
@@ -1,0 +1,1 @@
+../web-proof-commons/

--- a/packages/test-web-app/src/main.tsx
+++ b/packages/test-web-app/src/main.tsx
@@ -58,6 +58,10 @@ const router = createBrowserRouter([
     path: "/email",
     element: <Email />,
   },
+  {
+    path: "/",
+    element: <div></div>,
+  },
 ]);
 
 createRoot(document.getElementById("root")!).render(

--- a/packages/web-proof-commons/types/message.ts
+++ b/packages/web-proof-commons/types/message.ts
@@ -16,6 +16,8 @@ export type ExtensionStep =
 export const enum ExtensionAction {
   RequestWebProof = "RequestWebProof",
   NotifyZkProvingStatus = "NotifyZkProvingStatus",
+  OpenSidePanel = "OpenSidePanel",
+  CloseSidePanel = "CloseSidePanel",
 }
 
 export enum ZkProvingStatus {
@@ -35,6 +37,12 @@ export type MessageToExtension =
       payload: {
         status: ZkProvingStatus;
       };
+    }
+  | {
+      action: ExtensionAction.OpenSidePanel;
+    }
+  | {
+      action: ExtensionAction.CloseSidePanel;
     };
 
 export enum ExtensionMessageType {
@@ -43,6 +51,8 @@ export enum ExtensionMessageType {
   RedirectBack = "RedirectBack",
   TabOpened = "TabOpened",
   ProofProcessing = "ProofProcessing",
+  CleanProvingSessionStorageOnClose = "CleanProvingSessionStorageOnClose",
+  CloseSidePanel = "CloseSidePanel",
 }
 
 export type PresentationJSON = TLSNPresentationJSON;
@@ -89,10 +99,11 @@ export function isEmptyWebProverSessionConfig(
   config: WebProverSessionConfig,
 ): config is EmptyWebProverSessionConfig {
   return (
-    config.notaryUrl === null &&
-    config.wsProxyUrl === null &&
-    config.logoUrl === null &&
-    config.steps.length === 0
+    !config ||
+    (!config.notaryUrl &&
+      !config.wsProxyUrl &&
+      !config.logoUrl &&
+      config.steps.length === 0)
   );
 }
 


### PR DESCRIPTION
As said in title this PR is about ability to close extension progrmatically and make sure that if certain conditions (currently its finish of zk proving, but it can change in future) are met storage is cleaned. There are few things worth mention in this context 

- there is no `sidePanel.close` [api](https://developer.chrome.com/docs/extensions/reference/api/sidePanel#method )
- in light of above only way to handle close is to call `window.close` which has to be called outside of `background.ts` which has no access to window object 
- so there are two hooks added  [for storage clean](packages/browser-extension/src/hooks/useCleanStorageOnClose.ts) and[ for ability to close extension from outside ](https://github.com/vlayer-xyz/vlayer/pull/1940/files#diff-e7c3d03e61be3ba22cfbeb92b1cf9dec4cb041fe8773c85c4b704e25e1f1d7d9). Background listens to the external messages and emit another message that is then consubed by hook 
- whole this is tested in integration manner using playwright. To refactor towards better playwright testing readability POM's for extension and context are crearted so now test is much better to read and work with [here](packages/playwright-tests/extension.cleanOnClose.spec.ts) 
- Approach to storage in extension is refactored so now we have one source of truth about used storage ( probably in future it can be different for different keys) 