### PR TITLE
fix(jwt): enable missing strum feature to be able to test the package

### DIFF
--- a/rust/jwt/Cargo.toml
+++ b/rust/jwt/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 derive_builder = { workspace = true }
 jsonwebtoken = { workspace = true }
 serde = { workspace = true }
-strum = { workspace = true }
+strum = { workspace = true, features = ["derive"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Without this fix, we would get a compile error when running

```
$ cargo test -p jwt
```