### PR TITLE
fix steps display glitches 

### DIFF
--- a/examples/simple-web-proof/vlayer/src/components/organisms/ProveStep/Container.tsx
+++ b/examples/simple-web-proof/vlayer/src/components/organisms/ProveStep/Container.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
-import { useTwitterAccountProof } from "../../../hooks/useSimpleWebProof";
+import { useSimpleWebProof } from "../../../hooks/useSimpleWebProof";
 import { ProveStepPresentational } from "./Presentational";
 import { useAccount } from "wagmi";
 
@@ -11,7 +11,7 @@ export const ProveStep = () => {
   const modalRef = useRef<HTMLDialogElement>(null);
 
   const { requestWebProof, webProof, callProver, isPending, result, error } =
-    useTwitterAccountProof();
+    useSimpleWebProof();
 
   useEffect(() => {
     if (webProof) {

--- a/examples/simple-web-proof/vlayer/src/hooks/useSimpleWebProof.ts
+++ b/examples/simple-web-proof/vlayer/src/hooks/useSimpleWebProof.ts
@@ -59,7 +59,7 @@ const webProofConfig: GetWebProofArgs<Abi, string> = {
   ],
 };
 
-export const useTwitterAccountProof = () => {
+export const useSimpleWebProof = () => {
   const {
     requestWebProof,
     webProof,


### PR DESCRIPTION
This PR is fixes  
<img width="369" alt="Screenshot 2025-03-17 at 08 08 35" src="https://github.com/user-attachments/assets/f0ae39cd-11fc-499f-975b-c179ec97ebbc" />

missing "/" at the end of url couses `URLPattern` to match every twitter request, and as our extension listens to all request in browser when other tab made request to twietter api it marked first step completed like this. 

Potential thing to do would be to consider filtering request based on tabId and listen only to current tab. 
