### PR TITLE
feat: add example data for mainnet examples

### DIFF
--- a/examples/simple-teleport/vlayer/constants.ts
+++ b/examples/simple-teleport/vlayer/constants.ts
@@ -24,6 +24,14 @@ export const chainToTeleportConfig: Record<string, TeleportConfig> = {
       erc20BlockNumbers: "25181931",
     },
   },
+  mainnet: {
+    tokenHolder: "0xacD03D601e5bB1B275Bb94076fF46ED9D753435A",
+    prover: {
+      erc20Addresses: "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
+      erc20ChainIds: "10",
+      erc20BlockNumbers: "135720596",
+    },
+  },
 };
 
 export const getTeleportConfig = (chainName: string): TeleportConfig => {

--- a/examples/simple-time-travel/vlayer/constants.ts
+++ b/examples/simple-time-travel/vlayer/constants.ts
@@ -25,6 +25,15 @@ export const chainToTimeTravelConfig: Record<string, TimeTravelConfig> = {
       step: BigInt(2),
     },
   },
+  mainnet: {
+    tokenOwner: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+    usdcTokenAddr: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    prover: {
+      endBlock: "latest",
+      travelRange: BigInt(10),
+      step: BigInt(2),
+    },
+  },
 };
 
 export const getTimeTravelConfig = (chainName: string): TimeTravelConfig => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the "mainnet" chain in teleport and time travel configuration examples, enabling mainnet-specific settings and parameters for these features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->