### PR TITLE
ci: use stable release for vdns and chain services

### DIFF
--- a/.github/workflows/deploy_chain_services.yaml
+++ b/.github/workflows/deploy_chain_services.yaml
@@ -1,5 +1,5 @@
-# Updates the chain services.
-# Uses a built binary, because chain service binaries are not released (yet).
+# Updates the chain services with a latest nightly vlayer release,
+# after a successful release.
 name: Deploy Chain Services
 on:
   workflow_dispatch:
@@ -13,39 +13,12 @@ jobs:
     defaults:
       run:
         working-directory: ansible
-    runs-on: aws-linux-medium
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-          submodules: recursive
-      - name: Install Rust prerequisites
-        uses: ./.github/actions/rust-prerequisites
-      - name: Install Risc0 prerequisites
-        uses: ./.github/actions/risc0
-      - name: Install contracts prerequisites
-        uses: ./.github/actions/contracts-prerequisites
-      - name: Install Ansible
-        uses: alex-oleshkevich/setup-ansible@b77f1a5e01dbcf520c28b545fa37c8f022c1803a
-        with:
-          version: "11.2.0"
-
-      # Needed until we have those binaries released.
-      - name: Build chain service binaries
-        env:
-          VLAYER_RELEASE: "nightly"
-          RISC0_USE_DOCKER: 1
-        run: cargo build --release --bin worker --bin chain_server
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: chain-service-binaries
-          path: |
-            target/release/worker
-            target/release/chain_server
-          retention-days: 2
-
       - name: Install ansible galaxy collections
         run: |
           ansible-galaxy collection install -r requirements.yml

--- a/.github/workflows/deploy_vdns.yaml
+++ b/.github/workflows/deploy_vdns.yaml
@@ -1,9 +1,9 @@
-# Auto-updates the VDNS server with a latest nightly vlayer release,
+# Auto-updates the VDNS server with a latest stable vlayer release,
 # after a successful release.
 name: Deploy VDNS
 on:
   workflow_run:
-    workflows: ["Release nightly"]
+    workflows: ["Release stable"]
     types: [completed]
   workflow_dispatch:
 concurrency:

--- a/ansible/group_vars/chain_services.yml
+++ b/ansible/group_vars/chain_services.yml
@@ -5,3 +5,4 @@ chain_worker_rust_log:
 chain_server_rust_log:
   - info
 chain_services_db_path: "/data/chain_db"
+vlayer_release_channel: stable

--- a/ansible/group_vars/verifiable_dns_services.yml
+++ b/ansible/group_vars/verifiable_dns_services.yml
@@ -4,3 +4,4 @@ verifiable_dns_rust_log:
   - info
   - dns_server=debug
 vlayer_jwt_public_key_location: /home/{{ ansible_user }}/.vlayer/jwt.key.pub
+vlayer_release_channel: stable

--- a/ansible/roles/chain_server/README.md
+++ b/ansible/roles/chain_server/README.md
@@ -6,6 +6,7 @@ Installs the vlayer Chain Server service.
 
 | Name | Purpose |
 | --- | --- |
