### PR TITLE
[ENGA-595] Add data limits flags to cli

### DIFF
--- a/rust/web_prover/src/notarize.rs
+++ b/rust/web_prover/src/notarize.rs
@@ -17,8 +17,6 @@ use tracing::debug;
 use crate::{NotarizeParams, RedactionConfig};
 
 const USER_AGENT: &str = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36";
-const MAX_SENT_DATA: usize = 1 << 12;
-const MAX_RECV_DATA: usize = 1 << 14;
 
 pub async fn notarize(params: NotarizeParams) -> Result<(Attestation, Secrets, RedactionConfig)> {
     let NotarizeParams {
@@ -30,6 +28,8 @@ pub async fn notarize(params: NotarizeParams) -> Result<(Attestation, Secrets, R
         headers,
         body,
         redaction_config_fn,
+        max_sent_data,
+        max_recv_data,
     } = params;
 
     let notary_client = NotaryClient::builder()
@@ -40,8 +40,8 @@ pub async fn notarize(params: NotarizeParams) -> Result<(Attestation, Secrets, R
         .build()?;
 
     let notarization_request = NotarizationRequest::builder()
-        .max_sent_data(MAX_SENT_DATA)
-        .max_recv_data(MAX_RECV_DATA)
+        .max_sent_data(max_sent_data)
+        .max_recv_data(max_recv_data)
         .build()?;
 
     let Accepted {
@@ -57,8 +57,8 @@ pub async fn notarize(params: NotarizeParams) -> Result<(Attestation, Secrets, R
         .server_name(server_domain.as_ref())
         .protocol_config(
             ProtocolConfig::builder()
-                .max_sent_data(MAX_SENT_DATA)
-                .max_recv_data(MAX_RECV_DATA)
+                .max_sent_data(max_sent_data)
+                .max_recv_data(max_recv_data)
                 .build()?,
         )
         .crypto_provider(CryptoProvider::default())

--- a/rust/web_prover/src/params.rs
+++ b/rust/web_prover/src/params.rs
@@ -38,6 +38,10 @@ pub struct NotarizeParams {
     )]
     #[debug(skip)]
     pub redaction_config_fn: RedactionConfigFn,
+    #[builder(default = "1 << 12")]
+    pub max_sent_data: usize,
+    #[builder(default = "1 << 14")]
+    pub max_recv_data: usize,
 }
 
 pub type RedactionConfigFn = Arc<dyn Fn(&Transcript) -> RedactionConfig + Send + Sync>;

--- a/rust/web_prover/tests/integration_tests.rs
+++ b/rust/web_prover/tests/integration_tests.rs
@@ -11,6 +11,30 @@ mod integration_tests {
         verify_presentation,
     };
 
+    const MAX_SENT_DATA_TOO_LOW: usize = 100;
+    const MAX_RECV_DATA_TOO_LOW: usize = 100;
+
+    #[tokio::test]
+    async fn test_limits_too_low() {
+        let web_proof_result = Box::pin(generate_web_proof(
+            NotarizeParamsBuilder::default()
+                .notary_config(NotaryConfig::new("127.0.0.1".into(), 7047, "".into(), false))
+                .server_domain("lotr-api.online")
+                .server_host("127.0.0.1")
+                .server_port(3011_u16)
+                .uri("/auth_header_require")
+                .headers(HashMap::from([("Authorization".to_string(), "s3cret_t0ken".to_string())]))
+                .body("body content")
+                .max_sent_data(MAX_SENT_DATA_TOO_LOW)
+                .max_recv_data(MAX_RECV_DATA_TOO_LOW)
+                .build()
+                .unwrap(),
+        ))
+        .await;
+
+        assert!(web_proof_result.is_err(), "Generate web proof should fail");
+    }
+
     #[tokio::test]
     async fn test_full_roundtrip() {
         let web_proof_result = Box::pin(generate_web_proof(


### PR DESCRIPTION
It adds flags for MAX_SENT_DATA MAX_RECV_DATA. What would be nice to have in next PR is better integration test with some spy that asserts params of request sent to notary server. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added options to configure maximum sent and received HTTP data sizes for web proof generation via new command-line arguments.
- **Bug Fixes**
	- Improved handling of data size limits by allowing dynamic configuration instead of fixed values.
- **Tests**
	- Added integration test to verify error handling when data size limits are set too low.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->