### PR TITLE
bug: add enoughBalance check to teleport example UI

### DIFF
--- a/examples/simple-teleport/vlayer/src/pages/confirmMint/index.tsx
+++ b/examples/simple-teleport/vlayer/src/pages/confirmMint/index.tsx
@@ -57,7 +57,8 @@ export const ConfirmMintPage = () => {
       args: [proof, owner, tokens],
     });
   };
-  const enoughBalance = balance?.value && balance.value > 0n;
+  // estimated price for Sepolia verification tx
+  const enoughBalance = balance?.value && balance.value > 3000000000000000n;
 
   if (!holderAddress) {
     return <ConnectWallet />;
@@ -99,11 +100,7 @@ export const ConfirmMintPage = () => {
         />
       </div>
       <div className="mt-5 flex justify-center">
-        <button
-          type="submit"
-          id="nextButton"
-          disabled={isLoading || !enoughBalance}
-        >
+        <button type="submit" id="nextButton" disabled={isLoading}>
           {isLoading ? "Minting..." : "Mint token"}
         </button>
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a balance check before allowing minting; the mint button is now disabled if the wallet has insufficient funds.
  - Displayed a warning message with a link to an ETH Sepolia Faucet when the wallet balance is too low to mint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->