### PR TITLE
Use re-usable Cargo target dirs in more workflows

### DIFF
--- a/.github/workflows/test_e2e_devnet.yaml
+++ b/.github/workflows/test_e2e_devnet.yaml
@@ -83,7 +83,7 @@ jobs:
         run: |
           cargo build --bin vlayer --bin call_server --bin chain_server --bin worker --bin dns_server --features jwt
           mkdir target_debug
-          mv target/debug/{vlayer,call_server,chain_server,worker,dns_server} target_debug/
+          mv ${CARGO_TARGET_DIR}/debug/{vlayer,call_server,chain_server,worker,dns_server} target_debug/
 
       - name: Push binaries
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0

--- a/.github/workflows/test_e2e_testnet.yaml
+++ b/.github/workflows/test_e2e_testnet.yaml
@@ -100,7 +100,7 @@ jobs:
         run: |
           cargo build --bin vlayer --bin call_server --bin chain_server --bin worker --bin dns_server --features jwt
           mkdir target_debug
-          mv target/debug/{vlayer,call_server,chain_server,worker,dns_server} target_debug/
+          mv ${CARGO_TARGET_DIR}/debug/{vlayer,call_server,chain_server,worker,dns_server} target_debug/
 
       - name: Push binaries
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0

--- a/.github/workflows/test_e2e_web_apps_testnet.yaml
+++ b/.github/workflows/test_e2e_web_apps_testnet.yaml
@@ -90,7 +90,7 @@ jobs:
         run: |
           cargo build --bin vlayer --bin call_server --bin chain_server --bin worker --bin dns_server --features jwt
           mkdir target_debug
-          mv target/debug/{vlayer,call_server,chain_server,worker,dns_server} target_debug/
+          mv ${CARGO_TARGET_DIR}/debug/{vlayer,call_server,chain_server,worker,dns_server} target_debug/
 
       - name: Push binaries
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0


### PR DESCRIPTION
Continuation of https://github.com/vlayer-xyz/vlayer/pull/2082

Try to use it in more places.

It seemed to just work in combination with `RISC0_USE_DOCKER=1`.

The target names are already in line with not-yet-merged https://github.com/vlayer-xyz/vlayer/pull/2095