### PR TITLE
Clean up obsolete chain worker configuration options

### DIFF
--- a/ansible/chain_service.yml
+++ b/ansible/chain_service.yml
@@ -57,6 +57,5 @@
         chain_worker_max_back_propagation_blocks: "{{ item.chain_worker_max_back_propagation_blocks }}"
         chain_worker_max_head_blocks: "{{ item.chain_worker_max_head_blocks }}"
         chain_worker_confirmations: "{{ item.chain_worker_confirmations }}"
-        chain_worker_risc0_dev_mode: "{{ item.chain_worker_risc0_dev_mode }}"
       loop: "{{ chain_workers }}"
       no_log: true

--- a/ansible/host_vars/prod_fake_chain_service.yml
+++ b/ansible/host_vars/prod_fake_chain_service.yml
@@ -10,7 +10,6 @@ chain_workers:
     chain_worker_max_back_propagation_blocks: 10
     chain_worker_max_head_blocks: 10
     chain_worker_confirmations: 8
-    chain_worker_risc0_dev_mode: 1
   - chain_worker_identifier: base-sepolia
     chain_worker_rpc_url: https://omniscient-flashy-frog.base-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}
     chain_worker_chain_id: 84532
@@ -18,7 +17,6 @@ chain_workers:
     chain_worker_max_back_propagation_blocks: 10
     chain_worker_max_head_blocks: 10
     chain_worker_confirmations: 8
-    chain_worker_risc0_dev_mode: 1
   - chain_worker_identifier: optimism-sepolia
     chain_worker_rpc_url: https://omniscient-flashy-frog.optimism-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}
     chain_worker_chain_id: 11155420
@@ -26,4 +24,3 @@ chain_workers:
     chain_worker_max_back_propagation_blocks: 10
     chain_worker_max_head_blocks: 10
     chain_worker_confirmations: 8
-    chain_worker_risc0_dev_mode: 1

--- a/ansible/roles/chain_worker/README.md
+++ b/ansible/roles/chain_worker/README.md
@@ -17,4 +17,3 @@ Typically, more than 1 chain worker would be installed on a single machine.
 | `chain_worker_max_back_propagation_blocks` | Maximum number of historical blocks prepended in a single batch |
 | `chain_worker_max_head_blocks` | Maximum number of new blocks appended in a single batch |
 | `chain_worker_confirmations` | Minimum number of confirmations required for a block to be appended |
-| `chain_worker_risc0_dev_mode` | Whether to enable [risc0 dev mode](https://dev.risczero.com/api/generating-proofs/dev-mode) |


### PR DESCRIPTION
A follow-up to https://github.com/vlayer-xyz/vlayer/pull/1789

`Environment=RISC0_DEV_MODE={{ chain_worker_risc0_dev_mode }}` has been removed from the template, but the now-obsolete config options was not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed an obsolete development mode configuration option from chain worker settings, streamlining operational configurations.
- **Documentation**
	- Updated worker role documentation by eliminating references to the deprecated setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->