### PR TITLE
ci(simple-teleport): enable simple-teleport e2e with bonsai and opsepolia

### DIFF
--- a/.github/workflows/test_e2e_bonsai_opsepolia.yaml
+++ b/.github/workflows/test_e2e_bonsai_opsepolia.yaml
@@ -213,3 +213,29 @@ jobs:
           chain_name: "optimismSepolia"
           testnet_private_key_location: ${{ secrets.TESTNET_PRIVATE_KEY_LOCATION }}
           quicknode_api_key: ${{ secrets.QUICKNODE_API_KEY }}
+
+  test-e2e-bonsai-opsepolia-simple-teleport:
+    name: E2E test (simple-teleport) with Bonsai and OP Sepolia
+    needs: [changes, build-binaries]
+    runs-on: aws-linux-medium
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run E2E Test
+        uses: ./.github/actions/test-e2e
+        with:
+          example: "simple-teleport"
+
+          # JWT auth related
+          jwt_auth: "on"
+          vlayer_api_token: ${{ secrets.VLAYER_API_TOKEN_MAINNET }}
+
+          # Proving related
+          proving_mode: "prod"
+          bonsai_api_url: ${{ vars.BONSAI_API_URL }}
+          bonsai_api_key: ${{ secrets.BONSAI_API_KEY }}
+
+          # Chain related
+          chain_name: "optimismSepolia"
+          testnet_private_key_location: ${{ secrets.TESTNET_PRIVATE_KEY_LOCATION }}
+          quicknode_api_key: ${{ secrets.QUICKNODE_API_KEY }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a new automated end-to-end test for the "simple-teleport" example on the Optimism Sepolia testnet using Bonsai. This enhances test coverage and reliability for related workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->