### PR TITLE
[ENGA-158]Improve contract building

### DIFF
--- a/bash/lib/build-contracts.sh
+++ b/bash/lib/build-contracts.sh
@@ -1,4 +1,5 @@
 source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/examples.sh"
 
 function build_contracts_in() {
     echo "::group::Building ${1} contracts"
@@ -20,7 +21,7 @@ function build_example_contracts() {
     echo "::endgroup::Building ${1} example contracts"
 }
 
-function build_contracts() {
+function build_core_contracts() {
   echo "::group::Building contracts"
 
   build_contracts_in vlayer
@@ -28,4 +29,13 @@ function build_contracts() {
   generate_ts_bindings
 
   echo "::endgroup::Building contracts"
+}
+
+function build_contracts() {
+  build_contracts_in vlayer
+  build_contracts_in fixtures
+  for example in $(get_examples); do
+    build_example_contracts $example
+  done
+  generate_ts_bindings
 }

--- a/bash/lib/build-packages.sh
+++ b/bash/lib/build-packages.sh
@@ -24,8 +24,6 @@ function build_react_sdk_with_deps() {
 
   bun install --frozen-lockfile
 
-  build_contracts
-
   build_sdk
   build_sdk_hooks
 

--- a/bash/verifiers_management/deploy-verifiers.sh
+++ b/bash/verifiers_management/deploy-verifiers.sh
@@ -32,6 +32,6 @@ function verify_deployment_is_stable_across_networks(){
 cd "${CONTRACTS_DIR}"
 
 cleanup
-build_contracts
+build_core_contracts
 deploy_contracts
 verify_deployment_is_stable_across_networks


### PR DESCRIPTION
While not ideal yet this provide : 

- ability to build all the contracts from one place 
- rename build_contracts -> build_core_contracts for less confusing naming 

Next steps here would be 

- rename build_contracts_in  
- do not forge build in other bash script and use function from /lib/build_contracts instead 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the contract build workflow to integrate example contracts, ensuring a more comprehensive build process.

- **Refactor**
  - Streamlined the overall contract and deployment operations for improved efficiency and reliability.
  - Optimized the package build process by removing legacy build steps during React SDK creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->