### PR TITLE
fix(sdk-hooks): respect chainId arg in useCallProver args

### DIFF
--- a/packages/sdk-hooks/src/useCallProver/useCallProver.ts
+++ b/packages/sdk-hooks/src/useCallProver/useCallProver.ts
@@ -22,7 +22,8 @@ export const useCallProver = (
   // read vlayer client from context
   const { vlayerClient } = useProofContext();
   // read chainId from wagmi
-  const chainId = proveArgs.chainId ?? useChainId();
+  const wagmiChainId = useChainId();
+  const chainId = proveArgs.chainId ?? wagmiChainId;
 
   // state
   const [status, setStatus] = useState<ProverStatus>(ProverStatus.Idle);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved how the chain ID is determined, allowing an explicitly provided chain ID to take precedence over the default value. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->