### PR TITLE
[ENGA-458] Use bundled dependency instead of symlink

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -231,7 +231,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VLAYER_BUILD: ${{ needs.build-release.outputs.vlayer_build }}
         run: |
-          PACKAGE_TARBALL_NAME=$(npm pack)
+          ../../bash/replace-workspace-dep.sh packages/sdk @vlayer/sdk
+          ../../bash/replace-workspace-dep.sh packages/sdk @vlayer/web-proof-commons
+
+          PACKAGE_TARBALL_NAME=$(bun pm pack)
           if npm show "@vlayer/sdk@${VLAYER_BUILD}" > /dev/null 2>&1; then
             echo "Version $VLAYER_BUILD already exists. Skipping publish."
           else
@@ -268,7 +271,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VLAYER_BUILD: ${{ needs.build-release.outputs.vlayer_build }}
         run: |
-          PACKAGE_TARBALL_NAME=$(npm pack)
+          ../../bash/replace-workspace-dep.sh packages/sdk-hooks @vlayer/web-proof-commons
+
+          PACKAGE_TARBALL_NAME=$(bun pm pack)
           if npm show "@vlayer/react@${VLAYER_BUILD}" > /dev/null 2>&1; then
             echo "Version $VLAYER_BUILD already exists. Skipping publish."
           else

--- a/bash/lib/e2e.sh
+++ b/bash/lib/e2e.sh
@@ -70,6 +70,7 @@ remappings = [["risc0-ethereum-1.2.0/", "dependencies/risc0-ethereum-1.2.0/"]]
 [js-dependencies]
 "@vlayer/sdk" = { path = "$VLAYER_HOME/packages/sdk" }
 "@vlayer/react" = { path = "$VLAYER_HOME/packages/sdk-hooks" }
+"@vlayer/web-proof-commons" = { path = "$VLAYER_HOME/packages/web-proof-commons" }  
 EOF
 
   cat config.toml

--- a/bash/replace-workspace-dep.sh
+++ b/bash/replace-workspace-dep.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -ueo pipefail
+
+path_to_package=${1:-}
+dependency=${2:-}
+
+if [[ ! -f "$path_to_package/package.json" ]]; then
+  echo "package.json file not found: $path_to_package"
+  exit 1
+fi
+
+dependency_version=$(jq -r '.version' "$(dirname "$path_to_package")/../packages/$dependency/package.json")
+
+if [[ "$dependency_version" == "null" ]]; then
+  echo "Dependency $dependency not found in $path_to_package"
+  exit 1
+fi
+
+if jq -e --arg dep "$dependency" '.dependencies[$dep] == "workspace:*"' "$path_to_package" > /dev/null; then
+  jq --arg dep "$dependency" --arg version "$dependency_version" '
+    .dependencies[$dep] = $version
+  ' "$path_to_package" > tmp.$$.json && mv tmp.$$.json "$path_to_package"
+
+  echo "Replaced workspace:* with $dependency_version for $dependency in $path_to_package"
+else
+  echo "Dependency $dependency is not set to workspace:*. Current version is $dependency_version in $path_to_package"
+fi

--- a/bun.lock
+++ b/bun.lock
@@ -218,6 +218,7 @@
         "@types/chrome": "^0.0.271",
         "@types/ramda": "^0.30.2",
         "@vlayer/extension-hooks": "file:../extension-hooks",
+        "@vlayer/web-proof-commons": "workspace:*",
         "comlink": "^4.4.1",
         "debug": "^4.4.0",
         "fp-ts": "^2.16.9",
@@ -299,6 +300,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@vitejs/plugin-react": "^4.3.2",
+        "@vlayer/web-proof-commons": "workspace:*",
         "base64-js": "^1.5.1",
         "debug": "^4.4.0",
         "dotenv-flow": "^4.1.0",
@@ -327,6 +329,9 @@
     "packages/sdk-hooks": {
       "name": "@vlayer/react",
       "version": "0.1.0",
+      "dependencies": {
+        "@vlayer/web-proof-commons": "workspace:*",
+      },
       "devDependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -395,6 +400,16 @@
       },
       "peerDependencies": {
         "react": "^18.0.0",
+      },
+    },
+    "packages/web-proof-commons": {
+      "name": "@vlayer/web-proof-commons",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
       },
     },
   },
@@ -1064,6 +1079,8 @@
     "@vlayer/react": ["@vlayer/react@workspace:packages/sdk-hooks"],
 
     "@vlayer/sdk": ["@vlayer/sdk@workspace:packages/sdk"],
+
+    "@vlayer/web-proof-commons": ["@vlayer/web-proof-commons@workspace:packages/web-proof-commons"],
 
     "@wagmi/connectors": ["@wagmi/connectors@5.7.8", "", { "dependencies": { "@coinbase/wallet-sdk": "4.3.0", "@metamask/sdk": "0.32.0", "@safe-global/safe-apps-provider": "0.18.5", "@safe-global/safe-apps-sdk": "9.1.0", "@walletconnect/ethereum-provider": "2.17.0", "cbw-sdk": "npm:@coinbase/wallet-sdk@3.9.3" }, "peerDependencies": { "@wagmi/core": "2.16.5", "typescript": ">=5.0.4", "viem": "2.x" }, "optionalPeers": ["typescript"] }, "sha512-idLCc+GQ/GcGgxakEMC7/NSbpD6r1GB07lfDyEjvI5TMzl18pOZhKiqOTENzNi3hDas6ZMvS1xaGwrWufsb1rA=="],
 
