### PR TITLE
ci: Add prod prover to automatic deployment

### DIFF
--- a/.github/workflows/deploy_provers_stable.yaml
+++ b/.github/workflows/deploy_provers_stable.yaml
@@ -32,7 +32,7 @@ jobs:
           eval "$(ssh-agent -s)"
           ssh-add - <<< "${{ secrets.PRODUCTION_DEPLOYER_SSH_KEY }}"
 
-          ansible-playbook -i hosts.yml prover.yml --limit "stable_fake_prover" \
+          ansible-playbook -i hosts.yml prover.yml --limit "stable_fake_prover,stable_prod_prover" \
             --vault-password-file <(echo '${{ secrets.ANSIBLE_PRODUCTION_VAULT_PASSWORD }}')
       - name: Clean up manually added ssh keys
         if: always()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment workflow to include both "stable_fake_prover" and "stable_prod_prover" host groups during stable provers deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->