### PR TITLE
Add extensive proof mode validation

### DIFF
--- a/rust/host_utils/src/prover.rs
+++ b/rust/host_utils/src/prover.rs
@@ -12,7 +12,7 @@ use crate::ProofMode;
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct Prover {
-    mode: ProofMode,
+    pub mode: ProofMode,
 }
 
 #[derive(Debug, Error, Derivative)]

--- a/rust/services/call/host/src/host/prover.rs
+++ b/rust/services/call/host/src/host/prover.rs
@@ -1,7 +1,8 @@
+use anyhow::bail;
 use bytes::Bytes;
 use call_engine::Input;
 use host_utils::{ProofMode, Prover as Risc0Prover, proving};
-use risc0_zkvm::{ExecutorEnv, ProveInfo};
+use risc0_zkvm::{ExecutorEnv, InnerReceipt, ProveInfo};
 use tracing::instrument;
 
 #[derive(Debug, Clone, Default)]
@@ -24,16 +25,20 @@ impl Prover {
     /// Wrapper around Risc0Prover which specifies the call guest ELF
     #[instrument(skip_all)]
     pub fn prove(&self, input: &Input) -> proving::Result<ProveInfo> {
-        let executor_env = build_executor_env(input)?;
+        let executor_env = build_executor_env(input, self.prover.mode)?;
         Ok(self.prover.prove(executor_env, &self.guest_elf)?)
     }
 }
 
-fn build_executor_env(input: &Input) -> anyhow::Result<ExecutorEnv<'static>> {
+fn build_executor_env(
+    input: &Input,
+    proof_mode: ProofMode,
+) -> anyhow::Result<ExecutorEnv<'static>> {
     input
         .chain_proofs
         .values()
         .try_fold(ExecutorEnv::builder(), |mut builder, (_, proof)| {
+            validate_proof_mode_coherence(proof_mode, &proof.receipt.inner)?;
             builder.add_assumption(proof.receipt.clone());
             Ok::<_, anyhow::Error>(builder)
         })?
@@ -41,6 +46,29 @@ fn build_executor_env(input: &Input) -> anyhow::Result<ExecutorEnv<'static>> {
         // Workaround for r0vm bug reproed in: https://github.com/vlayer-xyz/risc0-r0vm-fake-repro
         .segment_limit_po2(22)
         .build()
+}
+
+fn validate_proof_mode_coherence(
+    proof_mode: ProofMode,
+    assumption_receipt: &InnerReceipt,
+) -> anyhow::Result<()> {
+    use InnerReceipt::*;
+    match assumption_receipt {
+        Fake(_) if proof_mode == ProofMode::Fake => Ok(()),
+        Succinct(_) if proof_mode == ProofMode::Groth16 => Ok(()),
+        Fake(_) => bail!("Trying to include a fake proof within {} proof", proof_mode),
+        Succinct(_) => bail!("Trying to include a succinct proof within {} proof", proof_mode),
+        Composite(_) | Groth16(_) => bail!(
+            "Trying to include a {} proof within {} proof. One can only use fake or succinct proofs as assumptions",
+            match assumption_receipt {
+                Composite(_) => "composite",
+                Groth16(_) => "Groth16",
+                _ => unreachable!(), // already matched above
+            },
+            proof_mode
+        ),
+        _ => unreachable!("Unknown proof mode in assumption receipt: {:?}", assumption_receipt),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
We've had a bunch of issues looking like: `ZK Verification failed - invalid proof` when trying to test on bonsai.
They appeared after we tried to connect assumption proven in a fake way to a proof proven with Groth16. This should be rejected earlier and with a clear error message which this PR accomplishes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stricter validation to ensure that proof modes are consistent when including assumption proofs, providing clearer error messages if there is a mismatch.

- **Improvements**
  - Enhanced reliability by enforcing coherence between the selected proof mode and the types of proofs that can be used.
  - The proof mode setting is now accessible for external use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->