### PR TITLE
Run path-filtered workflows on `main` always

### DIFF
--- a/.github/workflows/test_e2e_devnet.yaml
+++ b/.github/workflows/test_e2e_devnet.yaml
@@ -44,7 +44,7 @@ jobs:
     name: Build binaries
     needs: changes
     runs-on: aws-linux-medium
-    if: needs.changes.outputs.relevant-changes == 'true'
+    if: github.event_name == 'push' || needs.changes.outputs.relevant-changes == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test_e2e_testnet.yaml
+++ b/.github/workflows/test_e2e_testnet.yaml
@@ -60,7 +60,7 @@ jobs:
     name: Build binaries
     needs: changes
     runs-on: aws-linux-medium
-    if: needs.changes.outputs.workflow-changes == 'true' || (github.event_name != 'pull_request' && needs.changes.outputs.code-changes == 'true')
+    if: github.event_name == 'push' || needs.changes.outputs.workflow-changes == 'true' || (github.event_name != 'pull_request' && needs.changes.outputs.code-changes == 'true')
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test_e2e_web_apps_devnet.yaml
+++ b/.github/workflows/test_e2e_web_apps_devnet.yaml
@@ -39,7 +39,7 @@ jobs:
     name: E2E web apps test against devnet
     needs: changes
     runs-on: aws-linux-medium
-    if: needs.changes.outputs.relevant-changes == 'true'
+    if: github.event_name == 'push' || needs.changes.outputs.relevant-changes == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test_e2e_web_apps_testnet.yaml
+++ b/.github/workflows/test_e2e_web_apps_testnet.yaml
@@ -51,7 +51,7 @@ jobs:
     name: E2E web apps test against testnet
     needs: changes
     runs-on: aws-linux-medium
-    if: needs.changes.outputs.workflow-changes == 'true' || (github.event_name != 'pull_request' && needs.changes.outputs.code-changes == 'true')
+    if: github.event_name == 'push' || needs.changes.outputs.workflow-changes == 'true' || (github.event_name != 'pull_request' && needs.changes.outputs.code-changes == 'true')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
We have some path-filters for our jobs, however during the transition to the [new approach](https://github.com/vlayer-xyz/vlayer/tree/main/.github/docs#running-jobs-only-when-specified-paths-are-changed), we lost the functionality of running always on `main` - in case there was a mistake in the path filter.

This PR reconstructs that - we will run all the path-filtered workflows on `main` no matter what.