### PR TITLE
fix(extension): countdown display [ENGA-674]

### DIFF
--- a/packages/browser-extension/src/components/molecules/StepActions/Notarize/NotarizeStepActions.hooks.tsx
+++ b/packages/browser-extension/src/components/molecules/StepActions/Notarize/NotarizeStepActions.hooks.tsx
@@ -145,13 +145,7 @@ const useRedirectCallout = () => {
     if (isWebProving) {
       setIsRedirectCalloutVisible(true);
     }
-    if (
-      !isWebProving ||
-      isWebProvingDone ||
-      timeout === 0 ||
-      isWebProvingError ||
-      isZkProvingError
-    ) {
+    if (timeout === 0 || isWebProvingError || isZkProvingError) {
       setIsRedirectCalloutVisible(false);
     }
   }, [

--- a/packages/browser-extension/src/components/molecules/StepActions/Notarize/NotarizeStepActions.hooks.tsx
+++ b/packages/browser-extension/src/components/molecules/StepActions/Notarize/NotarizeStepActions.hooks.tsx
@@ -131,18 +131,13 @@ const useRedirectCallout = () => {
     error: isWebProvingError,
   } = useTlsnProver();
   const { error: isZkProvingError } = useZkProvingState();
+
   const [isRedirectCalloutVisible, setIsRedirectCalloutVisible] =
-    useDebounceValue(false, CALLOUT_DEBOUNCE_TIME);
+    useState(false);
+
   const redirectDelay =
     import.meta.env.REDIRECT_DELAY_SECONDS || DEFAULT_REDIRECT_DELAY_SECONDS;
   const [timeout, setTimeout] = useState(redirectDelay);
-
-  // reset timeout when web proving stops
-  useEffect(() => {
-    if (!isWebProving) {
-      setTimeout(redirectDelay);
-    }
-  }, [isWebProving, redirectDelay]);
 
   // redirection callout should be visible when web proving starts
   // and stay till redirection or error
@@ -150,20 +145,19 @@ const useRedirectCallout = () => {
     if (isWebProving) {
       setIsRedirectCalloutVisible(true);
     }
-    if (!isWebProving && !isWebProvingDone) {
-      setIsRedirectCalloutVisible(false);
-    }
-    if (timeout === 0) {
-      setIsRedirectCalloutVisible(false);
-    }
-    if (isWebProvingError || isZkProvingError) {
+    if (
+      !isWebProving ||
+      isWebProvingDone ||
+      timeout === 0 ||
+      isWebProvingError ||
+      isZkProvingError
+    ) {
       setIsRedirectCalloutVisible(false);
     }
   }, [
     isWebProving,
     isWebProvingDone,
     timeout,
-    setIsRedirectCalloutVisible,
     isWebProvingError,
     isZkProvingError,
   ]);

--- a/packages/browser-extension/src/components/molecules/StepActions/Notarize/NotarizeStepActions.test.tsx
+++ b/packages/browser-extension/src/components/molecules/StepActions/Notarize/NotarizeStepActions.test.tsx
@@ -19,6 +19,8 @@ const mocks = vi.hoisted(() => {
   };
 });
 
+const SECOND = 1000;
+
 vi.mock("hooks/useZkProvingState", () => ({
   useZkProvingState: mocks.useZkProvingState,
 }));
@@ -330,7 +332,7 @@ describe("NotarizeStepActions", () => {
       }),
     );
     act(() => {
-      vi.advanceTimersByTime(CALLOUT_DEBOUNCE_TIME);
+      vi.advanceTimersByTime(SECOND);
     });
     expect(result.current.isRedirectCalloutVisible).toBe(true);
 
