### PR TITLE
Disallow partial redaction on values that contain primary redaction characters

### DIFF
--- a/rust/web_proof/src/redaction.rs
+++ b/rust/web_proof/src/redaction.rs
@@ -6,11 +6,11 @@ use crate::{errors::ParsingError, utils::bytes::all_match};
 
 pub(crate) const REDACTED_BYTE_CODE: u8 = 0;
 
-// Both '*' and '+' are valid header characters. Replacing redacted '\0' bytes with
+// Both '*' and 'X' are valid header characters. Replacing redacted '\0' bytes with
 // two different characters ensures the request is parsable and allows analysis
 // of redacted content via diffs.
 pub(crate) const REDACTION_REPLACEMENT_CHAR_PRIMARY: char = '*';
-pub(crate) const REDACTION_REPLACEMENT_CHAR_SECONDARY: char = '+';
+pub(crate) const REDACTION_REPLACEMENT_CHAR_SECONDARY: char = 'X';
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct RedactedTranscriptNameValue {
@@ -116,7 +116,7 @@ mod test_validate_name_value_redaction {
     #[test]
     fn success_value_full_redaction() {
         let name_values_primary = vec![("name1", "******").into(), ("name2", "value2").into()];
-        let name_values_secondary = vec![("name1", "++++++").into(), ("name2", "value2").into()];
+        let name_values_secondary = vec![("name1", "XXXXX").into(), ("name2", "value2").into()];
 
         assert!(
             validate_name_value_redaction(
@@ -131,7 +131,7 @@ mod test_validate_name_value_redaction {
     #[test]
     fn fail_partial_name_redaction() {
         let primary = vec![("name*", "value1").into(), ("name2", "value2").into()];
-        let secondary = vec![("name+", "value1").into(), ("name2", "value2").into()];
+        let secondary = vec![("nameX", "value1").into(), ("name2", "value2").into()];
 
         let err = validate_name_value_redaction(
             &primary,
@@ -148,7 +148,7 @@ mod test_validate_name_value_redaction {
     #[test]
     fn fail_full_name_redaction() {
         let primary = vec![("*****", "value1").into(), ("name2", "value2").into()];
-        let secondary = vec![("+++++", "value1").into(), ("name2", "value2").into()];
+        let secondary = vec![("XXXXX", "value1").into(), ("name2", "value2").into()];
 
         let err = validate_name_value_redaction(
             &primary,
@@ -165,7 +165,7 @@ mod test_validate_name_value_redaction {
     #[test]
     fn fail_partial_value_redaction() {
         let primary = vec![("name1", "value*").into(), ("name2", "value2").into()];
-        let secondary = vec![("name1", "value+").into(), ("name2", "value2").into()];
+        let secondary = vec![("name1", "valueX").into(), ("name2", "value2").into()];
 
         let err = validate_name_value_redaction(
             &primary,
@@ -182,7 +182,7 @@ mod test_validate_name_value_redaction {
     #[test]
     fn fail_partial_value_redaction_using_primary_redaction_character() {
         let primary = vec![("name1", "**").into()];
-        let secondary = vec![("name1", "*+").into()];
+        let secondary = vec![("name1", "*X").into()];
 
         let err = validate_name_value_redaction(
             &primary,


### PR DESCRIPTION
Fixes: https://veridise.notion.site/Values-with-primary-redaction-character-may-be-partially-redacted-1bd105edf1db8050b5bbc1cfbae1854c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the redaction validation to more accurately detect partially redacted values, improving consistency checks.

- **Tests**
  - Added a new test to ensure that improper combinations of redaction characters trigger appropriate error notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->