### PR TITLE
Increase chain-proof timeout from 120s to 180s

### DIFF
--- a/rust/services/call/server/src/main.rs
+++ b/rust/services/call/server/src/main.rs
@@ -36,7 +36,7 @@ struct Cli {
     #[arg(long, requires = "chain_proof", value_parser = humantime::parse_duration, default_value = "5s")]
     chain_proof_poll_interval: Option<Duration>,
 
-    #[arg(long, requires = "chain_proof", value_parser = humantime::parse_duration, default_value = "120s")]
+    #[arg(long, requires = "chain_proof", value_parser = humantime::parse_duration, default_value = "180s")]
     chain_proof_timeout: Option<Duration>,
 
     #[arg(long, group = "gas_meter", env)]


### PR DESCRIPTION
In response to spurious timeouts when running simple-time-travel example in testnet in our CI

* https://github.com/vlayer-xyz/vlayer/actions/runs/14062614611/job/39379003932
* https://github.com/vlayer-xyz/vlayer/actions/runs/14079795200/job/39430984243

I'll try bumping the default timeout value from 120s to 180s.

Note that after one or more re-runs, those time-out failures listed above would go away suggesting we need slightly longer timeout value to get rid of most of them.