### PR TITLE
Improve error message display with scroll and max size

### DIFF
--- a/examples/simple-web-proof/vlayer/src/components/layout/ErrorBoundary.module.css
+++ b/examples/simple-web-proof/vlayer/src/components/layout/ErrorBoundary.module.css
@@ -11,6 +11,11 @@
     font-style: normal;
     font-weight: var(--t-font-weight-bold, 700);
     line-height: var(--t-font-lineHeight-leading-9, 36px);
+    max-width: 400px;
+    max-height: 72px;
+    overflow: auto;
+    word-wrap: break-word;
+    word-break: break-word;
 }
 
 .additionalText {
@@ -50,10 +55,12 @@
     align-items: center;
     gap: var(--Spacing-5, 24px);
 }
+
 .image {
     width: 282px;
     height: 156px;
 }
+
 .background {
     display: flex;
     width: 1413px;


### PR DESCRIPTION
Earlier the error message could stretch the field and cover part of the progress bar. Now its size is limited. If the whole message does not fit, one can scroll through it. Below a screenshot with part of the "Veeeryyy looong error message" which is scrollable.
<img width="589" alt="Screenshot 2025-04-14 at 15 19 24" src="https://github.com/user-attachments/assets/a22c57ba-d82f-43a3-8a7e-0bcb69e337a7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved error message presentation with enhanced size constraints, scrollable overflow, and better word wrapping to ensure readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->