### PR TITLE
Skip testnet E2E runs on PR commits

### DIFF
--- a/.github/workflows/test_e2e_testnet.yaml
+++ b/.github/workflows/test_e2e_testnet.yaml
@@ -60,7 +60,7 @@ jobs:
     name: Build binaries
     needs: changes
     runs-on: aws-linux-medium
-    if: needs.changes.outputs.workflow-changes == 'true' || (github.event_name != 'pull_request' && needs.changes.outputs.code-changes)
+    if: needs.changes.outputs.workflow-changes == 'true' || (github.event_name != 'pull_request' && needs.changes.outputs.code-changes == 'true')
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Context

We experience OP Sepolia gas price spikes, which drain our testnet ETH reserves.
Detecting spikes is not so easy.

We agreed to try skipping the checks on PRs, while still making sure red PRs cannot be merged (catching errors in the merge queue).

We still run the devnet e2e tests. A situation where OP Sepolia tests are broken and it cannot be caught using anvils is not so frequent.

## What's inside

Added a check that will skip the testnet workflow checks on PR commits - unless the workflow itself is modified.

Adding into one as a start, we also have web-apps testnet workflows to be changed later if this one works as intended.