### PR TITLE
call_server: move v_allocateGas into task queue

### DIFF
--- a/packages/sdk/src/api/lib/types/vlayer.ts
+++ b/packages/sdk/src/api/lib/types/vlayer.ts
@@ -48,6 +48,7 @@ export type CallHash = z.infer<typeof callHashSchema>;
 
 export enum ProofState {
   Queued = "queued",
+  AllocateGas = "allocate_gas",
   ChainProof = "chain_proof",
   Preflight = "preflight",
   Proving = "proving",
@@ -116,6 +117,7 @@ export const proofReceiptSchema = z.discriminatedUnion("status", [
     data: z.undefined(),
     metrics: z.custom<Metrics>(),
     state: z.enum([
+      ProofState.AllocateGas,
       ProofState.ChainProof,
       ProofState.Preflight,
       ProofState.Proving,
@@ -126,6 +128,7 @@ export const proofReceiptSchema = z.discriminatedUnion("status", [
     error: z.undefined(),
     state: z.enum([
       ProofState.Done,
+      ProofState.AllocateGas,
       ProofState.ChainProof,
       ProofState.Preflight,
       ProofState.Proving,

--- a/packages/sdk/src/api/prover.ts
+++ b/packages/sdk/src/api/prover.ts
@@ -79,14 +79,17 @@ export async function getProofReceipt<
 const handleErrors = ({ status, state, error }: ProofReceipt) => {
   if (status === 0) {
     match(state)
+      .with(ProofState.AllocateGas, () => {
+        throw new Error(`Allocating gas failed with error: ${error}`);
+      })
       .with(ProofState.ChainProof, () => {
-        throw new Error("Waiting for chain proof failed with error: " + error);
+        throw new Error(`Waiting for chain proof failed with error: ${error}`);
       })
       .with(ProofState.Preflight, () => {
-        throw new Error("Preflight failed with error: " + error);
+        throw new Error(`Preflight failed with error: ${error}`);
       })
       .with(ProofState.Proving, () => {
-        throw new Error("Proving failed with error: " + error);
+        throw new Error(`Proving failed with error: ${error}`);
       })
       .exhaustive();
   }

--- a/rust/services/call/server_lib/src/gas_meter.rs
+++ b/rust/services/call/server_lib/src/gas_meter.rs
@@ -168,15 +168,8 @@ impl Client for NoOpClient {
     }
 }
 
-pub async fn init(
-    config: Option<Config>,
-    call_hash: CallHash,
-    token: Option<Token>,
-    gas_limit: u64,
-) -> Result<Box<dyn Client>> {
-    let client: Box<dyn Client> = config.map_or(Box::new(NoOpClient), |config| {
+pub fn init(config: Option<Config>, call_hash: CallHash, token: Option<Token>) -> Box<dyn Client> {
+    config.map_or(Box::new(NoOpClient), |config| {
         Box::new(RpcClient::new(config, call_hash, token))
-    });
-    client.allocate(gas_limit).await?;
-    Ok(client)
+    })
 }

--- a/rust/services/call/server_lib/src/handlers/v_call.rs
+++ b/rust/services/call/server_lib/src/handlers/v_call.rs
@@ -31,8 +31,7 @@ pub async fn v_call(
 
     info!(hash = tracing::field::display(call_hash), "Call");
 
-    let gas_meter_client =
-        gas_meter::init(config.gas_meter_config.clone(), call_hash, token, call.gas_limit).await?;
+    let gas_meter_client = gas_meter::init(config.gas_meter_config.clone(), call_hash, token);
 
     let mut found_existing = true;
     state.entry(call_hash).or_insert_with(|| {

--- a/rust/services/call/server_lib/src/handlers/v_get_proof_receipt/types.rs
+++ b/rust/services/call/server_lib/src/handlers/v_get_proof_receipt/types.rs
@@ -12,6 +12,7 @@ use crate::{
 #[serde(rename_all = "snake_case")]
 pub enum State {
     Queued,
+    AllocateGas,
     ChainProof,
     Preflight,
     Proving,
@@ -48,6 +49,7 @@ impl From<&ProofState> for State {
     fn from(value: &ProofState) -> Self {
         match value {
             ProofState::Queued => Self::Queued,
+            ProofState::AllocateGasPending | ProofState::AllocateGasError(..) => Self::AllocateGas,
             ProofState::ChainProofPending | ProofState::ChainProofError(..) => Self::ChainProof,
             ProofState::PreflightPending | ProofState::PreflightError(..) => Self::Preflight,
             ProofState::ProvingPending | ProofState::ProvingError(..) => Self::Proving,


### PR DESCRIPTION
Currently, when the prover gets hit twice with the same proof request, we will call gas-meter twice which will lead to the gas-meter trying to write the same record twice into the DB causing a server error:

![image](https://github.com/user-attachments/assets/d4688221-3029-44f0-bfa7-10f42eacc976)

Instead, we should call the gas-meter as an explicit step in the queued task worker:

![image](https://github.com/user-attachments/assets/cfaba69a-14d7-48cf-bf14-917fc263e835)

This commit pushes first call to gas-meter into the queued proving task, and introduces another proving state, AllocateGas, which will report an error if allocating gas failed in the gas-meter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a new "AllocateGas" state in proof receipts and related processes.
  - Improved error handling for gas allocation failures during proof generation.

- **Bug Fixes**
  - Corrected a typo in a test function name.

- **Tests**
  - Added a test to ensure gas allocation is performed only once per contract call.
  - Updated tests to improve reliability in asynchronous gas meter interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->