### PR TITLE
Generate nightly github release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -330,11 +330,35 @@ jobs:
           merge-multiple: true
       - run: rm ./dist/{ImageID.sol,Elf.sol,methods.rs,risc0_call_guest} || true
 
+      - name: Determine previous nightly tag
+        id: tags
+        run: |
+          NEW_TAG="nightly-${{ github.sha }}"
+          PREVIOUS_TAG=$(git tag --sort=-creatordate | grep '^nightly-' | grep -v "$NEW_TAG" | head -n 1)
+          echo "NEW_TAG=$NEW_TAG" >> "$GITHUB_OUTPUT"
+          echo "PREVIOUS_TAG=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Generate release notes from previous nightly release
+        id: notes
+        run: |
+          NOTES=$(gh api repos/${{ github.repository }}/releases/generate-notes \
+            -f tag_name=${{ steps.tags.outputs.NEW_TAG }} \
+            -f previous_tag_name=${{ steps.tags.outputs.PREVIOUS_TAG }} \
+            --jq .body)
+          { 
+            echo "RELEASE_NOTES<<EOF"; 
+            echo "$NOTES"; 
+            echo "EOF"; 
+          } >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Release tagged nightly
         uses: ncipollo/release-action@v1
         with:
-          tag: nightly-${{ github.sha }}
+          tag: ${{ steps.tags.outputs.NEW_TAG }}
           makeLatest: false
+          prerelease: true
           allowUpdates: true
           artifacts: "./dist/*"
 
@@ -343,6 +367,7 @@ jobs:
         with:
           tag: nightly-latest
           makeLatest: false
+          prerelease: true
           allowUpdates: true
           artifacts: "./dist/*"
 


### PR DESCRIPTION
- Analogous to https://github.com/vlayer-xyz/vlayer/pull/2243
- Also mark the nightlies as prerelease

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved nightly release process to automatically generate release notes and ensure consistent tagging.
	- Nightly releases are now clearly marked as prereleases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->