### PR TITLE
wsproxy: use JSONTokenApi plugin to use another server as gatekeeper

### DIFF
--- a/bash/e2e-web-apps-test.sh
+++ b/bash/e2e-web-apps-test.sh
@@ -18,7 +18,7 @@ build_sdk
 build_sdk_hooks
 
 echo "🚀 Running services for example: $EXAMPLE"
-DOCKER_COMPOSE_SERVICES="anvil-l1 anvil-l2-op wsproxy notary-server"
+DOCKER_COMPOSE_SERVICES="anvil-l1 anvil-l2-op wsproxy wsproxy-test-client notary-server"
 
 source "${VLAYER_HOME}/bash/run-services.sh"
 

--- a/bash/e2e-web-proof-example-test.sh
+++ b/bash/e2e-web-proof-example-test.sh
@@ -13,7 +13,7 @@ set_proving_mode
 generate_ts_bindings
 
 echo "::group::Running services"
-DOCKER_COMPOSE_SERVICES="anvil-l1 anvil-l2-op wsproxy notary-server"
+DOCKER_COMPOSE_SERVICES="anvil-l1 anvil-l2-op wsproxy wsproxy-test-client notary-server"
 
 source ${VLAYER_HOME}/bash/run-services.sh
 echo "::endgroup::Running services"

--- a/bash/run-web-example.sh
+++ b/bash/run-web-example.sh
@@ -34,7 +34,7 @@ function run_browser_extension {
     echo "::endgroup::Running browser extension"
 }
 
-DOCKER_COMPOSE_SERVICES="anvil-l1 anvil-l2-op wsproxy notary-server"
+DOCKER_COMPOSE_SERVICES="anvil-l1 anvil-l2-op wsproxy wsproxy-test-client notary-server"
 source ${VLAYER_HOME}/bash/run-services.sh
 
 install_deps

--- a/docker/docker-compose.devnet.yaml
+++ b/docker/docker-compose.devnet.yaml
@@ -6,5 +6,6 @@ include:
   - call_server/service.yaml
   # webproofs 
   - websockify/service.yaml
+  - websockify-test-client/service.yaml
   - notary-server/service.yaml
 

--- a/docker/websockify-test-client/Dockerfile
+++ b/docker/websockify-test-client/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:22-slim
+
+WORKDIR /app
+COPY . .
+
+CMD ["node", "run.js"]

--- a/docker/websockify-test-client/run.js
+++ b/docker/websockify-test-client/run.js
@@ -1,0 +1,43 @@
+const http = require('http');
+const url = require('url');
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET') {
+    const parsedUrl = url.parse(req.url, true);
+    const token = parsedUrl.query.token;
+
+    console.log(`Received new request: ?token=${token}`);
+
+    if (token) {
+      const [host, portStr] = token.split(':');
+      const port = parseInt(portStr, 10) || 443;
+
+      if (!host) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid token format. Expected host:port' }));
+        return;
+      }
+
+      const response = {
+        host,
+        port
+      };
+
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(response));
+    } else {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Missing token parameter' }));
+    }
+  } else {
+    res.writeHead(405, { 'Content-Type': 'text/plain' });
+    res.end('405 Method Not Allowed\n');
+  }
+});
+
+const PORT = parseInt(process.env.PORT, 10) || 3010;
+
+server.listen(PORT, '0.0.0.0', () => {
+  console.log(`Server is running at http://localhost:${PORT}`);
+});
+

--- a/docker/websockify-test-client/service.yaml
+++ b/docker/websockify-test-client/service.yaml
@@ -1,0 +1,8 @@
+services:
+  wsproxy-test-client:
+    container_name: wsproxy-test-client
+    build: .
+    expose:
+      - "${PORT}"
+    environment:
+      - PORT=3010

--- a/docker/websockify/service.yaml
+++ b/docker/websockify/service.yaml
@@ -5,4 +5,4 @@ services:
     platform: linux/amd64
     ports:
       - "127.0.0.1:3003:80" 
-    command: "80 api.x.com:443"
+    command: "80 --token-plugin JSONTokenApi --token-source 'http://wsproxy-test-client:3010/?token=%s'"


### PR DESCRIPTION
In devnet, we can use JSONTokenApi plugin in wsproxy and point at another server which will accept `/?token=host:port` and return it as wsproxy JSON-encoded token `{ host: host, port: port }`.

This then implies that we can automatically handle any target host:port in wsproxy without the need to tweak any docker files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new test client service supporting token-based authentication for the web proxy.
  - Added an HTTP server that processes and validates tokens for proxy requests.

- **Chores**
  - Updated Docker Compose configurations and scripts to include the new test client service.
  - Enhanced proxy service setup to enable token-based authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->