### PR TITLE
[DRAFT] Add a discord alert on failed release workflows

### DIFF
--- a/.github/workflows/alert_failed_release.yaml
+++ b/.github/workflows/alert_failed_release.yaml
@@ -19,7 +19,7 @@ jobs:
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
         run: |
           MESSAGE="🔴 Release failed. Workflow: **${WORKFLOW_NAME}**.\n<${RUN_URL}>"
-          curl -H "Content-Type: application/json" \
+          curl --fail -H "Content-Type: application/json" \
                -X POST \
                -d "{\"content\": \"$MESSAGE\"}" \
                "$DISCORD_WEBHOOK"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced an automated alert system that sends notifications via Discord when any key release processes encounter issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->