### PR TITLE
Rename ambigous secret variable name 

### DIFF
--- a/.github/workflows/deploy_book.yaml
+++ b/.github/workflows/deploy_book.yaml
@@ -54,7 +54,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_BOOK_PROJECT_ID }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -66,7 +66,7 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_BOOK_PROJECT_ID }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
Problem: `VERCEL_PROJECT_ID` is to general as we do have many vercel projects 
Solution: Add new secret `VERCEL_BOOK_PROJECT_ID=prj_jF1ZEKdGzgwqTlSese4fYuOb9KmZ`. 

Caution: Before merge we need to add new secret and after merge remove the old one. 