### PR TITLE
Change WSProxy port out of the ephemeral range

### DIFF
--- a/book/src/advanced/dev-and-production.md
+++ b/book/src/advanced/dev-and-production.md
@@ -78,7 +78,7 @@ docker compose -f <(curl -L https://install.vlayer.xyz/devnet) up -d
 | Prover             | `http://127.0.0.1:3000`        | zkEVM prover for vlayer contracts           |
 | Indexer            | `http://127.0.0.1:3001`        | Storage proof indexer                       |
 | Notary             | `http://127.0.0.1:7047`        | TLS Notary server                           |
-| WebSocket Proxy    | `http://127.0.0.1:55688`       | Proxying websocket connections              |
+| WebSocket Proxy    | `http://127.0.0.1:3003`       | Proxying websocket connections              |
 
 ### Stopping Devnet
 

--- a/book/src/javascript/web-proofs.md
+++ b/book/src/javascript/web-proofs.md
@@ -204,16 +204,16 @@ Currently, the allowed domains are:
 If you'd like to notarize a request for a different domain, you can run your own proxy server. To do this locally run websockify using Docker:
 
 ```bash
-docker run -p 55688:80 jwnmulder/websockify 80 api.x.com:443
+docker run -p 3003:80 jwnmulder/websockify 80 api.x.com:443
 ```
 
-Replace `api.x.com` with the domain you'd like to use. Then, configure your Web Proof provider to use your local WebSocket proxy (running on port 55688):
+Replace `api.x.com` with the domain you'd like to use. Then, configure your Web Proof provider to use your local WebSocket proxy (running on port 3003):
 
 ```ts
 import { createExtensionWebProofProvider } from '@vlayer/sdk/web_proof'
 
 const webProofProvider = createExtensionWebProofProvider({
-  wsProxyUrl: "ws://localhost:55688",
+  wsProxyUrl: "ws://localhost:3003",
 })
 ```
 

--- a/docker/web-proof/docker-compose-release.yaml
+++ b/docker/web-proof/docker-compose-release.yaml
@@ -3,7 +3,7 @@ services:
     image: jwnmulder/websockify
     platform: linux/amd64
     ports:
-      - "55688:80" 
+      - "3003:80" 
     command: "80 lotr-api.online:3011"
       
   notary-server:

--- a/docker/websockify/service.yaml
+++ b/docker/websockify/service.yaml
@@ -4,6 +4,6 @@ services:
     container_name: wsproxy
     platform: linux/amd64
     ports:
-      - "127.0.0.1:55688:80" 
+      - "127.0.0.1:3003:80" 
     command: "80 api.x.com:443"
     

--- a/examples/simple-web-proof/vlayer/.env.dev
+++ b/examples/simple-web-proof/vlayer/.env.dev
@@ -4,5 +4,5 @@ JSON_RPC_URL=http://127.0.0.1:8545
 # this is anvil test private key for testing purpose only
 EXAMPLES_TEST_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 NOTARY_URL=http://127.0.0.1:7047
-WS_PROXY_URL=ws://127.0.0.1:55688
+WS_PROXY_URL=ws://127.0.0.1:3003
 CLIENT_AUTH_MODE=envPrivateKey

--- a/packages/sdk-hooks/src/defaults.ts
+++ b/packages/sdk-hooks/src/defaults.ts
@@ -4,7 +4,7 @@ export const DEFAULT_CONFIG = {
   [ProofEnv.DEV]: {
     proverUrl: "http://localhost:3000",
     notaryUrl: "http://localhost:7047",
-    wsProxyUrl: "ws://localhost:55688",
+    wsProxyUrl: "ws://localhost:3003",
   },
   //for now we use the same urls for testnet and prod
   [ProofEnv.TESTNET]: {

--- a/packages/test-web-app/src/Dapp.tsx
+++ b/packages/test-web-app/src/Dapp.tsx
@@ -45,7 +45,7 @@ function DappWithProfile(profile: string) {
   const webProofProvider = useMemo(() => {
     return createExtensionWebProofProvider({
       notaryUrl: "http://localhost:7047",
-      wsProxyUrl: "ws://localhost:55688",
+      wsProxyUrl: "ws://localhost:3003",
     });
   }, []);
 
@@ -246,7 +246,7 @@ function Dapp() {
   const requestWebProof = useCallback(async () => {
     const provider = createExtensionWebProofProvider({
       notaryUrl: "http://localhost:7047",
-      wsProxyUrl: "ws://localhost:55688",
+      wsProxyUrl: "ws://localhost:3003",
     });
     const loginUrl = `${window.location.origin}${import.meta.env.BASE_URL}login`;
     const profileUrl = `${window.location.origin}${import.meta.env.BASE_URL}profile`;

--- a/packages/test-web-app/src/DappProveWeb.tsx
+++ b/packages/test-web-app/src/DappProveWeb.tsx
@@ -23,7 +23,7 @@ function DappProveWeb() {
   const webProofProvider = useMemo(() => {
     return createExtensionWebProofProvider({
       notaryUrl: "http://localhost:7047",
-      wsProxyUrl: "ws://localhost:55688",
+      wsProxyUrl: "ws://localhost:3003",
     });
   }, []);
 

--- a/packages/test-web-app/src/DappPut.tsx
+++ b/packages/test-web-app/src/DappPut.tsx
@@ -65,7 +65,7 @@ function DappPut() {
     <ProofProvider
       config={{
         notaryUrl: "http://localhost:7047",
-        wsProxyUrl: "ws://localhost:55688",
+        wsProxyUrl: "ws://localhost:3003",
       }}
     >
       <DappPutContent />

--- a/rust/cli/src/commands/update.rs
+++ b/rust/cli/src/commands/update.rs
@@ -433,7 +433,7 @@ mod tests {
             container_name: wsproxy
             platform: linux/amd64
             ports:
-              - "127.0.0.1:55688:80" 
+              - "127.0.0.1:3003:80" 
             command: "80 api.x.com:443"
           notary-server:
             image: ghcr.io/tlsnotary/tlsn/notary-server:v0.1.0-alpha.7


### PR DESCRIPTION
`55688` is in the range of emphemeral / dynamic ports, and should not be used as a fixed port number.

This has caused issues on CI, where we couldn't bind wsproxy to that port because of some ephemeral connection done by the OS.