### PR TITLE
docs: remove not working instruction for docker compose devnet

### DIFF
--- a/book/src/getting-started/dev-and-production.md
+++ b/book/src/getting-started/dev-and-production.md
@@ -62,13 +62,6 @@ bun run devnet:down
 ```
 It is useful in case of any Docker configuration change. 
 
-#### Outside of the vlayer project
-
-Download and run vlayer [Docker Compose](https://install.vlayer.xyz/devnet) to start services:
-```sh
-docker compose -f <(curl -L https://install.vlayer.xyz/devnet) up -d
-```
-
 ### Available Services
 
 | Service            | Endpoint                       | Description                                 |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed instructions for starting devnet services using the vlayer Docker Compose setup outside the project directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->