### PR TITLE
server_utils: fix typo in clap args

### DIFF
--- a/rust/server_utils/src/jwt/cli.rs
+++ b/rust/server_utils/src/jwt/cli.rs
@@ -11,7 +11,7 @@ pub struct Args {
     #[arg(long, group = "auth")]
     pub jwt_public_key: Option<PathBuf>,
 
-    #[arg(long, group = "auth", default_value = "RS256")]
+    #[arg(long, requires = "auth", default_value = "RS256")]
     pub jwt_algorithm: Option<Algorithm>,
 }
 


### PR DESCRIPTION
Without this fix, `--jwt-public-key` and `--jwt-algorithm` flags are mutually exclusive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated command-line argument behavior so that the `jwt_algorithm` option now requires the "auth" group to be specified, improving clarity for users configuring authentication options. The default value for `jwt_algorithm` remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->