@@ -343,17 +345,10 @@ describe("NotarizeStepActions", () => {
       />,
     );
     act(() => {
-      vi.advanceTimersByTime(CALLOUT_DEBOUNCE_TIME);
-    });
-    mocks.useTlsnProver.mockReturnValue({
-      isProving: false,
-      isProvingDone: true,
-      error: null,
+      vi.advanceTimersByTime(SECOND);
     });
     rerender();
-    act(() => {
-      vi.advanceTimersByTime(CALLOUT_DEBOUNCE_TIME);
-    });
+
     expect(result.current.isRedirectCalloutVisible).toBe(true);
 
     const redirectCallout = screen.getByTestId("redirect-callout");

--- a/packages/browser-extension/src/components/molecules/StepActions/Notarize/RedirectCallout.tsx
+++ b/packages/browser-extension/src/components/molecules/StepActions/Notarize/RedirectCallout.tsx
@@ -14,13 +14,11 @@ export const RedirectCallout: FC<{ show: boolean; timeout: number }> = ({
         <Callout.Icon>
           <InfoCircledIcon />
         </Callout.Icon>
-        {show && (
-          <Callout.Text>
-            You will be redirected back in{" "}
-            <b data-testid="timeout">{timeout}</b> second
-            {timeout !== 1 ? "s" : ""}.
-          </Callout.Text>
-        )}
+        <Callout.Text>
+          You will be redirected back in <b data-testid="timeout">{timeout}</b>{" "}
+          second
+          {timeout !== 1 ? "s" : ""}.
+        </Callout.Text>
       </Callout.Root>
     </AnimatedContainer>
   );

--- a/packages/playwright-tests/extension.full.get.spec.ts
+++ b/packages/playwright-tests/extension.full.get.spec.ts
@@ -65,6 +65,8 @@ test("Full flow from opening sidepanel to redirection", async ({
     await extension.expectCountDown();
 
     await webpage.expectWebProof();
+
+    await extension.expectCountDownToBeHidden();
   });
 
   await test.step("Zk prove button should appear after receiving webProof", async () => {

--- a/packages/playwright-tests/extension.full.get.spec.ts
+++ b/packages/playwright-tests/extension.full.get.spec.ts
@@ -62,6 +62,8 @@ test("Full flow from opening sidepanel to redirection", async ({
   await test.step("Click button should generate webproof", async () => {
     await extension.generateWebProof();
 
+    await extension.expectCountDown();
+
     await webpage.expectWebProof();
   });
 

--- a/packages/playwright-tests/pom/extension.ts
+++ b/packages/playwright-tests/pom/extension.ts
@@ -78,6 +78,11 @@ export class Extension {
     const countdown = this.page.getByText(/You will be redirected back in/i);
     await expect(countdown).toBeVisible();
   }
+
+  async expectCountDownToBeHidden() {
+    const countdown = this.page.getByText(/You will be redirected back in/i);
+    await expect(countdown).toBeHidden();
+  }
 }
 
 export const waitForExtension = async (context: BrowserContext) => {

--- a/packages/playwright-tests/pom/extension.ts
+++ b/packages/playwright-tests/pom/extension.ts
@@ -73,6 +73,11 @@ export class Extension {
     const step = this.page.getByTestId(`step-${stepName}`).nth(stepIndex);
     await expect(step).toHaveAttribute("data-status", "completed");
   }
+
+  async expectCountDown() {
+    const countdown = this.page.getByText(/You will be redirected back in/i);
+    await expect(countdown).toBeVisible();
+  }
 }
 
 export const waitForExtension = async (context: BrowserContext) => {


### PR DESCRIPTION
The countdown till redirection in extension stopped being displayed. This PR is fixing this problem and adding playwright testing if this countdown is displayed and if it disappears after being redirected.
Using `useDebounceValue` was removed because it seemed to be an overkill. It works visually good without it and it's more straightforward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the visibility logic of the redirect countdown callout for a more consistent user experience during web proofing.
  - Adjusted countdown display to ensure it accurately reflects the remaining time.

- **Tests**
  - Enhanced tests to explicitly check the visibility of the countdown before and after web proof generation.
  - Refined test timing to better align countdown assertions with timer progression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->