### PR TITLE
Make sure version commit sha is no longer than 7 chars in vlayer version.

### DIFF
--- a/rust/version/src/lib.rs
+++ b/rust/version/src/lib.rs
@@ -4,7 +4,7 @@ pub fn version() -> String {
         env!("CARGO_PKG_VERSION"),
         env!("VLAYER_RELEASE"),
         build_date.as_str(),
-        env!("VERGEN_GIT_SHA"),
+        &env!("VERGEN_GIT_SHA")[..7],
     ]
     .join("-")
 }


### PR DESCRIPTION
Hotfix for issue: https://discord.com/channels/1196440523662163999/1198880822879596617/1357733355075932180

Proper solution to be found next week.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated version display now presents a concise commit identifier for a cleaner, more user-friendly version output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->