### PR TITLE
ci: don't deploy examples from main, only from stable

### DIFF
--- a/.github/actions/example-deploy/action.yaml
+++ b/.github/actions/example-deploy/action.yaml
@@ -126,7 +126,7 @@ runs:
       working-directory: ./examples/${{ inputs.example_name }}/vlayer
 
     - name: Deploy to Vercel
-      if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
       shell: bash
       env:
         VERCEL_ENV: production

--- a/.github/workflows/deploy_simple_email_proof.yaml
+++ b/.github/workflows/deploy_simple_email_proof.yaml
@@ -7,12 +7,6 @@ on:
     paths:
       - examples/simple-email-proof/**
       - .github/workflows/deploy_simple_email_proof.yaml
-  push:
-    paths:
-      - examples/simple-email-proof/**
-      - .github/workflows/deploy_simple_email_proof.yaml
-    branches:
-      - main
 concurrency:
   # Do not cancel jobs on main by forcing a unique group name.
   group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.run_id || github.ref_name }}

--- a/.github/workflows/deploy_simple_teleport.yaml
+++ b/.github/workflows/deploy_simple_teleport.yaml
@@ -7,12 +7,6 @@ on:
     paths:
       - examples/simple-teleport/**
       - .github/workflows/deploy_simple_teleport.yaml
-  push:
-    paths:
-      - examples/simple-teleport/**
-      - .github/workflows/deploy_simple_teleport.yaml
-    branches:
-      - main
 concurrency:
   # Do not cancel jobs on main by forcing a unique group name.
   group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.run_id || github.ref_name }}

--- a/.github/workflows/deploy_simple_time-travel.yaml
+++ b/.github/workflows/deploy_simple_time-travel.yaml
@@ -7,12 +7,6 @@ on:
     paths:
       - examples/simple-time-travel/**
       - .github/workflows/deploy_simple_time-travel.yaml
-  push:
-    paths:
-      - examples/simple-time-travel/**
-      - .github/workflows/deploy_simple_time-travel.yaml
-    branches:
-      - main
 concurrency:
   # Do not cancel jobs on main by forcing a unique group name.
   group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.run_id || github.ref_name }}

--- a/.github/workflows/deploy_simple_web_proof.yaml
+++ b/.github/workflows/deploy_simple_web_proof.yaml
@@ -8,12 +8,6 @@ on:
       - examples/simple-web-proof/**
       - .github/workflows/deploy_simple_web_proof.yaml
       - bash/e2e-web-proof-example-test.sh
-  push:
-    paths:
-      - examples/simple-web-proof/**
-      - .github/workflows/deploy_simple_web_proof.yaml
-    branches:
-      - main
 concurrency:
   # Do not cancel jobs on main by forcing a unique group name.
   group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.run_id || github.ref_name }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated deployment workflows to only trigger on successful completion of related workflows or relevant pull requests, removing direct push-based triggers for improved workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->