### PR TITLE
ci: remove run-services from vercel test

### DIFF
--- a/bash/e2e-web-proof-example-test.sh
+++ b/bash/e2e-web-proof-example-test.sh
@@ -12,17 +12,8 @@ set_proving_mode
 
 generate_ts_bindings
 
-echo "::group::Running services"
-DOCKER_COMPOSE_SERVICES="anvil-l1 anvil-l2-op wsproxy wsproxy-test-client notary-server"
-
-# source ${VLAYER_HOME}/bash/run-services.sh
 ./bash/mock-imageid.sh
-echo "::endgroup::Running services"
 
 build_extension
 
 run_web_tests simple-web-proof
-
-echo "::group::Cleanup"
-# cleanup
-echo "::endgroup::Cleanup"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the test script to simplify service management during end-to-end web proof example tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->