### PR TITLE
sdk: add error note about JWT tokens for auth errors

### DIFF
--- a/packages/sdk/src/api/lib/client.ts
+++ b/packages/sdk/src/api/lib/client.ts
@@ -17,12 +17,27 @@ import {
 } from "../../web-proof-commons";
 import { type ContractFunctionArgsWithout } from "types/viem";
 import { type ProveArgs } from "types/vlayer";
+import { HttpAuthorizationError } from "./errors";
+import { match, P } from "ts-pattern";
 
 function dropEmptyProofFromArgs(args: unknown) {
   if (Array.isArray(args)) {
     return args.slice(1) as unknown[];
   }
   return [];
+}
+
+export const VLAYER_ERROR_NOTES = {
+  [HttpAuthorizationError.name]:
+    ", go to https://dashboard.vlayer.xyz to generate a JWT token and save it to VLAYER_API_TOKEN env var",
+};
+
+function httpAuthorizationErrorWithNote(
+  error: HttpAuthorizationError,
+): HttpAuthorizationError {
+  return new HttpAuthorizationError(
+    `${error.message}${VLAYER_ERROR_NOTES[error.name]}`,
+  );
 }
 
 export const createVlayerClient = (
@@ -55,22 +70,30 @@ export const createVlayerClient = (
     }: ProveArgs<T, F>) => {
       webProofProvider.notifyZkProvingStatus(ZkProvingStatus.Proving);
 
-      const hash = await prove(
-        address,
-        proverAbi,
-        functionName,
-        args,
-        chainId,
-        url,
-        gasLimit,
-        token,
-      ).catch((e) => {
-        webProofProvider.notifyZkProvingStatus(ZkProvingStatus.Error);
-        throw e;
-      });
+      try {
+        const hash = await prove(
+          address,
+          proverAbi,
+          functionName,
+          args,
+          chainId,
+          url,
+          gasLimit,
+          token,
+        );
 
-      resultHashMap.set(hash.hash, [proverAbi, functionName]);
-      return hash;
+        resultHashMap.set(hash.hash, [proverAbi, functionName]);
+        return hash;
+      } catch (error) {
+        webProofProvider.notifyZkProvingStatus(ZkProvingStatus.Error);
+
+        const errorWithNote = match(error)
+          .with(P.instanceOf(HttpAuthorizationError), (error) =>
+            httpAuthorizationErrorWithNote(error),
+          )
+          .otherwise((error) => error);
+        throw errorWithNote;
+      }
     },
 
     waitForProvingResult: async <
@@ -114,9 +137,15 @@ export const createVlayerClient = (
           AbiStateMutability,
           F
         >;
-      } catch (e) {
+      } catch (error) {
         webProofProvider.notifyZkProvingStatus(ZkProvingStatus.Error);
-        throw e;
+
+        const errorWithNote = match(error)
+          .with(P.instanceOf(HttpAuthorizationError), (error) =>
+            httpAuthorizationErrorWithNote(error),
+          )
+          .otherwise((error) => error);
+        throw errorWithNote;
       }
     },
 


### PR DESCRIPTION
When triggering a missing/invalid JWT token in any of the examples via an CLI implementation (e.g., `bun run prove:testnet`, etc.), the SDK client will now include an informative note where an JWT token can be obtained from:

<img width="1147" alt="Screenshot 2025-04-09 at 13 42 27" src="https://github.com/user-attachments/assets/671131e4-7304-4665-95ca-f8978bd65af4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved error messaging now provides clear, actionable guidance when authentication tokens are missing or invalid.
- **Tests**
  - Updated test scenarios ensure consistent behavior and robust handling of authentication errors, including specific cases for missing and invalid tokens.
- **Refactor**
  - Consolidated authentication error logic to deliver more informative feedback and a uniform user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->