@@ -2275,7 +2292,7 @@
 
     "react-error-boundary": ["react-error-boundary@5.0.0", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "react": ">=16.13.1" } }, "sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ=="],
 
-    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
 
@@ -2821,13 +2838,15 @@
 
     "@vlayer/browser-extension/@vlayer/extension-hooks": ["@vlayer/extension-hooks@file:packages/extension-hooks", { "dependencies": { "@types/react": "^18.3.5", "vitest": "^2.1.4" }, "devDependencies": { "@types/bun": "latest", "jsdom": "^25.0.1", "webextension-polyfill": "^0.12.0" }, "peerDependencies": { "react": "^18.3.1", "typescript": "^5.0.0" } }],
 
-    "@vlayer/react/@types/bun": ["@types/bun@1.2.5", "", { "dependencies": { "bun-types": "1.2.5" } }, "sha512-w2OZTzrZTVtbnJew1pdFmgV99H0/L+Pvw+z1P67HaR18MHOzYnTYOi6qzErhK8HyT+DB782ADVPPE92Xu2/Opg=="],
+    "@vlayer/react/@types/bun": ["@types/bun@1.2.6", "", { "dependencies": { "bun-types": "1.2.6" } }, "sha512-fY9CAmTdJH1Llx7rugB0FpgWK2RKuHCs3g2cFDYXUutIy1QGiPQxKkGY8owhfZ4MXWNfxwIbQLChgH5gDsY7vw=="],
 
