### PR TITLE
Specify commit in release creation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -343,6 +343,7 @@ jobs:
         run: |
           NOTES=$(gh api repos/${{ github.repository }}/releases/generate-notes \
             -f tag_name=${{ steps.tags.outputs.NEW_TAG }} \
+            -f target_commitish=${{ github.sha }} \
             -f previous_tag_name=${{ steps.tags.outputs.PREVIOUS_TAG }} \
             --jq .body)
           { 
@@ -411,6 +412,7 @@ jobs:
         run: |
           NOTES=$(gh api repos/${{ github.repository }}/releases/generate-notes \
             -f tag_name=${{ steps.tags.outputs.NEW_TAG }} \
+            -f target_commitish=${{ github.sha }} \
             -f previous_tag_name=${{ steps.tags.outputs.PREVIOUS_TAG }} \
             --jq .body)
           { 


### PR DESCRIPTION
- Specify the exact commits, important in case PRs are merged to `main` while the release is still running
- Reference: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#generate-release-notes-content-for-a-release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release process to ensure releases are created for the correct commit in both nightly and stable jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->