### PR TITLE
feat(cli,jwt): optionally validate JWT signature if pubkey specified

### DIFF
--- a/rust/cli/src/commands/jwt.rs
+++ b/rust/cli/src/commands/jwt.rs
@@ -1,4 +1,7 @@
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use anyhow::Context;
 use clap::{Args as ClapArgs, Parser, Subcommand};
@@ -147,9 +150,9 @@ fn decode_jwt(args: Decode) -> Result<()> {
 }
 
 fn parse_decoding_key(path: impl AsRef<Path>) -> Result<DecodingKey> {
-    let pub_key = fs::read(public_key_path)
-        .with_context(|| format!("public key {} not found", public_key_path.display()))?;
-    DecodingKey::from_rsa_pem(&x).map_err(Error::Jwt)
+    let pub_key = fs::read(path.as_ref())
+        .with_context(|| format!("public key {} not found", path.as_ref().display()))?;
+    DecodingKey::from_rsa_pem(&pub_key).map_err(Error::Jwt)
 }
 
 fn parse_host(host: impl AsRef<str>) -> Result<(String, u16)> {


### PR DESCRIPTION
Until now, we always required the public key to be specified which is a little cumbersome and not always desired. Instead, a better UX in my opinion would be to optionally require the public key and if not present, dump the JWT contents *without* signature validation. Then, if the key is present, we would additionally validate the signature also.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for decoding JWTs without requiring a public key, allowing signature validation to be skipped if no key is provided.

- **Documentation**
  - Updated help text to clarify behavior when the public key is not specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->