-    "@vlayer/sdk/@types/bun": ["@types/bun@1.2.5", "", { "dependencies": { "bun-types": "1.2.5" } }, "sha512-w2OZTzrZTVtbnJew1pdFmgV99H0/L+Pvw+z1P67HaR18MHOzYnTYOi6qzErhK8HyT+DB782ADVPPE92Xu2/Opg=="],
+    "@vlayer/sdk/@types/bun": ["@types/bun@1.2.6", "", { "dependencies": { "bun-types": "1.2.6" } }, "sha512-fY9CAmTdJH1Llx7rugB0FpgWK2RKuHCs3g2cFDYXUutIy1QGiPQxKkGY8owhfZ4MXWNfxwIbQLChgH5gDsY7vw=="],
 
     "@vlayer/sdk/ts-pattern": ["ts-pattern@5.6.0", "", {}, "sha512-SL8u60X5+LoEy9tmQHWCdPc2hhb2pKI6I1tU5Jue3v8+iRqZdcT3mWPwKKJy1fMfky6uha82c8ByHAE8PMhKHw=="],
 
     "@vlayer/sdk/viem": ["viem@2.21.0", "", { "dependencies": { "@adraffy/ens-normalize": "1.10.0", "@noble/curves": "1.4.0", "@noble/hashes": "1.4.0", "@scure/bip32": "1.4.0", "@scure/bip39": "1.3.0", "abitype": "1.0.5", "isows": "1.0.4", "webauthn-p256": "0.0.5", "ws": "8.17.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-9g3Gw2nOU6t4bNuoDI5vwVExzIxseU0J7Jjx10gA2RNQVrytIrLxggW++tWEe3w4mnnm/pS1WgZFjQ/QKf/nHw=="],
+
+    "@vlayer/web-proof-commons/@types/bun": ["@types/bun@1.2.6", "", { "dependencies": { "bun-types": "1.2.6" } }, "sha512-fY9CAmTdJH1Llx7rugB0FpgWK2RKuHCs3g2cFDYXUutIy1QGiPQxKkGY8owhfZ4MXWNfxwIbQLChgH5gDsY7vw=="],
 
     "@walletconnect/environment/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
@@ -2937,8 +2956,6 @@
 
     "glob/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 
-    "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
-
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "json-rpc-engine/@metamask/safe-event-emitter": ["@metamask/safe-event-emitter@2.0.0", "", {}, "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q=="],
@@ -2974,6 +2991,8 @@
     "postcss-import/resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
@@ -3123,9 +3142,11 @@
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 
-    "@vlayer/react/@types/bun/bun-types": ["bun-types@1.2.5", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-3oO6LVGGRRKI4kHINx5PIdIgnLRb7l/SprhzqXapmoYkFl5m4j6EvALvbDVuuBFaamB46Ap6HCUxIXNLCGy+tg=="],
+    "@vlayer/browser-extension/@vlayer/extension-hooks/@types/bun": ["@types/bun@1.2.6", "", { "dependencies": { "bun-types": "1.2.6" } }, "sha512-fY9CAmTdJH1Llx7rugB0FpgWK2RKuHCs3g2cFDYXUutIy1QGiPQxKkGY8owhfZ4MXWNfxwIbQLChgH5gDsY7vw=="],
 
-    "@vlayer/sdk/@types/bun/bun-types": ["bun-types@1.2.5", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-3oO6LVGGRRKI4kHINx5PIdIgnLRb7l/SprhzqXapmoYkFl5m4j6EvALvbDVuuBFaamB46Ap6HCUxIXNLCGy+tg=="],
+    "@vlayer/react/@types/bun/bun-types": ["bun-types@1.2.6", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-FbCKyr5KDiPULUzN/nm5oqQs9nXCHD8dVc64BArxJadCvbNzAI6lUWGh9fSJZWeDIRD38ikceBU8Kj/Uh+53oQ=="],
+
+    "@vlayer/sdk/@types/bun/bun-types": ["bun-types@1.2.6", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-FbCKyr5KDiPULUzN/nm5oqQs9nXCHD8dVc64BArxJadCvbNzAI6lUWGh9fSJZWeDIRD38ikceBU8Kj/Uh+53oQ=="],
 
     "@vlayer/sdk/viem/@noble/curves": ["@noble/curves@1.4.0", "", { "dependencies": { "@noble/hashes": "1.4.0" } }, "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg=="],
 
@@ -3140,6 +3161,8 @@
     "@vlayer/sdk/viem/isows": ["isows@1.0.4", "", { "peerDependencies": { "ws": "*" } }, "sha512-hEzjY+x9u9hPmBom9IIAqdJCwNLax+xrPb51vEPpERoFlIxgmZcHzsT5jKG06nvInKOBGvReAVz80Umed5CczQ=="],
 
     "@vlayer/sdk/viem/ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
+
+    "@vlayer/web-proof-commons/@types/bun/bun-types": ["bun-types@1.2.6", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-FbCKyr5KDiPULUzN/nm5oqQs9nXCHD8dVc64BArxJadCvbNzAI6lUWGh9fSJZWeDIRD38ikceBU8Kj/Uh+53oQ=="],
 
     "@walletconnect/ethereum-provider/@walletconnect/sign-client/@walletconnect/core": ["@walletconnect/core@2.17.0", "", { "dependencies": { "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/jsonrpc-ws-connection": "1.0.14", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.0.4", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.17.0", "@walletconnect/utils": "2.17.0", "events": "3.3.0", "lodash.isequal": "4.5.0", "uint8arrays": "3.1.0" } }, "sha512-On+uSaCfWdsMIQsECwWHZBmUXfrnqmv6B8SXRRuTJgd8tUpEvBkLQH4X7XkSm3zW6ozEkQTCagZ2ox2YPn3kbw=="],
 
@@ -3404,6 +3427,8 @@
     "@manypkg/find-root/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "@vlayer/browser-extension/@vlayer/extension-hooks/@types/bun/bun-types": ["bun-types@1.2.6", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-FbCKyr5KDiPULUzN/nm5oqQs9nXCHD8dVc64BArxJadCvbNzAI6lUWGh9fSJZWeDIRD38ikceBU8Kj/Uh+53oQ=="],
 
     "@vlayer/sdk/viem/@scure/bip32/@scure/base": ["@scure/base@1.1.9", "", {}, "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="],
 

--- a/examples/simple-email-proof/vlayer/src/shared/hooks/useEmailProofVerification.ts
+++ b/examples/simple-email-proof/vlayer/src/shared/hooks/useEmailProofVerification.ts
@@ -96,7 +96,9 @@ export const useEmailProofVerification = () => {
       emlContent,
       import.meta.env.VITE_DNS_SERVICE_URL,
     );
+    console.log("email", email);
     await callProver([email, claimerAddr]);
+    console.log("callProver done");
     setCurrentStep(ProofVerificationStep.WAITING_FOR_PROOF);
   };
 

--- a/packages/browser-extension/package.json
+++ b/packages/browser-extension/package.json
@@ -30,6 +30,7 @@
     "webextension-polyfill": "^0.12.0"
   },
   "dependencies": {
+    "@vlayer/web-proof-commons": "workspace:*",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/themes": "^3.1.3",
     "@sentry/react": "^8.54.0",

--- a/packages/browser-extension/src/background.test.ts
+++ b/packages/browser-extension/src/background.test.ts
@@ -2,7 +2,7 @@ import "./background";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { zkProvingStatusStore } from "./state/zkProvingStatusStore.ts";
 import browser from "webextension-polyfill";
-import { ExtensionAction, ZkProvingStatus } from "./web-proof-commons";
+import { ExtensionAction, ZkProvingStatus } from "@vlayer/web-proof-commons";
 
 describe("zk related messaging", () => {
   beforeEach(() => {

--- a/packages/browser-extension/src/background.ts
+++ b/packages/browser-extension/src/background.ts
@@ -10,7 +10,7 @@ import {
   ExtensionMessageType,
   MessageToExtension,
   ZkProvingStatus,
-} from "./web-proof-commons";
+} from "@vlayer/web-proof-commons";
 
 import { WebProverSessionContextManager } from "./state/webProverSessionContext";
 import { match, P } from "ts-pattern";

--- a/packages/browser-extension/src/components/molecules/Step.tsx
+++ b/packages/browser-extension/src/components/molecules/Step.tsx
@@ -7,7 +7,7 @@ import { Separator } from "components/atoms/Separator";
 import { StepActions } from "components/molecules/StepActions/StepActions";
 import styles from "./Step.module.css";
 import { match } from "ts-pattern";
-import { ExtensionStep } from "src/web-proof-commons/types/message.ts";
+import { ExtensionStep } from "@vlayer/web-proof-commons";
 
 type StepProps = {
   label: string;

--- a/packages/browser-extension/src/components/molecules/StepActions/Notarize/RedirectCallout.test.tsx
+++ b/packages/browser-extension/src/components/molecules/StepActions/Notarize/RedirectCallout.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, act, cleanup, within } from "@testing-library/react";
 import { vi, beforeEach, describe, afterEach, expect, it } from "vitest";
 import { RedirectCallout } from "./RedirectCallout";
 import sendMessageToServiceWorker from "lib/sendMessageToServiceWorker";
-import { ExtensionMessageType } from "../../../../web-proof-commons";
+import { ExtensionMessageType } from "@vlayer/web-proof-commons";
 import { DEFAULT_REDIRECT_DELAY_SECONDS } from "constants/defaults";
 
 vi.mock("lib/sendMessageToServiceWorker", () => ({

--- a/packages/browser-extension/src/components/molecules/StepActions/Notarize/RedirectCallout.tsx
+++ b/packages/browser-extension/src/components/molecules/StepActions/Notarize/RedirectCallout.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState, useEffect } from "react";
 import { Callout } from "@radix-ui/themes";
 import { InfoCircledIcon } from "@radix-ui/react-icons";
 import sendMessageToServiceWorker from "lib/sendMessageToServiceWorker";
-import { ExtensionMessageType } from "../../../../web-proof-commons";
+import { ExtensionMessageType } from "@vlayer/web-proof-commons";
 import { DEFAULT_REDIRECT_DELAY_SECONDS } from "constants/defaults";
 import { useInterval } from "usehooks-ts";
 import { AnimatedContainer } from "components/molecules/AnimationContainer";

--- a/packages/browser-extension/src/components/molecules/StepActions/StartPage/StartPageStepActions.tsx
+++ b/packages/browser-extension/src/components/molecules/StepActions/StartPage/StartPageStepActions.tsx
@@ -5,7 +5,7 @@ import { Button } from "components/atoms";
 import browser from "webextension-polyfill";
 import { motion, AnimatePresence } from "framer-motion";
 import sendMessageToServiceWorker from "lib/sendMessageToServiceWorker";
-import { ExtensionMessageType } from "../../../../web-proof-commons";
+import { ExtensionMessageType } from "@vlayer/web-proof-commons";
 
 type StartPageStepActionProps = {
   isVisited: boolean;

--- a/packages/browser-extension/src/components/molecules/StepActions/StepActions.tsx
+++ b/packages/browser-extension/src/components/molecules/StepActions/StepActions.tsx
@@ -5,10 +5,7 @@ import { ExpectUrlStepActions } from "./ExpectUrl";
 import { NotarizeStepActions } from "./Notarize";
 import { StartPageStepActions } from "./StartPage";
 import { StepStatus } from "constants/step";
-import {
-  EXTENSION_STEP,
-  ExtensionStep,
-} from "src/web-proof-commons/types/message.ts";
+import { EXTENSION_STEP, ExtensionStep } from "@vlayer/web-proof-commons";
 
 export const StepActions: React.FC<{
   kind: ExtensionStep;

--- a/packages/browser-extension/src/components/pages/SidePanelContent.tsx
+++ b/packages/browser-extension/src/components/pages/SidePanelContent.tsx
@@ -2,7 +2,7 @@ import { useProvingSessionConfig } from "hooks/useProvingSessionConfig";
 import {
   isEmptyWebProverSessionConfig,
   WebProverSessionConfig,
-} from "../../web-proof-commons";
+} from "@vlayer/web-proof-commons";
 
 import React, { useEffect } from "react";
 import * as Sentry from "@sentry/react";

--- a/packages/browser-extension/src/components/pages/StepPanelContent.test.tsx
+++ b/packages/browser-extension/src/components/pages/StepPanelContent.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { SidePanelContainer } from "./SidePanelContent";
 import * as React from "react";
-import { ZkProvingStatus } from "src/web-proof-commons";
+import { ZkProvingStatus } from "@vlayer/web-proof-commons";
 import { LOADING } from "@vlayer/extension-hooks";
 
 const mocks = vi.hoisted(() => {
@@ -27,7 +27,7 @@ vi.mock("hooks/useSteps", () => ({
   useSteps: mocks.useSteps,
 }));
 
-vi.mock("../../web-proof-commons", () => ({
+vi.mock("@vlayer/web-proof-commons", () => ({
   isEmptyWebProverSessionConfig: mocks.isEmptyWebProverSessionConfig,
   ZkProvingStatus: mocks.ZkProvingStatus,
 }));

--- a/packages/browser-extension/src/constants/step.ts
+++ b/packages/browser-extension/src/constants/step.ts
@@ -1,4 +1,4 @@
-import type { ExtensionStep, UrlPattern } from "src/web-proof-commons";
+import type { ExtensionStep, UrlPattern } from "@vlayer/web-proof-commons";
 
 export enum StepStatus {
   Completed = "completed",

--- a/packages/browser-extension/src/hooks/tlsnProve/redaction/body/tlsn.response.body.ranges.test.ts
+++ b/packages/browser-extension/src/hooks/tlsnProve/redaction/body/tlsn.response.body.ranges.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "vitest";
 import {
   RedactResponseJsonBody,
   RedactResponseJsonBodyExcept,
-} from "src/web-proof-commons";
+} from "@vlayer/web-proof-commons";
 import {
   InvalidJsonError,
   PathNotFoundError,

--- a/packages/browser-extension/src/hooks/tlsnProve/redaction/headers/tlsn.headers.ranges.test.ts
+++ b/packages/browser-extension/src/hooks/tlsnProve/redaction/headers/tlsn.headers.ranges.test.ts
@@ -1,4 +1,4 @@
-import { RedactResponseHeaders } from "src/web-proof-commons";
+import { RedactResponseHeaders } from "@vlayer/web-proof-commons";
 import { describe, expect, test } from "vitest";
 import {
   getHeaderRange,

--- a/packages/browser-extension/src/hooks/tlsnProve/redaction/redact.test.ts
+++ b/packages/browser-extension/src/hooks/tlsnProve/redaction/redact.test.ts
@@ -1,4 +1,4 @@
-import { RedactionConfig } from "src/web-proof-commons";
+import { RedactionConfig } from "@vlayer/web-proof-commons";
 import { calcRedactionRanges, calcRevealRanges } from "./redact";
 import { describe, expect, test } from "vitest";
 import {

--- a/packages/browser-extension/src/hooks/tlsnProve/redaction/redact.ts
+++ b/packages/browser-extension/src/hooks/tlsnProve/redaction/redact.ts
@@ -2,7 +2,7 @@ import { Commit } from "tlsn-wasm";
 import { match, P } from "ts-pattern";
 import { calculateRequestRanges } from "./tlsn.request.ranges";
 import { calculateResponseRanges } from "./tlsn.response.ranges";
-import { RedactionConfig } from "src/web-proof-commons";
+import { RedactionConfig } from "@vlayer/web-proof-commons";
 import { CommitData } from "tlsn-js/src/types";
 import {
   InvalidRangeError,

--- a/packages/browser-extension/src/hooks/tlsnProve/redaction/tlsn.request.ranges.ts
+++ b/packages/browser-extension/src/hooks/tlsnProve/redaction/tlsn.request.ranges.ts
@@ -3,7 +3,7 @@ import {
   RedactRequestHeadersExcept,
   RedactRequestUrlQueryParam,
   RedactRequestUrlQueryParamExcept,
-} from "src/web-proof-commons";
+} from "@vlayer/web-proof-commons";
 import { CommitData } from "tlsn-js/src/types";
 import { match, P } from "ts-pattern";
 import {

--- a/packages/browser-extension/src/hooks/tlsnProve/redaction/tlsn.response.ranges.ts
+++ b/packages/browser-extension/src/hooks/tlsnProve/redaction/tlsn.response.ranges.ts
@@ -3,7 +3,7 @@ import {
   RedactResponseHeadersExcept,
   RedactResponseJsonBody,
   RedactResponseJsonBodyExcept,
-} from "src/web-proof-commons";
+} from "@vlayer/web-proof-commons";
 import { CommitData } from "tlsn-js/src/types";
 import { match, P } from "ts-pattern";
 import { getStringPaths } from "./utils";

--- a/packages/browser-extension/src/hooks/tlsnProve/tlsnProve.ts
+++ b/packages/browser-extension/src/hooks/tlsnProve/tlsnProve.ts
@@ -3,7 +3,7 @@ import { wrap } from "comlink";
 import { Prover as TProver, Presentation as TPresentation } from "tlsn-js";
 import type { PresentationJSON } from "tlsn-js/src/types";
 import { Reveal, Method } from "tlsn-wasm";
-import { type RedactionConfig } from "../../web-proof-commons";
+import { type RedactionConfig } from "@vlayer/web-proof-commons";
 import { redact } from "./redaction/redact";
 import { HTTPMethod } from "lib/HttpMethods";
 import debug from "debug";

--- a/packages/browser-extension/src/hooks/useCleanStorageOnClose.ts
+++ b/packages/browser-extension/src/hooks/useCleanStorageOnClose.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { provingSessionStorageConfig } from "src/state/config";
-import { ExtensionMessageType } from "src/web-proof-commons";
+import { ExtensionMessageType } from "@vlayer/web-proof-commons";
 import browser from "webextension-polyfill";
 
 // Listen to clean storage request where window is available

--- a/packages/browser-extension/src/hooks/useCloseSidePanelOnRequest.ts
+++ b/packages/browser-extension/src/hooks/useCloseSidePanelOnRequest.ts
@@ -1,4 +1,4 @@
-import { ExtensionMessageType } from "src/web-proof-commons";
+import { ExtensionMessageType } from "@vlayer/web-proof-commons";
 import browser from "webextension-polyfill";
 import { useEffect } from "react";
 

--- a/packages/browser-extension/src/hooks/useProvingSessionConfig.ts
+++ b/packages/browser-extension/src/hooks/useProvingSessionConfig.ts
@@ -1,5 +1,5 @@
 import { useSessionStorage } from "@vlayer/extension-hooks";
-import { WebProverSessionConfig } from "../web-proof-commons";
+import { WebProverSessionConfig } from "@vlayer/web-proof-commons";
 
 export const useProvingSessionConfig = () => {
   const initialValue = {

--- a/packages/browser-extension/src/hooks/useSteps.test.data.ts
+++ b/packages/browser-extension/src/hooks/useSteps.test.data.ts
@@ -1,6 +1,6 @@
 import { BrowsingHistoryItem } from "../state/history.ts";
 import { StepStatus } from "constants/step.ts";
-import { WebProofStep } from "../web-proof-commons";
+import { WebProofStep } from "@vlayer/web-proof-commons";
 
 export const steps = [
   {

--- a/packages/browser-extension/src/hooks/useSteps.ts
+++ b/packages/browser-extension/src/hooks/useSteps.ts
@@ -1,6 +1,6 @@
 import { BrowsingHistoryItem } from "../state/history";
 import { Step, StepStatus } from "../constants";
-import { UrlPattern, WebProofStep } from "../web-proof-commons";
+import { UrlPattern, WebProofStep } from "@vlayer/web-proof-commons";
 import { useProvingSessionConfig } from "hooks/useProvingSessionConfig.ts";
 import { useBrowsingHistory } from "hooks/useBrowsingHistory.ts";
 import { useZkProvingState } from "./useZkProvingState";

--- a/packages/browser-extension/src/hooks/useTlsnProver.tsx
+++ b/packages/browser-extension/src/hooks/useTlsnProver.tsx
@@ -11,7 +11,7 @@ import {
   isDefined,
   ExtensionMessageType,
   getRedactionConfig,
-} from "../web-proof-commons";
+} from "@vlayer/web-proof-commons";
 import { useProvingSessionConfig } from "./useProvingSessionConfig";
 import { useProvenUrl } from "./useProvenUrl";
 import { useTrackHistory } from "hooks/useTrackHistory";

--- a/packages/browser-extension/src/hooks/useZkProvingState.test.ts
+++ b/packages/browser-extension/src/hooks/useZkProvingState.test.ts
@@ -1,6 +1,6 @@
 import { InvalidZkProvingStatus, useZkProvingState } from "./useZkProvingState";
 import { describe, expect, it, vi } from "vitest";
-import { ZkProvingStatus } from "../web-proof-commons";
+import { ZkProvingStatus } from "@vlayer/web-proof-commons";
 import { renderHook } from "@testing-library/react";
 import { LOADING } from "@vlayer/extension-hooks";
 

--- a/packages/browser-extension/src/hooks/useZkProvingState.ts
+++ b/packages/browser-extension/src/hooks/useZkProvingState.ts
@@ -1,5 +1,5 @@
 import { useSessionStorage, LOADING } from "@vlayer/extension-hooks";
-import { ZkProvingStatus } from "../web-proof-commons";
+import { ZkProvingStatus } from "@vlayer/web-proof-commons";
 
 export function isValidZkProvingStatus(
   value: unknown,

--- a/packages/browser-extension/src/lib/sendMessageToServiceWorker.ts
+++ b/packages/browser-extension/src/lib/sendMessageToServiceWorker.ts
@@ -1,5 +1,5 @@
 import browser from "webextension-polyfill";
-import type { ExtensionMessage } from "../web-proof-commons";
+import type { ExtensionMessage } from "@vlayer/web-proof-commons";
 
 async function sendMessageToServiceWorker(message: ExtensionMessage) {
   await browser.runtime.sendMessage(message);

--- a/packages/browser-extension/src/state/webProverSessionContext.ts
+++ b/packages/browser-extension/src/state/webProverSessionContext.ts
@@ -1,6 +1,6 @@
 import { Store } from "./store";
 import browser from "webextension-polyfill";
-import { WebProverSessionConfig } from "../web-proof-commons";
+import { WebProverSessionConfig } from "@vlayer/web-proof-commons";
 import { provingSessionStorageConfig } from "./config";
 
 type WebProverSessionContext = {

--- a/packages/browser-extension/src/state/zkProvingStatusStore.ts
+++ b/packages/browser-extension/src/state/zkProvingStatusStore.ts
@@ -1,6 +1,6 @@
 import { Store } from "./store";
 import browser from "webextension-polyfill";
-import { ZkProvingStatus } from "../web-proof-commons";
+import { ZkProvingStatus } from "@vlayer/web-proof-commons";
 import { provingSessionStorageConfig } from "./config";
 
 //this belongs to the service worker so it does not use react under the hood

--- a/packages/browser-extension/src/web-proof-commons
+++ b/packages/browser-extension/src/web-proof-commons
@@ -1,1 +1,0 @@
-../../web-proof-commons

--- a/packages/browser-extension/vitest/setup.ts
+++ b/packages/browser-extension/vitest/setup.ts
@@ -1,5 +1,5 @@
 import { vi } from "vitest";
-import { MessageToExtension } from "../src/web-proof-commons";
+import { MessageToExtension } from "@vlayer/web-proof-commons";
 import "@testing-library/jest-dom/vitest";
 
 const mockStore = function () {

--- a/packages/playwright-tests/pom/webpage.ts
+++ b/packages/playwright-tests/pom/webpage.ts
@@ -1,5 +1,4 @@
 import { BrowserContext, Page } from "@playwright/test";
-import { ExtensionAction, ZkProvingStatus } from "../web-proof-commons";
 import { extensionId } from "../config";
 //Webpage acts as a webpage that uses SDK to communicate with extension
 export class Webpage {
@@ -34,14 +33,14 @@ export class Webpage {
   }
 
   openExtension() {
-    return this.sendMessageToExtension(ExtensionAction.OpenSidePanel);
+    return this.sendMessageToExtension("OpenSidePanel");
   }
   closeExtension() {
-    return this.sendMessageToExtension(ExtensionAction.CloseSidePanel);
+    return this.sendMessageToExtension("CloseSidePanel");
   }
   finishZkProof() {
-    return this.sendMessageToExtension(ExtensionAction.NotifyZkProvingStatus, {
-      payload: { status: ZkProvingStatus.Done },
+    return this.sendMessageToExtension("NotifyZkProvingStatus", {
+      payload: { status: "Done" },
     });
   }
 }

--- a/packages/playwright-tests/web-proof-commons
+++ b/packages/playwright-tests/web-proof-commons
@@ -1,1 +1,0 @@
-../web-proof-commons/

--- a/packages/sdk-hooks/package.json
+++ b/packages/sdk-hooks/package.json
@@ -14,6 +14,12 @@
     "vitest": "^2.1.8",
     "vitest-fetch-mock": "^0.4.2"
   },
+  "dependencies": {
+    "@vlayer/web-proof-commons": "workspace:*"
+  },
+  "bundleDependencies": [
+    "@vlayer/web-proof-commons"
+  ],
   "peerDependencies": {
     "typescript": "^5.0.0",
     "react": "^18 || ^19",

--- a/packages/sdk-hooks/src/useWebproof/extension.mock.ts
+++ b/packages/sdk-hooks/src/useWebproof/extension.mock.ts
@@ -1,10 +1,10 @@
-import type { PresentationJSON } from "@vlayer/sdk";
+import type { WebProofProvider } from "@vlayer/sdk";
 
 import {
+  type PresentationJSON,
   ExtensionMessageType,
   type ExtensionMessage,
-  type WebProofProvider,
-} from "@vlayer/sdk";
+} from "@vlayer/web-proof-commons";
 
 export class MockExtensionWebProofProvider implements WebProofProvider {
   private listeners: Partial<

--- a/packages/sdk-hooks/src/useWebproof/useWebProof.ts
+++ b/packages/sdk-hooks/src/useWebproof/useWebProof.ts
@@ -2,7 +2,9 @@ import { useEffect, useState } from "react";
 import { type Abi, type ContractFunctionName } from "viem";
 import { useProofContext } from "../context";
 import { WebProofRequestStatus } from "../types";
-import { ExtensionMessageType, type WebProofConfig } from "@vlayer/sdk";
+import { ExtensionMessageType } from "@vlayer/web-proof-commons";
+
+import { type WebProofConfig } from "@vlayer/sdk";
 
 export const useWebProof = (
   webProofRequest: WebProofConfig<Abi, ContractFunctionName>,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -30,10 +30,14 @@
     "vitest": "^2.1.1",
     "vitest-fetch-mock": "^0.4.1"
   },
+  "bundleDependencies": [
+    "@vlayer/web-proof-commons"
+  ],
   "peerDependencies": {
     "typescript": "^5.6.3"
   },
   "dependencies": {
+    "@vlayer/web-proof-commons": "workspace:*",
     "@vitejs/plugin-react": "^4.3.2",
     "base64-js": "^1.5.1",
     "debug": "^4.4.0",

--- a/packages/sdk/src/api/lib/client.test.ts
+++ b/packages/sdk/src/api/lib/client.test.ts
@@ -11,7 +11,7 @@ import {
 import { createExtensionWebProofProvider } from "../webProof";
 import { createVlayerClient } from "./client";
 import { type BrandedHash, type VlayerClient } from "types/vlayer";
-import { ZkProvingStatus } from "../../web-proof-commons";
+import { ZkProvingStatus } from "@vlayer/web-proof-commons";
 import createFetchMock from "vitest-fetch-mock";
 
 declare const global: {

--- a/packages/sdk/src/api/lib/client.ts
+++ b/packages/sdk/src/api/lib/client.ts
@@ -14,7 +14,7 @@ import {
   ExtensionMessageType,
   ZkProvingStatus,
   type PresentationJSON,
-} from "../../web-proof-commons";
+} from "@vlayer/web-proof-commons";
 import { type ContractFunctionArgsWithout } from "types/viem";
 import { type ProveArgs } from "types/vlayer";
 

--- a/packages/sdk/src/api/lib/types/ethereum.ts
+++ b/packages/sdk/src/api/lib/types/ethereum.ts
@@ -1,5 +1,5 @@
 import { type Abi, type Address, type Hex } from "viem";
-import { type Branded } from "../../../web-proof-commons";
+import { type Branded } from "@vlayer/web-proof-commons";
 
 export type Bytecode = {
   object: Hex;

--- a/packages/sdk/src/api/lib/types/vlayer.ts
+++ b/packages/sdk/src/api/lib/types/vlayer.ts
@@ -1,4 +1,4 @@
-import { type Branded } from "../../../web-proof-commons/utils";
+import { type Branded } from "@vlayer/web-proof-commons";
 import {
   type Abi,
   type AbiStateMutability,

--- a/packages/sdk/src/api/lib/types/webProofProvider.ts
+++ b/packages/sdk/src/api/lib/types/webProofProvider.ts
@@ -6,7 +6,7 @@ import {
   type ExtensionMessage,
   type WebProofStep,
   type ZkProvingStatus,
-} from "../../../web-proof-commons";
+} from "@vlayer/web-proof-commons";
 
 export type WebProofRequestInput = {
   logoUrl: string;

--- a/packages/sdk/src/api/webProof/providers/extension.test.ts
+++ b/packages/sdk/src/api/webProof/providers/extension.test.ts
@@ -1,7 +1,7 @@
 import { createExtensionWebProofProvider } from "./extension";
 import { describe, it, expect, vi } from "vitest";
 import { expectUrl, startPage, notarize } from "../steps";
-import { StepValidationError } from "../../../web-proof-commons";
+import { StepValidationError } from "@vlayer/web-proof-commons";
 
 const chrome = {
   runtime: {

--- a/packages/sdk/src/api/webProof/providers/extension.ts
+++ b/packages/sdk/src/api/webProof/providers/extension.ts
@@ -16,7 +16,7 @@ import {
   type RedactionConfig,
   RedactionItemsArray,
   type MessageToExtension,
-} from "../../../web-proof-commons";
+} from "@vlayer/web-proof-commons";
 
 import debug from "debug";
 

--- a/packages/sdk/src/api/webProof/steps/expectUrl.ts
+++ b/packages/sdk/src/api/webProof/steps/expectUrl.ts
@@ -1,7 +1,7 @@
 import {
   EXTENSION_STEP,
   type WebProofStepExpectUrl,
-} from "../../../web-proof-commons";
+} from "@vlayer/web-proof-commons";
 
 export const expectUrl = (url: string, label: string) => {
   return {

--- a/packages/sdk/src/api/webProof/steps/notarize.ts
+++ b/packages/sdk/src/api/webProof/steps/notarize.ts
@@ -2,7 +2,7 @@ import {
   EXTENSION_STEP,
   type WebProofStepNotarize,
   type RedactionConfig,
-} from "../../../web-proof-commons";
+} from "@vlayer/web-proof-commons";
 
 export const notarize = (
   url: string,

--- a/packages/sdk/src/api/webProof/steps/startPage.ts
+++ b/packages/sdk/src/api/webProof/steps/startPage.ts
@@ -1,7 +1,7 @@
 import {
   EXTENSION_STEP,
   type WebProofStepStartPage,
-} from "../../../web-proof-commons";
+} from "@vlayer/web-proof-commons";
 
 export const startPage = (url: string, label: string) => {
   return {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -4,5 +4,5 @@ export { createExtensionWebProofProvider } from "./api/webProof/providers/extens
 
 export * from "./api/lib/types";
 
-export * from "./web-proof-commons/utils";
-export * from "./web-proof-commons/types/message";
+export * from "@vlayer/web-proof-commons/utils";
+export * from "@vlayer/web-proof-commons/types/message";

--- a/packages/sdk/src/web-proof-commons
+++ b/packages/sdk/src/web-proof-commons
@@ -1,1 +1,0 @@
-../../web-proof-commons

--- a/packages/web-proof-commons/package.json
+++ b/packages/web-proof-commons/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vlayer/web-proof-commons",
+  "module": "index.ts",
+  "type": "module",
+  "version": "0.1.0",
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/web-proof-commons/tsconfig.base.json
+++ b/packages/web-proof-commons/tsconfig.base.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./",
+    "outDir": "./dist",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "jsx": "react-jsx",
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "downlevelIteration": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
+    "baseUrl": "./",
+    "types": [
+      "bun"
+    ]
+  }, 
+  "include": [
+    ".",
+  ]
+}

--- a/packages/web-proof-commons/tsconfig.json
+++ b/packages/web-proof-commons/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.base.json",
+  "tsc-alias" : {
+    "resolveFullPaths": true
+  }
+}


### PR DESCRIPTION
No more symlink for `web-proof-commons`. 

Instead bundle dependency is in use. However due to another issue in bun : https://github.com/oven-sh/bun/issues/18518 
I added as temporary workarround script that replacing `workspace:*` dependency by actual value. 