### PR TITLE
Make fix flag impact lint packages

### DIFF
--- a/bash/lint/ts.sh
+++ b/bash/lint/ts.sh
@@ -56,6 +56,7 @@ echo "::endgroup::Building contracts"
 
 echo "::group::Running eslint "
 pushd "${VLAYER_HOME}"
-bun run lint $FIX_FLAG
+bun run lint:packages $FIX_FLAG
+bun run lint:examples $FIX_FLAG
 popd
 echo "::endgroup::Running eslint"


### PR DESCRIPTION
Earlier fix flag worked only on `lint:examples`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated linting process to run separately on packages and examples, improving clarity in linting output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->