### PR TITLE
fix(call_server): rename Environment::Mainnet to Environment::Production

### DIFF
--- a/rust/jwt/src/lib.rs
+++ b/rust/jwt/src/lib.rs
@@ -13,7 +13,7 @@ use strum::{Display, EnumString};
 pub enum Environment {
     #[default]
     Test,
-    Mainnet,
+    Production,
 }
 
 #[derive(Builder, Debug, Clone, Serialize, Deserialize)]
@@ -124,17 +124,17 @@ mod tests {
     }
 
     #[test]
-    fn decodes_as_mainnet() {
+    fn decodes_as_production() {
         let jwt = token(&TokenArgs {
             secret: JWT_SECRET,
             host: None,
             port: None,
             invalid_after: 0,
             subject: "1234",
-            environment: Some(Environment::Mainnet),
+            environment: Some(Environment::Production),
         });
         let token_data: TokenData<Claims> =
             decode(&jwt, &decoding_key(), &Validation::default()).unwrap();
-        assert_eq!(token_data.claims.environment, Some(Environment::Mainnet));
+        assert_eq!(token_data.claims.environment, Some(Environment::Production));
     }
 }

--- a/rust/services/call/server_lib/src/jwt.rs
+++ b/rust/services/call/server_lib/src/jwt.rs
@@ -57,7 +57,7 @@ impl IntoResponse for Error {
 
 const fn proof_mode_from_environment(environment: Environment) -> ProofMode {
     match environment {
-        Environment::Mainnet => ProofMode::Groth16,
+        Environment::Production => ProofMode::Groth16,
         Environment::Test => ProofMode::Fake,
     }
 }
@@ -73,7 +73,7 @@ mod tests {
             .with_proof_mode(ProofMode::Groth16)
             .build()
             .unwrap();
-        let environment = Some(Environment::Mainnet);
+        let environment = Some(Environment::Production);
         let result = validate_environment(&config, environment);
         assert!(result.is_ok());
     }
@@ -117,7 +117,7 @@ mod tests {
             .with_proof_mode(ProofMode::Fake)
             .build()
             .unwrap();
-        let environment = Some(Environment::Mainnet);
+        let environment = Some(Environment::Production);
         let result = validate_environment(&config, environment);
         assert!(result.is_err());
     }

--- a/rust/services/call/server_lib/tests/integration_tests.rs
+++ b/rust/services/call/server_lib/tests/integration_tests.rs
@@ -599,7 +599,7 @@ mod server_tests {
             let claims = ClaimsBuilder::default()
                 .exp(ts)
                 .sub("1234".to_string())
-                .environment(Environment::Mainnet)
+                .environment(Environment::Production)
                 .build()
                 .unwrap();
             let token = encode(&Header::default(), &claims, &key).unwrap();
@@ -611,7 +611,7 @@ mod server_tests {
             assert_eq!(StatusCode::BAD_REQUEST, resp.status());
             assert_json_eq!(
                 body_to_json(resp.into_body()).await,
-                json!({ "error": "Invalid environment in JWT: mainnet, prover server proof mode: fake" }),
+                json!({ "error": "Invalid environment in JWT: production, prover server proof mode: fake" }),
             );
         }
 


### PR DESCRIPTION
This now matches JWT claims generated by the dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the environment variant from "Mainnet" to "Production" across the app for improved consistency in environment naming.

- **Tests**
  - Updated test names, references, and expected values to reflect the new "Production" environment naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->