### PR TITLE
fix(extension): empty error after repeated "Open extension"

### DIFF
--- a/packages/browser-extension/src/components/organisms/ErrorCallout.tsx
+++ b/packages/browser-extension/src/components/organisms/ErrorCallout.tsx
@@ -8,12 +8,7 @@ export const useErrorCallout = () => {
   const [isErrorCalloutVisible, setIsErrorCalloutVisible] = useState(false);
   const { error } = useTlsnProver();
   useEffect(() => {
-    if (error) {
-      setIsErrorCalloutVisible(true);
-    }
-    if (!error) {
-      setIsErrorCalloutVisible(false);
-    }
+    setIsErrorCalloutVisible(!!error);
   }, [error]);
   return {
     isErrorCalloutVisible,


### PR DESCRIPTION
The task: https://www.notion.so/vlayer/Error-in-extension-after-requesting-proof-for-second-time-1f2fdaece267802a8a4fd688edf69fa2?pvs=4

The empty error frame does not appear anymore after this fix.
But the error remains visible after clicking `Refresh` and it stays there until you click `Open extension` again. Is it ok, or do we want to close the extension on `Refresh` or something else?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error callout behavior to ensure it is properly hidden when errors are cleared, providing a more consistent user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->