+| `vlayer_release_channel` | Stable or nightly release channel. |
 | `chain_server_rust_log` | An array of log levels for constructing [`RUST_LOG`](https://rust-lang-nursery.github.io/rust-cookbook/development_tools/debugging/config_log.html). |
 | `chain_server_host` | Host to bind to, for example `127.0.0.1` or `0.0.0.0`. |
 | `chain_server_port` | A port on which the chain server should listen. |

--- a/ansible/roles/chain_server/tasks/main.yml
+++ b/ansible/roles/chain_server/tasks/main.yml
@@ -2,20 +2,24 @@
 - name: Install log configuration
   ansible.builtin.import_tasks: logs.yml
 
-- name: Create vlayer directory
-  become: true
-  ansible.builtin.file:
-    path: /opt/vlayer
-    state: directory
-    mode: '755'
+- name: Install vlayerup
+  ansible.builtin.shell: |
+    set -ueo pipefail
+    curl -SL https://install.vlayer.xyz | bash
+  args:
+    creates: ~/.vlayer/bin/vlayerup
+    executable: /bin/bash
 
-# Copying a built binary because the binary is not a part of the release (yet).
-- name: Copy chain server binary
-  become: true
-  ansible.builtin.copy:
-    src: ../target/release/chain_server
-    dest: /opt/vlayer/chain_server
-    mode: '755'
+# We're installing a most-recent nightly or stable version every time.
+- name: Install chain server binary # noqa: no-changed-when
+  ansible.builtin.shell: |
+    export PATH="$PATH:~/.foundry/bin"
+    ~/.vlayer/bin/vlayerup --channel {{ vlayer_release_channel }}
+  args:
+    executable: /bin/bash
+  async: 600  # 10 minutes to complete
+  poll: 10  # check every 10 seconds
+  retries: 2
   notify: "Restart vlayer"
 
 - name: Install service file

--- a/ansible/roles/chain_server/templates/vlayer-chain-server.service.j2
+++ b/ansible/roles/chain_server/templates/vlayer-chain-server.service.j2
@@ -17,7 +17,7 @@ SyslogFacility=local0
 Environment=RUST_LOG={{ chain_server_rust_log | join(',') }}
 Environment=VLAYER_LOG_FORMAT=json
 Environment=DB_PATH={{ chain_server_db_path }}
-ExecStart=/opt/vlayer/chain_server --listen-addr {{ chain_server_host }}:{{ chain_server_port }}
+ExecStart=/home/{{ ansible_user }}/.vlayer/bin/chain_server --listen-addr {{ chain_server_host }}:{{ chain_server_port }}
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/chain_worker/README.md
+++ b/ansible/roles/chain_worker/README.md
@@ -8,6 +8,7 @@ Typically, more than 1 chain worker would be installed on a single machine.
 
 | Name | Purpose |
 | --- | --- |
+| `vlayer_release_channel` | Stable or nightly release channel. |
 | `chain_worker_identifier` | An identifier for distinguishing multiple workers running on a single machine. |
 | `chain_worker_rust_log` | An array of log levels for constructing [`RUST_LOG`](https://rust-lang-nursery.github.io/rust-cookbook/development_tools/debugging/config_log.html). |
 | `chain_worker_db_path` | Where is the DB located. |

--- a/ansible/roles/chain_worker/tasks/main.yml
+++ b/ansible/roles/chain_worker/tasks/main.yml
@@ -3,23 +3,27 @@
   ansible.builtin.import_role:
     name: risc0
 
+- name: Install vlayerup
+  ansible.builtin.shell: |
+    set -ueo pipefail
+    curl -SL https://install.vlayer.xyz | bash
+  args:
+    creates: ~/.vlayer/bin/vlayerup
+    executable: /bin/bash
+
 - name: Install log configuration
   ansible.builtin.import_tasks: logs.yml
 
-- name: Create vlayer directory
-  become: true
-  ansible.builtin.file:
-    path: /opt/vlayer
-    state: directory
-    mode: '755'
-
-# Copying a built binary because the binary is not a part of the release (yet).
-- name: Copy chain worker binary
-  become: true
-  ansible.builtin.copy:
-    src: ../target/release/worker
-    dest: /opt/vlayer/chain_worker
-    mode: '755'
+# We're installing a most-recent nightly or stable version every time.
+- name: Install chain worker binary # noqa: no-changed-when
+  ansible.builtin.shell: |
+    export PATH="$PATH:~/.foundry/bin"
+    ~/.vlayer/bin/vlayerup --channel {{ vlayer_release_channel }}
+  args:
+    executable: /bin/bash
+  async: 600  # 10 minutes to complete
+  poll: 10  # check every 10 seconds
+  retries: 2
   notify: "Restart vlayer"
 
 - name: Install service file

--- a/ansible/roles/chain_worker/templates/vlayer-chain-worker.service.j2
+++ b/ansible/roles/chain_worker/templates/vlayer-chain-worker.service.j2
@@ -24,7 +24,7 @@ Environment=PROOF_MODE={{ chain_worker_proof_mode }}
 Environment=MAX_BACK_PROPAGATION_BLOCKS={{ chain_worker_max_back_propagation_blocks }}
 Environment=MAX_HEAD_BLOCKS={{ chain_worker_max_head_blocks }}
 Environment=CONFIRMATIONS={{ chain_worker_confirmations }}
-ExecStart=/opt/vlayer/chain_worker
+ExecStart=/home/{{ ansible_user }}/.vlayer/bin/worker
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/prover/tasks/main.yml
+++ b/ansible/roles/prover/tasks/main.yml
@@ -21,7 +21,7 @@
     mode: '644'
   notify: "Restart vlayer"
 
-# We're installing a most-recent nightly version every time.
+# We're installing a most-recent nightly or stable version every time.
 - name: Install vlayer # noqa: no-changed-when
   ansible.builtin.shell: |
     export PATH="$PATH:~/.foundry/bin"

--- a/ansible/roles/verifiable_dns/tasks/main.yml
+++ b/ansible/roles/verifiable_dns/tasks/main.yml
@@ -20,11 +20,11 @@
     mode: '644'
   notify: "Restart verifiable dns"
 
-# We're installing a most-recent nightly version every time.
+# We're installing a most-recent nightly or stable version every time.
 - name: Install dns service binary # noqa: no-changed-when
   ansible.builtin.shell: |
     export PATH="$PATH:~/.foundry/bin"
-    ~/.vlayer/bin/vlayerup
+    ~/.vlayer/bin/vlayerup --channel {{ vlayer_release_channel }}
   args:
     executable: /bin/bash
   async: 600  # 10 minutes to complete


### PR DESCRIPTION
Previously, chain services were not released as binaries, so in the deployment workflows we built it from code.

Now, the binaries are there so we change the deployment to use `vlayerup`, same as others.
Also, changing the channel to "stable" (including vdns)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment workflows to use the latest stable or nightly releases for chain services and VDNS, with improved automation and simplified steps.
  - Deployment now installs binaries dynamically using a new tool, removing the need for manual binary copying and directory setup.
  - Added configurable release channel support (stable or nightly) for service installations.
- **Documentation**
  - Updated documentation to describe the new release channel variable and clarify installation processes in relevant roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->