### PR TITLE
chore: deploy new contracts

### DIFF
--- a/contracts/vlayer/deployed_contracts.json
+++ b/contracts/vlayer/deployed_contracts.json
@@ -6,15 +6,15 @@
     },
     {
       "contractName": "FakeProofVerifier",
-      "contractAddress": "0x1737776d145af312f24f51fff1f0b22f2f7b9082"
+      "contractAddress": "0x913649a62807b2b8144a1e4d41a0e1aee10a3985"
     },
     {
       "contractName": "Groth16ProofVerifier",
-      "contractAddress": "0x39599ac412c14f9635f5b5bf8f4d4c1aeecf6307"
+      "contractAddress": "0x41f78ef6625e119f328ec8a88d54f9da1c227e6a"
     },
     {
       "contractName": "ProofVerifierRouter",
-      "contractAddress": "0xe3443ab33ba5c406056fe10715da20c8619d4137"
+      "contractAddress": "0x17c9793523c11eb0b6da1daed53839146277ab4e"
     }
   ]
 }

--- a/contracts/vlayer/src/TestnetStableDeployment.sol
+++ b/contracts/vlayer/src/TestnetStableDeployment.sol
@@ -12,11 +12,11 @@ library TestnetStableDeployment {
     }
 
     function verifiers() internal pure returns (FakeProofVerifier, Groth16ProofVerifier, ProofVerifierRouter) {
-        FakeProofVerifier fakeProofVerifier = FakeProofVerifier(address(0x1737776D145af312f24F51fFF1F0B22f2f7b9082));
+        FakeProofVerifier fakeProofVerifier = FakeProofVerifier(address(0x913649a62807b2B8144a1E4d41a0E1aEe10a3985));
         Groth16ProofVerifier groth16ProofVerifier =
-            Groth16ProofVerifier(address(0x39599aC412c14F9635f5b5Bf8f4D4C1aeeCF6307));
+            Groth16ProofVerifier(address(0x41f78ef6625E119f328EC8a88D54f9da1c227E6A));
         ProofVerifierRouter proofVerifierRouter =
-            ProofVerifierRouter(address(0xE3443ab33ba5C406056FE10715dA20c8619d4137));
+            ProofVerifierRouter(address(0x17C9793523c11eb0b6Da1DaeD53839146277AB4e));
 
         return (fakeProofVerifier, groth16ProofVerifier, proofVerifierRouter);
     }


### PR DESCRIPTION
New set of contracts introduces `settleChainId` field into `CallAssumptions`.

CC: @LogvinovLeon  @Chmarusso @rzadp 