### PR TITLE
Extract JWT public key location to group vars

### DIFF
--- a/ansible/group_vars/provers.yml
+++ b/ansible/group_vars/provers.yml
@@ -2,3 +2,4 @@
 vlayer_rust_log:
   - info
   - call_engine=debug
+vlayer_jwt_public_key_location: /home/{{ ansible_user }}/.vlayer/jwt.key.pub

--- a/ansible/roles/prover/README.md
+++ b/ansible/roles/prover/README.md
@@ -12,4 +12,5 @@ Installs the vlayer Prover server.
 | `vlayer_proof_type` | Type of proof - `fake` or `groth16`. |
 | `vlayer_bonsai_api_url` | API url for Bonsai, required for real proofs. |
 | `vlayer_bonsai_api_key` | API key for Bonsai, required for real proofs. |
+| `vlayer_jwt_public_key_location` | Where to install the JWT public key file. |
 | `vlayer_rust_log` | An array of log levels for constructing [`RUST_LOG`](https://rust-lang-nursery.github.io/rust-cookbook/development_tools/debugging/config_log.html). |

--- a/ansible/roles/prover/tasks/main.yml
+++ b/ansible/roles/prover/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: Install JWT public key
   ansible.builtin.copy:
     src: jwt.key.pub
-    dest: ~/.vlayer/jwt.key.pub
+    dest: "{{ vlayer_jwt_public_key_location }}"
     mode: '644'
   notify: "Restart vlayer"
 

--- a/ansible/roles/prover/templates/vlayer.service.j2
+++ b/ansible/roles/prover/templates/vlayer.service.j2
@@ -32,9 +32,9 @@ ExecStart=/home/{{ ansible_user }}/.vlayer/bin/call_server
 {% endfor %}
 {% if vlayer_prover_gas_meter_url is defined %}
 {{- ' --gas-meter-url ' ~ vlayer_prover_gas_meter_url }}
-{{- ' --gas-meter-api-key ' ~ vlayer_prover_gas_meter_api_key}}
+{{- ' --gas-meter-api-key ' ~ vlayer_prover_gas_meter_api_key -}}
 {% endif %}
-{{- ' --public-key /home/{{ ansible_user}}/.vlayer/jwt.key.pub' }}
+{{- ' --public-key ' ~ vlayer_jwt_public_key_location }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The location is used in two places, we extract this location to a group variable.

At the same time, added some whitespace fixes to the systemd unit template.