### PR TITLE
Add Krzysztof to web team

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -3,6 +3,7 @@ Web:
   - '@akonior'
   - '@wgromniak2'
   - '@pociej'
+  - '@krzysztof-jelski'
 
 Email:
   - '@pik694'


### PR DESCRIPTION
Will Krzysztof's PRs be labeled `web` after that?
Will he be added to reviews when `web-proof team` is added for review?