### PR TITLE
chore(web_prover): add more logs

### DIFF
--- a/rust/web_prover/src/notarize.rs
+++ b/rust/web_prover/src/notarize.rs
@@ -19,6 +19,8 @@ use crate::{NotarizeParams, RedactionConfig};
 const USER_AGENT: &str = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36";
 
 pub async fn notarize(params: NotarizeParams) -> Result<(Attestation, Secrets, RedactionConfig)> {
+    debug!("notarizing...");
+
     let NotarizeParams {
         notary_config,
         server_domain,


### PR DESCRIPTION
Running with

```
$ RUST_LOG="error,vlayer=debug,web_prover=debug" ./target/debug/vlayer web-proof-fetch...
```

is so much more pleasant now.