### PR TITLE
Bare stable version in Rust

### DIFF
--- a/rust/version/build.rs
+++ b/rust/version/build.rs
@@ -5,6 +5,8 @@ use vergen_gitcl::{
 };
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=VLAYER_RELEASE");
+
     if env::var("VLAYER_RELEASE").is_err() {
         println!("cargo:rustc-env=VLAYER_RELEASE=dev");
     }

--- a/rust/version/src/lib.rs
+++ b/rust/version/src/lib.rs
@@ -1,4 +1,7 @@
 pub fn version() -> String {
+    if env!("VLAYER_RELEASE") == "stable" {
+        return env!("CARGO_PKG_VERSION").to_string();
+    }
     let build_date = env!("VERGEN_BUILD_DATE").replace("-", "");
     [
         env!("CARGO_PKG_VERSION"),


### PR DESCRIPTION
Currently, we use `VLAYER_RELEASE=nightly` for nightly releases, and `dev` by default if not specified.
It produces the versions with date and commit hash suffixes.

This change allows us to compile with `VLAYER_RELEASE=stable` producing a bare version (e.g. `0.1.0`).

Also added a `rerun-if-env-changed` directive which was missing.