### PR TITLE
Handle leading non-zero bytes case in `u64_from_be_slice` function

### DIFF
--- a/rust/services/call/engine/src/travel_call/args.rs
+++ b/rust/services/call/engine/src/travel_call/args.rs
@@ -81,7 +81,7 @@ mod u64_from_be_slice {
     }
 
     #[test]
-    #[should_panic(expected = "slice must be at leas 8 bytes")]
+    #[should_panic(expected = "slice must be at least 8 bytes")]
     fn too_short() {
         let slice = [0];
         u64_from_be_slice(&slice);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved input validation for numeric conversions, preventing silent truncation of values and providing clearer error messages for invalid input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->