### PR TITLE
Remove of Transfer-Encoding header redaction in simple-web-proof.

### DIFF
--- a/examples/simple-web-proof/vlayer/src/hooks/useSimpleWebProof.ts
+++ b/examples/simple-web-proof/vlayer/src/hooks/useSimpleWebProof.ts
@@ -49,7 +49,9 @@ const webProofConfig: GetWebProofArgs<Abi, string> = {
         },
         {
           response: {
-            headers_except: [],
+            // response from api.x.com sometimes comes with Transfer-Encoding: Chunked
+            // which needs to be recognised by Prover and cannot be redacted
+            headers_except: ["Transfer-Encoding"],
           },
         },
       ],


### PR DESCRIPTION
This PR resolves bug in simple-web-proof demo reported in [Discord](https://discord.com/channels/1196440523662163999/1348647211235278900/1349020611187572767). It seems that Transfer-Encoding changed on Twitter side, so we need to adjust.