### PR TITLE
Replace channel in vlayer init with stable or nightly

### DIFF
--- a/examples/kraken-web-proof/vlayer/.env.testnet
+++ b/examples/kraken-web-proof/vlayer/.env.testnet
@@ -1,5 +1,5 @@
 CHAIN_NAME=optimismSepolia
-PROVER_URL=https://test-prover.vlayer.xyz
+PROVER_URL=https://stable-fake-prover.vlayer.xyz
 JSON_RPC_URL=https://sepolia.optimism.io
 VITE_FAUCET_URL=https://faucet.vlayer.xyz
 NOTARY_URL=https://test-notary.vlayer.xyz

--- a/examples/simple-email-proof/vlayer/.env.testnet
+++ b/examples/simple-email-proof/vlayer/.env.testnet
@@ -1,5 +1,5 @@
 CHAIN_NAME=optimismSepolia
-PROVER_URL=https://test-prover.vlayer.xyz
+PROVER_URL=https://stable-fake-prover.vlayer.xyz
 JSON_RPC_URL=https://sepolia.optimism.io
 DNS_SERVICE_URL=https://test-dns.vlayer.xyz/dns-query
 EMAIL_SERVICE_URL=https://email-example-inbox.s3.us-east-2.amazonaws.com

--- a/examples/simple-teleport/vlayer/.env.testnet
+++ b/examples/simple-teleport/vlayer/.env.testnet
@@ -1,5 +1,5 @@
 CHAIN_NAME=sepolia
-PROVER_URL=https://test-prover.vlayer.xyz
+PROVER_URL=https://stable-fake-prover.vlayer.xyz
 L2_JSON_RPC_URL=https://sepolia.optimism.io
 # Publicly accessible, best-effort RPC endpoint for Sepolia, subject to rate-limiting and downtime.
 # Replace with your own RPC endpoint for better stability.

--- a/examples/simple-time-travel/vlayer/.env.testnet
+++ b/examples/simple-time-travel/vlayer/.env.testnet
@@ -1,4 +1,4 @@
 # Prover and RPC endpoints
-PROVER_URL=https://test-prover.vlayer.xyz
+PROVER_URL=https://stable-fake-prover.vlayer.xyz
 JSON_RPC_URL=https://sepolia.optimism.io
 CHAIN_NAME=optimismSepolia

--- a/examples/simple-web-proof/vlayer/.env.testnet
+++ b/examples/simple-web-proof/vlayer/.env.testnet
@@ -1,5 +1,5 @@
 CHAIN_NAME=optimismSepolia
-PROVER_URL=https://test-prover.vlayer.xyz
+PROVER_URL=https://stable-fake-prover.vlayer.xyz
 JSON_RPC_URL=https://sepolia.optimism.io
 VITE_FAUCET_URL=https://faucet.vlayer.xyz
 NOTARY_URL=https://test-notary.vlayer.xyz

--- a/examples/simple/vlayer/.env.testnet
+++ b/examples/simple/vlayer/.env.testnet
@@ -1,3 +1,3 @@
 CHAIN_NAME=optimismSepolia
-PROVER_URL=https://test-prover.vlayer.xyz
+PROVER_URL=https://stable-fake-prover.vlayer.xyz
 JSON_RPC_URL=https://sepolia.optimism.io

--- a/rust/cli/src/errors.rs
+++ b/rust/cli/src/errors.rs
@@ -55,6 +55,8 @@ pub enum Error {
     UpdateDocker(#[from] update::docker::Error),
     #[error(transparent)]
     Jwt(#[from] JwtError),
+    #[error(transparent)]
+    Regex(#[from] regex::Error),
 }
 
 impl Error {

--- a/rust/version/src/lib.rs
+++ b/rust/version/src/lib.rs
@@ -12,6 +12,10 @@ pub fn version() -> String {
     .join("-")
 }
 
+pub fn is_stable() -> bool {
+    env!("VLAYER_RELEASE") == "stable"
+}
+
 #[cfg(test)]
 mod tests {
     use regex::Regex;


### PR DESCRIPTION
Depending on `vlayer` release channel, use an appropriate prover url.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated environment configuration files across multiple examples to use a new prover service URL for testnet deployments.

- **New Features**
	- Added automatic updating of the prover service URL in testnet configuration files during project initialization.
	- Introduced a utility to detect the current release channel for improved configuration handling.

- **Bug Fixes**
	- Enhanced error handling to support issues related to URL pattern matching in configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->