### PR TITLE
Add missing trigger to prover deployment

### DIFF
--- a/.github/workflows/deploy_provers.yaml
+++ b/.github/workflows/deploy_provers.yaml
@@ -3,7 +3,7 @@
 name: Deploy Provers
 on:
   workflow_run:
-    workflows: ["Release nightly"]
+    workflows: ["Release nightly", "Release stable"]
     types: [completed]
   workflow_dispatch:
 concurrency:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment workflow to trigger after completion of either the "Release nightly" or "Release stable" workflows, improving automation flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->