### PR TITLE
Add delay before open/close messages [ENGA-553]

### DIFF
--- a/packages/playwright-tests/extension.cleanOnClose.spec.ts
+++ b/packages/playwright-tests/extension.cleanOnClose.spec.ts
@@ -3,25 +3,32 @@ import { waitForExtension } from "./pom/extension";
 import { Webpage } from "./pom/webpage";
 import { dappUrl, dashboardUrl, loginUrl } from "./urls";
 
+// For now to remove flakyness of tests we need to delay messages
+const delayMessage = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+};
 test("Cleanup of storage on extension close", async ({ page, context }) => {
-  await test.step("Web-app should open sidepanel via SDK call", async () => {
-    await page.goto(dappUrl);
-    const webpage = new Webpage(page, context);
-    await webpage.clickButton("Request proof of beeing a wizard");
-    let extension = await waitForExtension(context);
-    const newPage = await extension.redirect();
-    await newPage.waitForURL(loginUrl);
-    await newPage.clickButton("Login");
-    await newPage.waitForURL(dashboardUrl);
-    await webpage.closeExtension();
-    await webpage.openExtension();
-    extension = await waitForExtension(context);
-    await extension.startPageStepShouldBeCompleted();
-    await extension.expectUrlStepShouldBeCompleted();
-    await webpage.finishZkProof();
-    await webpage.closeExtension();
-    await webpage.openExtension();
-    extension = await waitForExtension(context);
-    await extension.expectSessionStorageToBeCleaned();
-  });
+  await page.goto(dappUrl);
+  const webpage = new Webpage(page, context);
+  await webpage.clickButton("Request proof of beeing a wizard");
+  let extension = await waitForExtension(context);
+  const newPage = await extension.redirect();
+  await newPage.waitForURL(loginUrl);
+  await newPage.clickButton("Login");
+  await newPage.waitForURL(dashboardUrl);
+  // close and reopen 
+  await webpage.closeExtension();
+  await delayMessage();
+  await webpage.openExtension();
+  extension = await waitForExtension(context);
+  // make sure storage is not cleaned as steps are rendered properly
+  await extension.startPageStepShouldBeCompleted();
+  await extension.expectUrlStepShouldBeCompleted();
+  await webpage.finishZkProof();
+  // close and reopen after finish flow now session storage is expected to be cleaned
+  await webpage.closeExtension();
+  await delayMessage();
+  await webpage.openExtension();
+  extension = await waitForExtension(context);
+  await extension.expectSessionStorageToBeCleaned();
 });


### PR DESCRIPTION
This is a temporary solution for flaky Playwright tests. In real-world scenarios, we rarely send messages one after another, so this should be acceptable for now. This is especially true considering that a deeper solution relates to two existing tickets: [ENGA-562](https://www.notion.so/vlayer/Make-sure-we-properly-handle-async-listeners-1cafdaece267804eba30fc979e288a52?pvs=4) and [ENGA-561](https://www.notion.so/vlayer/Ensure-extension-sdk-extension-messaging-1cafdaece26780bc948bd087c342ac21?pvs=4) and can be done in when working on [ENGA-410](https://www.notion.so/vlayer/Create-typesafe-wrapper-on-browser-runtime-messaging-api-1aefdaece267801eb5e5e754574551e5?pvs=4)