### PR TITLE
Prevent delegatecalls in travel calls

### DIFF
--- a/rust/services/call/engine/src/travel_call/inspector.rs
+++ b/rust/services/call/engine/src/travel_call/inspector.rs
@@ -298,7 +298,7 @@ mod test {
     fn delegate_call_panics_in_on_call() {
         let other_contract = address!("0000000000000000000000000000000000000000");
         let mut inspector = inspector_call(other_contract, &[], &[]);
-        let mut call_inputs = create_mock_call_inputs(other_contract, [0u8; 4]);
+        let mut call_inputs = create_mock_call_inputs(other_contract, [0_u8; 4]);
         call_inputs.scheme = CallScheme::DelegateCall;
 
         inspector.set_block(1);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a safeguard that detects and prevents unsupported delegate call operations in travel scenarios, providing a clear error message if such an operation is attempted.
- **Tests**
	- Introduced a new test case to ensure that unsupported delegate call operations trigger the expected error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->