### PR TITLE
Disallow groth16 proofs in chain workers

### DIFF
--- a/rust/services/chain/worker/src/main.rs
+++ b/rust/services/chain/worker/src/main.rs
@@ -163,6 +163,13 @@ async fn main() {
     let mode = cli.mode;
     let config: HostConfig = cli.into();
 
+    if config.proof_mode == ProofMode::Groth16 {
+        error!(
+            "Groth16 proof mode is not supported by chain workers as they need to compose proofs. Use succinct or fake"
+        );
+        std::process::exit(1);
+    }
+
     if config.proof_mode == ProofMode::Fake {
         set_risc0_dev_mode();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation to prevent starting the application with an unsupported proof mode. If Groth16 proof mode is selected, an error message is displayed and the application will exit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->