### PR TITLE
fix: remove testnet RPC URLs from stable_prod_prover.yml

### DIFF
--- a/ansible/host_vars/stable_prod_prover.yml
+++ b/ansible/host_vars/stable_prod_prover.yml
@@ -27,40 +27,28 @@ vlayer_alchemy_api_key: !vault |
   63343030643438373066326432356565363534623131306166383939656563623537656535626161
   6164386166343532386262626237643763623366376537663030
 vlayer_prover_rpc_urls:
- - "11155111:https://omniscient-flashy-frog.ethereum-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
- - "11155420:https://omniscient-flashy-frog.optimism-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
  - "1:https://eth-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "8453:https://base-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "10:https://opt-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "84532:https://omniscient-flashy-frog.base-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
- - "80002:https://polygon-amoy.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "421614:https://arb-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "300:https://zksync-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "8453:https://base-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "42161:https://arb-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "42170:https://arbnova-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "137:https://polygon-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "324:https://zksync-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "747:https://flow-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "545:https://flow-testnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "534352:https://scroll-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "534351:https://scroll-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "5000:https://mantle-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "59144:https://linea-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "59141:https://linea-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "100:https://gnosis-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "10200:https://gnosis-chiado.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  # https://docs.bitkubchain.org/rpc-service/rpc
  # The rate limit of RPC endpoint on Mainnet and Testnet is 2K/1min.
  - "96:https://rpc.bitkubchain.io"
- - "25925:https://rpc-testnet.bitkubchain.io"
  # https://docs.kinto.xyz/kinto-the-safe-l2/building-on-kinto/tools/node-rpc
  - "7887:https://rpc.kinto-rpc.com"
  # https://docs.celo.org/network
  - "42220:https://forno.celo.org"
  # https://docs.zircuit.com/dev-tools/rpc-endpoints
  - "48900:https://zircuit1-mainnet.p2pify.com"
- - "48899:https://zircuit1-testnet.p2pify.com"
  # https://docs.fhenix.zone/getting-started
  - "8008135:https://api.helium.fhenix.zone"
 vlayer_prover_gas_meter_url: "https://dashboard.vlayer.xyz/api/webhooks/prover"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed multiple testnet and Sepolia RPC URLs from configuration, retaining primarily mainnet endpoints. No other settings were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->