### PR TITLE
ci: Mark "stable" channel as "latest" on docker image registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -284,7 +284,7 @@ jobs:
         id: tags
         run: |
           tags="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.vlayer_release }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VLAYER_BUILD }}"
-          if [ "${{ inputs.vlayer_release }}" = "nightly" ]; then
+          if [ "${{ inputs.vlayer_release }}" = "stable" ]; then
             tags="${tags},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
           fi
           echo "TAGS=$tags" >> $GITHUB_ENV


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release workflow to apply the `latest` Docker image tag only for stable releases instead of nightly releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->