### PR TITLE
Extract and start parametrizing a reusable workflow for releasing

### DIFF
--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -51,7 +51,8 @@ Our workflows fall into the following categories, grouped by a common prefix:
 | [Lint Workflows](/.github/workflows/lint_workflows.yaml) | Lint GitHub Actions workflows. |
 | [Rust compilation performance](/.github/workflows/performance_rust_compilation.yaml) | Checks Rust incremental compilation performance. |
 | [PR team labeler](/.github/workflows/pr_team_labeler.yaml) | Adds team labels to PRs. |
-| [Release vlayer artifacts](/.github/workflows/release.yaml) | Release artifacts to npm, GitHub Releases, S3. |
+| [Release](/.github/workflows/release.yaml) | Reusable workflow to publish artifacts to npm, GitHub Releases, S3. |
+| [Release nightly](/.github/workflows/release_nightly.yaml) | Uses the reusable release workflow to publish a nightly release. |
 | [Release browser extension](/.github/workflows/release_browser_extension.yaml) | Uploads the extension to Chrome Web Store. |
 | [Test contracts](/.github/workflows/test_contracts.yaml) | Test and lint contracts. |
 | [Test chain worker migration](./github/workflows/test_chain_worker_migration.yaml) | Verifies that a new version of chain worker can generate new ZK proofs based on existing proofs. |

--- a/.github/workflows/deploy_provers.yaml
+++ b/.github/workflows/deploy_provers.yaml
@@ -3,7 +3,7 @@
 name: Deploy Provers
 on:
   workflow_run:
-    workflows: ["Release vlayer artifacts"]
+    workflows: ["Release nightly"]
     types: [completed]
   workflow_dispatch:
 concurrency:

--- a/.github/workflows/deploy_vdns.yaml
+++ b/.github/workflows/deploy_vdns.yaml
@@ -3,7 +3,7 @@
 name: Deploy VDNS
 on:
   workflow_run:
-    workflows: ["Release vlayer artifacts"]
+    workflows: ["Release nightly"]
     types: [completed]
   workflow_dispatch:
 concurrency:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,12 @@
-name: Release vlayer artifacts
+name: Release
 on:
-  schedule:
-    - cron: "0 6 * * 1-5" # Mon-Fri at 06:00 UTC (07:00 CET / 08:00 CEST)
-  workflow_dispatch:
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
+  workflow_call:
+    inputs:
+      vlayer_release:
+        # Only nightly supported for now.
+        description: "Release type (nightly or stable)"
+        required: true
+        type: string
 jobs:
   build-release:
     if: github.repository == 'vlayer-xyz/vlayer'

--- a/.github/workflows/release_nightly.yaml
+++ b/.github/workflows/release_nightly.yaml
@@ -1,0 +1,15 @@
+name: Release nightly
+on:
+  schedule:
+    - cron: "0 6 * * 1-5" # Mon-Fri at 06:00 UTC (07:00 CET / 08:00 CEST)
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+jobs:
+  release:
+    if: github.repository == 'vlayer-xyz/vlayer'
+    uses: ./.github/workflows/release.yaml
+    with:
+      vlayer_release: nightly
+    secrets: inherit


### PR DESCRIPTION
In preparation for adding a "stable" release (we only have a "nightly" now), I am proposing to extract the release workflow into a reusable, callable workflow parametrized by release type.

In this PR, there are no behaviour change intended - only a small refactor intended to separate reduce the diffs in subsequent PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated workflow documentation to clarify the release process and added details for nightly releases.
- **Chores**
  - Renamed the release workflow and restructured triggers for improved clarity.
  - Introduced a new nightly release workflow for automated weekday releases.
  - Updated dependent workflows to trigger on the new nightly release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->