### PR TITLE
 [ENGA-598] Use temp file to avoid subshell issue

### DIFF
--- a/bash/lint/json.sh
+++ b/bash/lint/json.sh
@@ -1,19 +1,23 @@
 #! /bin/bash
 set -uo pipefail
 
-HAS_ERROR=false
+ERROR_FLAG=$(mktemp -u)
 VLAYER_HOME=$(git rev-parse --show-toplevel)
 
 find "$VLAYER_HOME" -type f -name "*.json" ! -path "*/node_modules/*" ! -path "*/target/*" ! -path "*/out/*" ! -path "*/dependencies/*" ! -path "*/.vscode/*" | while read -r file; do
   if ! jq empty "$file" > /dev/null 2>&1; then
     echo "----------------------------------------"
     jq empty "$file"
-    echo "Invalid JSON: $file" 
+    echo "Invalid JSON: $file"
     echo "----------------------------------------"
-    HAS_ERROR=true
+    touch "$ERROR_FLAG"
+  else
+    echo "Linting passed for $file"
   fi
 done
 
-if $HAS_ERROR; then
+if [[ -f "$ERROR_FLAG" ]]; then
+  rm "$ERROR_FLAG"
+  echo "Linting failed"
   exit 1
 fi

--- a/packages/web-proof-commons/tsconfig.json
+++ b/packages/web-proof-commons/tsconfig.json
@@ -3,5 +3,5 @@
     "compilerOptions": {
         "moduleResolution": "bundler"
     },
-    "include": ["**/*"],
+    "include": ["**/*"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a clear success message when JSON files pass linting, giving immediate positive feedback.
	- Enhanced error handling during JSON validation with improved logging messages.

- **Bug Fixes**
	- Refined error reporting to accurately notify users if any JSON file fails validation, ensuring improved clarity during JSON linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->