### PR TITLE
Add public endpoint for Sepolia for the teleport example

### DIFF
--- a/examples/simple-teleport/vlayer/.env.testnet
+++ b/examples/simple-teleport/vlayer/.env.testnet
@@ -1,12 +1,12 @@
 CHAIN_NAME=sepolia
 PROVER_URL=https://test-prover.vlayer.xyz
-JSON_RPC_URL=https://sepolia.drpc.org
+
+# Publicly accessible, best-effort RPC endpoint for Sepolia, subject to rate-limiting and downtime.
+# Replace with your own RPC endpoint for better stability.
+JSON_RPC_URL=https://virulent-green-paper.ethereum-sepolia.quiknode.pro/61a794a034c819264f86f5e8243a4e24cfb84b25
 TOKEN_HOLDER=0xA6E3d943197A53C5608fF49239310C19843B3Cf1
 
 PROVER_ERC20_ADDRESSES=0x1c7d4b196cb0c7b01d743fbc6116a902379c7238
 PROVER_ERC20_CHAIN_IDS=11155420
 PROVER_ERC20_BLOCK_NUMBERS=8076158
-
-# Publicly accessible, best-effort RPC endpoint for Sepolia, subject to rate-limiting and downtime.
-# Replace with your own RPC endpoint for better stability.
-L2_JSON_RPC_URL=https://virulent-green-paper.ethereum-sepolia.quiknode.pro/61a794a034c819264f86f5e8243a4e24cfb84b25
+L2_JSON_RPC_URL=https://sepolia.optimism.io


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Revised the test network’s RPC configuration by updating the connection endpoint. The previous endpoint has been replaced with a new publicly available endpoint to maintain network access. Additional advisory notes encourage users to replace this default setting with their own endpoint for improved connection stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->