### PR TITLE
Allow unsafe body redaction in E2E playwright tests

### DIFF
--- a/contracts/fixtures/src/vlayer/LotrApiProver.sol
+++ b/contracts/fixtures/src/vlayer/LotrApiProver.sol
@@ -22,7 +22,7 @@ contract LotrApiProver is Prover {
     // solhint-disable-next-line func-name-mixedcase
     function web_proof(WebProof calldata webProof) public view returns (Proof memory, string memory, string memory) {
         Web memory web =
-            WebProofLib.recover(webProof, WebProofLib.UrlTestMode.Full, WebProofLib.BodyRedactionMode.Disabled);
+            WebProofLib.recover(webProof, WebProofLib.UrlTestMode.Prefix, WebProofLib.BodyRedactionMode.Enabled_UNSAFE);
 
         require(NOTARY_PUB_KEY.equal(web.notaryPubKey), "Incorrect notary public key");
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the processing of web proofs to use prefix matching for URLs and enabled an unsafe mode for body redaction, affecting how web proof data is handled during verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->