### PR TITLE
ci: Revert adding teleport example to CI

### DIFF
--- a/.github/workflows/test_e2e_bonsai_opsepolia.yaml
+++ b/.github/workflows/test_e2e_bonsai_opsepolia.yaml
@@ -53,7 +53,7 @@ jobs:
               - 'ansible/**'
               - 'bun.lock'
             workflow-changes:
-              - '.github/workflows/test_e2e_testnet.yaml'
+              - '.github/workflows/test_e2e_bonsai_opsepolia.yaml'
               - '.github/actions/test-e2e/**'
 
   build-binaries:
@@ -199,32 +199,6 @@ jobs:
         uses: ./.github/actions/test-e2e
         with:
           example: "simple-time-travel"
-
-          # JWT auth related
-          jwt_auth: "on"
-          vlayer_api_token: ${{ secrets.VLAYER_API_TOKEN_MAINNET }}
-
-          # Proving related
-          proving_mode: "prod"
-          bonsai_api_url: ${{ vars.BONSAI_API_URL }}
-          bonsai_api_key: ${{ secrets.BONSAI_API_KEY }}
-
-          # Chain related
-          chain_name: "optimismSepolia"
-          testnet_private_key_location: ${{ secrets.TESTNET_PRIVATE_KEY_LOCATION }}
-          quicknode_api_key: ${{ secrets.QUICKNODE_API_KEY }}
-
-  test-e2e-bonsai-opsepolia-simple-teleport:
-    name: E2E test (simple-teleport) with Bonsai and OP Sepolia
-    needs: [changes, build-binaries]
-    runs-on: aws-linux-medium
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Run E2E Test
-        uses: ./.github/actions/test-e2e
-        with:
-          example: "simple-teleport"
 
           # JWT auth related
           jwt_auth: "on"


### PR DESCRIPTION
Reverts https://github.com/vlayer-xyz/vlayer/pull/2361, which got merged but the error was caught on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated workflow filters to match the correct workflow file.
	- Removed the end-to-end test job for the "simple-teleport" example using Bonsai and Optimism Sepolia.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->