### PR TITLE
Move xvfb-run to workflow in playwright tests.

### DIFF
--- a/.github/workflows/deploy_simple_web_proof.yaml
+++ b/.github/workflows/deploy_simple_web_proof.yaml
@@ -90,7 +90,7 @@ jobs:
           WEB_SERVER_URL: ${{needs.deploy-simple-web-proof.outputs.deployment_url}}
           VLAYER_TMP_DIR: ./artifacts
           PLAYWRIGHT_TEST_X_COM_AUTH_TOKEN: ${{ secrets.PLAYWRIGHT_TEST_X_COM_AUTH_TOKEN }}
-        run: bash/e2e-web-proof-example-test.sh
+        run: xvfb-run bash/e2e-web-proof-example-test.sh
       - name: Handle Playwright Reports
         uses: ./.github/actions/handle-playwright-reports
         if: ${{ !cancelled() }}

--- a/.github/workflows/test_e2e_web_apps_devnet.yaml
+++ b/.github/workflows/test_e2e_web_apps_devnet.yaml
@@ -67,7 +67,7 @@ jobs:
           VLAYER_ENV: dev
           VLAYER_TMP_DIR: ./artifacts
           PLAYWRIGHT_TEST_X_COM_AUTH_TOKEN: ${{ secrets.PLAYWRIGHT_TEST_X_COM_AUTH_TOKEN }}
-        run: bash/e2e-web-apps-test.sh
+        run: xvfb-run bash/e2e-web-apps-test.sh
 
       # Teardown
       - name: Display Logs

--- a/examples/simple-web-proof/vlayer/package.json
+++ b/examples/simple-web-proof/vlayer/package.json
@@ -15,7 +15,7 @@
     "prove:dev": "VLAYER_ENV=dev bun run prove.ts",
     "deploy:testnet": "VLAYER_ENV=testnet bun run deploy.ts",
     "deploy:dev": "VLAYER_ENV=dev bun run deploy.ts",
-    "test-web:dev": "TEST_MODE=headed VLAYER_ENV=dev xvfb-run bun run playwright test",
+    "test-web:dev": "TEST_MODE=headed VLAYER_ENV=dev bun run playwright test",
     "test-web:testnet": "VLAYER_ENV=testnet bun run playwright test",
     "web:dev": "VLAYER_ENV=dev bun run deploy.ts && vite",
     "web:testnet": "VLAYER_ENV=testnet bun run deploy.ts && vite"


### PR DESCRIPTION
Making `test-web:dev` for simple-web-proof work both locally (without xvfb-run) and in CI.