### PR TITLE
ci: stable release trigger browser extension deploy

### DIFF
--- a/.github/workflows/release_browser_extension.yaml
+++ b/.github/workflows/release_browser_extension.yaml
@@ -3,8 +3,9 @@
 
 name: Release Browser Extension
 on:
-  schedule:
-    - cron: "0 8 * * 2" # Tuesday at 08:00 UTC (09:00 CET / 10:00 CEST)
+  workflow_run:
+    workflows: ["Release stable"]
+    types: [completed]
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow to trigger browser extension release after successful completion of the "Release stable" workflow instead of on a weekly schedule. Manual trigger remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->