### PR TITLE
call_server: return 401 for wrong/missing JWT tokens

### DIFF
--- a/rust/services/call/server_lib/tests/integration_tests.rs
+++ b/rust/services/call/server_lib/tests/integration_tests.rs
@@ -491,6 +491,19 @@ mod server_tests {
         }
 
         #[tokio::test(flavor = "multi_thread")]
+        async fn rejects_requests_with_missing_token() {
+            let app = default_app();
+            let req = rpc_body("dummy", &json!([]));
+            let resp = app.post("/", &req).await;
+
+            assert_eq!(StatusCode::UNAUTHORIZED, resp.status());
+            assert_json_eq!(
+                body_to_json(resp.into_body()).await,
+                json!({ "error": "Missing JWT token" })
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
         async fn rejects_requests_with_expired_token() {
             let app = default_app();
             let req = rpc_body("dummy", &json!([]));
@@ -498,7 +511,7 @@ mod server_tests {
                 .post_with_bearer_auth("/", &req, &token(-120, "1234"))
                 .await;
 
-            assert_eq!(StatusCode::BAD_REQUEST, resp.status());
+            assert_eq!(StatusCode::UNAUTHORIZED, resp.status());
             assert_json_eq!(
                 body_to_json(resp.into_body()).await,
                 json!({ "error": "ExpiredSignature" })
@@ -516,7 +529,7 @@ mod server_tests {
             let req = rpc_body("dummy", &json!([]));
             let resp = app.post_with_bearer_auth("/", &req, &token).await;
 
-            assert_eq!(StatusCode::BAD_REQUEST, resp.status());
+            assert_eq!(StatusCode::UNAUTHORIZED, resp.status());
             assert_json_eq!(
                 body_to_json(resp.into_body()).await,
                 json!({ "error": "InvalidSignature" })
@@ -531,10 +544,10 @@ mod server_tests {
             let req = rpc_body("dummy", &json!([]));
             let resp = app.post_with_bearer_auth("/", &req, OLD_TOKEN).await;
 
-            assert_eq!(StatusCode::BAD_REQUEST, resp.status());
+            assert_eq!(StatusCode::UNAUTHORIZED, resp.status());
             assert_json_eq!(
                 body_to_json(resp.into_body()).await,
-                json!({ "error": "InvalidToken" })
+                json!({ "error": "Invalid JWT token" })
             );
         }
 


### PR DESCRIPTION
* handles lack of bearer token reporting it as an error
* maps auth errors to 401 status code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced authentication error handling to return a consistent "Unauthorized" response with clear messaging when a valid token is missing or invalid.
  
- **Tests**
  - Updated and added tests to verify that requests lacking proper authentication are correctly rejected with the proper error status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->