### PR TITLE
vlayer update - Install the strict JS and soldeer dependencies

### DIFF
--- a/rust/cli/src/cli_wrappers/js.rs
+++ b/rust/cli/src/cli_wrappers/js.rs
@@ -58,7 +58,7 @@ impl Cli {
     pub fn install(&self, name: &str, version: &str) -> Result<(), Error> {
         base::Cli::run(
             self.0.name(),
-            &[self.0.install_command(), format!("{}@{}", name, version).as_str()],
+            &[self.0.install_command(), format!("{name}@{version}").as_str()],
         )?;
         println!("{} {} updated {}\n", "✔".green().bold(), name.bold(), "successfully".green());
         Ok(())

--- a/rust/cli/src/commands/update.rs
+++ b/rust/cli/src/commands/update.rs
@@ -6,10 +6,7 @@ use logger::UpdateLogger;
 use serde_json::Value;
 
 use crate::{
-    cli_wrappers::{
-        base, js,
-        vlayer::{self, Cli as Vlayer},
-    },
+    cli_wrappers::{base, js, vlayer},
     config::{Config, DEFAULT_CONFIG},
     errors::{Error, Result},
     soldeer::{add_remappings, install_solidity_dependencies},
@@ -54,7 +51,7 @@ fn update_cli() -> Result<()> {
 
 fn update_sdk() -> Result<()> {
     let version = vlayer::Cli::version()?;
-    let logger = UpdateLogger::new(format!("SDK to {}", version));
+    let logger = UpdateLogger::new(format!("SDK to {version}"));
     let Some((path, package_json)) = find_package_json()? else {
         logger.warn(format!("{} not found. Skipping SDK update.", "package.json".bold()));
         return Ok(());
@@ -87,8 +84,7 @@ async fn update_contracts() -> Result<()> {
     };
     let foundry_root = foundry_toml_path.parent().unwrap();
 
-    let config = Config::from_str(DEFAULT_CONFIG.replace("{{VERSION}}", version.as_str()))
-        .expect("Could not construct an internal foundry config");
+    let config = Config::from_str(DEFAULT_CONFIG.replace("{{VERSION}}", version.as_str()))?;
     install_solidity_dependencies(&config.sol_dependencies).await?;
     add_remappings(foundry_root, config.sol_dependencies.values())?;
     logger.success();


### PR DESCRIPTION
`vlayer update` updates 3 things:

- docker compose files
- solidity dependencies
- JS dependencies

(And also the vlayer CLI through `vlayerup`).

The `update` command is supposed to update to a specific version (the version of `vlayer CLI`).
It works that way for docker, but not for other types of dependencies.

This PR:

- Makes vlayer solidity dependency be installed to a specific version
- Makes the JS dependencies be installed to a specific version
  - Also added a missing `@vlayer/react`. I don't think a loop over all `@vlayer/*` is called for just yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The install command now allows specifying a package version during installation.
- **Improvements**
  - SDK and related package updates now consistently handle and display version information.
  - The update process conditionally installs additional related packages if present, streamlining updates for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->