### PR TITLE
[ENGA-613] Fix useEffect dependencies

### DIFF
--- a/examples/simple-web-proof/vlayer/src/components/organisms/ProveStep/Container.tsx
+++ b/examples/simple-web-proof/vlayer/src/components/organisms/ProveStep/Container.tsx
@@ -10,14 +10,20 @@ export const ProveStep = () => {
   const [disabled, setDisabled] = useState(false);
   const modalRef = useRef<HTMLDialogElement>(null);
 
-  const { requestWebProof, webProof, callProver, isPending, result } =
-    useTwitterAccountProof();
+  const {
+    requestWebProof,
+    webProof,
+    callProver,
+    isPending,
+    isCallProverPending,
+    result,
+  } = useTwitterAccountProof();
 
   useEffect(() => {
-    if (webProof) {
+    if (webProof && !isCallProverPending) {
       void callProver([webProof, address]);
     }
-  }, [webProof, address, callProver]);
+  }, [webProof, address, callProver, isCallProverPending]);
 
   useEffect(() => {
     if (result) {

--- a/examples/simple-web-proof/vlayer/src/hooks/useTwitterAccountProof.ts
+++ b/examples/simple-web-proof/vlayer/src/hooks/useTwitterAccountProof.ts
@@ -96,23 +96,26 @@ export const useTwitterAccountProof = () => {
 
   useEffect(() => {
     if (webProof) {
-      console.log("webProof ready", webProof);
+      console.log("webProof", webProof);
       setWebProof(JSON.stringify(webProof));
     }
-  }, [webProof]);
+  }, [JSON.stringify(webProof)]);
 
   useEffect(() => {
     if (result) {
       console.log("proverResult", result);
       setProverResult(JSON.stringify(result));
     }
-  }, [result]);
+  }, [JSON.stringify(result)]);
 
   return {
     requestWebProof,
     webProof,
     isPending:
       isWebProofPending || isCallProverPending || isWaitingForProvingResult,
+    isCallProverPending,
+    isWaitingForProvingResult,
+    isWebProofPending,
     callProver,
     result,
   };


### PR DESCRIPTION
This is temp fix of memory issue. We should : 

1. use `useCallback` to wrap call prover so it can be passed to dependency array 
2. Provide a way to monitor potential react memory leak 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of updates in the proof step by adjusting when certain actions are triggered.
	- Enhanced state handling to prevent redundant operations during proof processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->