### PR TITLE
ci: Increase chain service rate limiting

### DIFF
--- a/ansible/roles/chain_service_nginx/defaults/main.yml
+++ b/ansible/roles/chain_service_nginx/defaults/main.yml
@@ -1,2 +1,2 @@
-chain_service_nginx_ip_rate_limit_per_minute: 30
-chain_service_nginx_ip_rate_limit_burst: 5
+chain_service_nginx_ip_rate_limit_per_minute: 60
+chain_service_nginx_ip_rate_limit_burst: 30


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the default rate limit for incoming requests per IP from 30 to 60 per minute.
  - Raised the burst limit for requests from 5 to 30, allowing higher short-term traffic spikes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->