### PR TITLE
sdk: coerce undefined VLAYER_API_TOKEN to "" if missing in envs

### DIFF
--- a/packages/sdk/src/config/utils/envToConfig.ts
+++ b/packages/sdk/src/config/utils/envToConfig.ts
@@ -14,7 +14,7 @@ export const envToConfig = (config: z.infer<typeof envSchema>) => {
   return {
     ...unchangedKeys,
     privateKey: examplesTestPrivateKey as Hex,
-    token: vlayerApiToken,
+    token: vlayerApiToken ?? "",
     deployConfig: {
       shouldRedeployVerifierRouter: shouldDeployVerifierRouter ?? false,
     },


### PR DESCRIPTION
@wgromniak2 I believe this should unblock you. Sadly I don't see how this can be done automatically using `zod`. Maybe @pociej or @vanruch will have some ideas?