### PR TITLE
fix(sdk): increase sleep duration to 3s to factor in bonsai times

### DIFF
--- a/packages/sdk/src/api/lib/client.ts
+++ b/packages/sdk/src/api/lib/client.ts
@@ -92,7 +92,7 @@ export const createVlayerClient = (
     >({
       hash,
       numberOfRetries = 900,
-      sleepDuration = 1000,
+      sleepDuration = 3000,
     }: {
       hash: BrandedHash<T, F>;
       numberOfRetries?: number;

--- a/packages/sdk/src/api/prover.ts
+++ b/packages/sdk/src/api/prover.ts
@@ -103,7 +103,7 @@ export async function waitForProof<
   url: string,
   token?: string,
   numberOfRetries: number = 900,
-  sleepDuration: number = 1000,
+  sleepDuration: number = 3000,
 ): Promise<ProofDataWithMetrics> {
   for (let retry = 0; retry < numberOfRetries; retry++) {
     const { state, data, metrics } = await getProofReceipt(hash, url, token);


### PR DESCRIPTION
This effectively confirms @rzadp's hypothesis that 503 we observed when testing mainnet pre-release is the SDK hitting the rate limit of the prover's nginx instance which is directly related to longer zk proving times due to the use of Bonsai.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Increased the default polling interval when waiting for proof results, resulting in a longer wait time between status checks. This may reduce the frequency of status updates during proof generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->