### PR TITLE
chore(version): bump version to 1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14560,7 +14560,7 @@ dependencies = [
 
 [[package]]
 name = "version"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "regex",

--- a/rust/version/Cargo.toml
+++ b/rust/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "version"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2024"
 build = "build.rs"
 


### PR DESCRIPTION
## What's Changed
* fix: readme intro by @Chmarusso in https://github.com/vlayer-xyz/vlayer/pull/2373
* fix(sdk-hooks): respect chainId arg in useCallProver args by @kubkon in https://github.com/vlayer-xyz/vlayer/pull/2354
* Disallow groth16 proofs in chain workers by @LogvinovLeon in https://github.com/vlayer-xyz/vlayer/pull/2369
* docs: change feature order, remove obsolete point by @Chmarusso in https://github.com/vlayer-xyz/vlayer/pull/2377
* docs: add get started video by @Chmarusso in https://github.com/vlayer-xyz/vlayer/pull/2379
* fix(jwt): enable missing strum feature to be able to test the package by @kubkon in https://github.com/vlayer-xyz/vlayer/pull/2381
* fix(email example): fix block explorer url by @aajj999 in https://github.com/vlayer-xyz/vlayer/pull/2374
* fix(dns-server): add version to CLI args by @kubkon in https://github.com/vlayer-xyz/vlayer/pull/2380


**Full Changelog**: https://github.com/vlayer-xyz/vlayer/compare/v1.0.1...v1.0.2
