### PR TITLE
Remove incorrect script from simple-web-proof example

### DIFF
--- a/examples/simple-web-proof/vlayer/package.json
+++ b/examples/simple-web-proof/vlayer/package.json
@@ -6,7 +6,6 @@
     "devnet:down": "docker compose --file docker-compose.devnet.yaml down",
     "lint:solidity": "solhint '../src/**/*.sol' --max-warnings 0 && forge fmt ../src --check",
     "lint-fix:solidity": "solhint '../src/**/*.sol' --fix --noPrompt && forge fmt ../src",
-    "test": "VLAYER_ENV=test bun run prove.ts",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
Incorrect `VLAYER_ENV` and duplication with `prove:testnet`