### PR TITLE
fix: proving on slower chains using viem (all CLI examples)

### DIFF
--- a/examples/kraken-web-proof/vlayer/prove.ts
+++ b/examples/kraken-web-proof/vlayer/prove.ts
@@ -70,6 +70,17 @@ const [proof, avgPrice] = result;
 console.log("✅ Proof generated");
 
 console.log("⏳ Verifying...");
+
+// Workaround for viem estimating gas with `latest` block causing future block assumptions to fail on slower chains like mainnet/sepolia
+const gas = await ethClient.estimateContractGas({
+  address: verifier,
+  abi: verifierSpec.abi,
+  functionName: "verify",
+  args: [proof, avgPrice],
+  account,
+  blockTag: "pending",
+});
+
 const txHash = await ethClient.writeContract({
   address: verifier,
   abi: verifierSpec.abi,
@@ -77,6 +88,7 @@ const txHash = await ethClient.writeContract({
   args: [proof, avgPrice],
   chain,
   account,
+  gas,
 });
 
 await ethClient.waitForTransactionReceipt({

--- a/examples/simple-email-proof/vlayer/prove.ts
+++ b/examples/simple-email-proof/vlayer/prove.ts
@@ -61,12 +61,23 @@ const result = await vlayer.waitForProvingResult({ hash });
 
 console.log("Verifying...");
 
+// Workaround for viem estimating gas with `latest` block causing future block assumptions to fail on slower chains like mainnet/sepolia
+const gas = await ethClient.estimateContractGas({
+  address: verifier,
+  abi: verifierSpec.abi,
+  functionName: "verify",
+  args: result,
+  account: john,
+  blockTag: "pending",
+});
+
 const verificationHash = await ethClient.writeContract({
   address: verifier,
   abi: verifierSpec.abi,
   functionName: "verify",
   args: result,
   account: john,
+  gas,
 });
 
 const receipt = await ethClient.waitForTransactionReceipt({

--- a/examples/simple-teleport/vlayer/prove.ts
+++ b/examples/simple-teleport/vlayer/prove.ts
@@ -76,12 +76,23 @@ const result = await vlayer.waitForProvingResult({ hash: proofHash });
 console.log("Proof:", result[0]);
 console.log("⏳ Verifying...");
 
+// Workaround for viem estimating gas with `latest` block causing future block assumptions to fail on slower chains like mainnet/sepolia
+const gas = await ethClient.estimateContractGas({
+  address: verifier,
+  abi: verifierSpec.abi,
+  functionName: "claim",
+  args: result,
+  account,
+  blockTag: "pending",
+});
+
 const verificationHash = await ethClient.writeContract({
   address: verifier,
   abi: verifierSpec.abi,
   functionName: "claim",
   args: result,
   account,
+  gas,
 });
 
 const receipt = await ethClient.waitForTransactionReceipt({

--- a/examples/simple-time-travel/vlayer/prove.ts
+++ b/examples/simple-time-travel/vlayer/prove.ts
@@ -64,12 +64,23 @@ const result = await vlayer.waitForProvingResult({ hash: provingHash });
 console.log("Proof:", result[0]);
 console.log("Verifying...");
 
+// Workaround for viem estimating gas with `latest` block causing future block assumptions to fail on slower chains like mainnet/sepolia
+const gas = await ethClient.estimateContractGas({
+  address: verifier,
+  abi: verifierSpec.abi,
+  functionName: "claim",
+  args: result,
+  account,
+  blockTag: "pending",
+});
+
 const verificationHash = await ethClient.writeContract({
   address: verifier,
   abi: verifierSpec.abi,
   functionName: "claim",
   args: result,
   account,
+  gas,
 });
 
 const receipt = await waitForTransactionReceipt({

--- a/examples/simple-web-proof/vlayer/prove.ts
+++ b/examples/simple-web-proof/vlayer/prove.ts
@@ -81,6 +81,16 @@ async function testSuccessProvingAndVerification({
 
   console.log("Verifying...");
 
+  // Workaround for viem estimating gas with `latest` block causing future block assumptions to fail on slower chains like mainnet/sepolia
+  const gas = await ethClient.estimateContractGas({
+    address: verifier,
+    abi: verifierSpec.abi,
+    functionName: "verify",
+    args: [proof, twitterHandle, address],
+    account,
+    blockTag: "pending",
+  });
+
   const txHash = await ethClient.writeContract({
     address: verifier,
     abi: verifierSpec.abi,
@@ -88,6 +98,7 @@ async function testSuccessProvingAndVerification({
     args: [proof, twitterHandle, address],
     chain,
     account,
+    gas,
   });
 
   await ethClient.waitForTransactionReceipt({

--- a/examples/simple/vlayer/prove.ts
+++ b/examples/simple/vlayer/prove.ts
@@ -77,6 +77,15 @@ const result = await vlayer.waitForProvingResult({ hash });
 const [proof, owner, balance] = result;
 
 console.log("Proof result:", result);
+// Workaround for viem estimating gas with `latest` block causing future block assumptions to fail on slower chains like mainnet/sepolia
+const gas = await ethClient.estimateContractGas({
+  address: verifier,
+  abi: verifierSpec.abi,
+  functionName: "claimWhale",
+  args: [proof, owner, balance],
+  account: john,
+  blockTag: "pending",
+});
 
 const verificationHash = await ethClient.writeContract({
   address: verifier,
@@ -84,6 +93,7 @@ const verificationHash = await ethClient.writeContract({
   functionName: "claimWhale",
   args: [proof, owner, balance],
   account: john,
+  gas,
 });
 
 const receipt = await ethClient.waitForTransactionReceipt({


### PR DESCRIPTION
Viem estimates gas using the latest block, which causes assertions to fail when the prover assumes callAssumptions.blockNumber < block.number or when blockhash is unavailable for the current block. 

This PR adds a workaround to `prove.ts` scripts. Error didn't show up in UI cases as probably meta mask  (or other wallets) do gas estimations in different way. 