### PR TITLE
Change approach of skipping E2E-web-apps testnet workflow

### DIFF
--- a/.github/workflows/test_e2e_web_apps_testnet.yaml
+++ b/.github/workflows/test_e2e_web_apps_testnet.yaml
@@ -49,6 +49,7 @@ jobs:
 
   test-e2e-web-apps:
     name: E2E web apps test against testnet
+    needs: changes
     runs-on: aws-linux-medium
     if: needs.changes.outputs.workflow-changes == 'true' || (github.event_name != 'pull_request' && needs.changes.outputs.code-changes == 'true')
     steps:


### PR DESCRIPTION
1. Follow the new way of detecting changes: https://github.com/vlayer-xyz/vlayer/tree/main/.github/docs#running-jobs-only-when-specified-paths-are-changed
2. Skip checks on PRs - same rationale as https://github.com/vlayer-xyz/vlayer/pull/2020