### PR TITLE
Add gas price checker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6331,6 +6331,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gas_price_checker"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "anyhow",
+ "reqwest 0.12.12",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "generate_fixtures"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6334,12 +6334,9 @@ dependencies = [
 name = "gas_price_checker"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
  "anyhow",
  "reqwest 0.12.12",
- "serde",
  "serde_json",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "rust/cli",
     "rust/common",
     "rust/email_proof",
+    "rust/gas_price_checker",
     "rust/generate_fixtures",
     "rust/guest_wrapper",
     "rust/guest_wrapper/build_utils",
@@ -215,6 +216,7 @@ chain_test_utils = { path = "rust/services/chain/test_utils" }
 chain_worker = { path = "rust/services/chain/worker" }
 common = { path = "rust/common" }
 email_proof = { path = "rust/email_proof" }
+gas_price_checker = { path = "rust/gas_price_checker" }
 guest_build_utils = { path = "rust/guest_wrapper/build_utils" }
 guest_wrapper = { path = "rust/guest_wrapper" }
 host_utils = { path = "rust/host_utils" }

--- a/rust/gas_price_checker/Cargo.toml
+++ b/rust/gas_price_checker/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-alloy-primitives = { workspace = true }
 anyhow = { workspace = true }
-reqwest = { workspace = true, features = ["json", "rustls-tls"] }
-serde = { workspace = true }
+reqwest = { workspace = true, features = ["json", "blocking", "rustls-tls"] }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["full"] }

--- a/rust/gas_price_checker/Cargo.toml
+++ b/rust/gas_price_checker/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "gas_price_checker"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+alloy-primitives = { workspace = true }
+anyhow = { workspace = true }
+reqwest = { workspace = true, features = ["json", "rustls-tls"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/rust/gas_price_checker/README
+++ b/rust/gas_price_checker/README
@@ -5,11 +5,11 @@ A simple Rust command-line tool that fetches the current Ethereum gas price from
 ## Usage
 
 ```sh
-cargo run -- <RPC_URL> [THRESHOLD_GWEI]
+cargo run -- <RPC_URL> <THRESHOLD_GWEI>
 ```
 
-- <RPC_URL>: The HTTP(S) URL of your Ethereum JSON-RPC endpoint.
-- [THRESHOLD_GWEI]: Optional. A floating-point gas-price threshold in Gwei. Defaults to 10.0 if omitted.
+- `<RPC_URL>`: The HTTP(S) URL of your Ethereum JSON-RPC endpoint.
+- `<THRESHOLD_GWEI>`: Optional. A floating-point gas-price threshold in Gwei. Defaults to 10.0 if omitted.
 
 ## Example
 
@@ -19,7 +19,7 @@ cargo run -- https://eth-sepolia.g.alchemy.com/v2/<API_KEY> 5
 
 This will:
 
-1. Query eth_gasPrice on the Sepolia testnet via your Alchemy endpoint.
+1. Query `eth_gasPrice` on the Sepolia testnet via your Alchemy endpoint.
 2. Print the current gas price in Gwei.
 3. Exit with 0 if the price is ≤ 5 Gwei, or with a non-zero code if it’s higher.
 
@@ -32,7 +32,7 @@ Gas price: 2.3456 gwei
 
 ## How It Works
 
-1. Sends a JSON-RPC eth_gasPrice request using reqwest.
-2. Parses the returned hex string into a U256 (from alloy_primitives).
+1. Sends a JSON-RPC eth_gasPrice request using `reqwest`.
+2. Parses the returned hex string into a U`256 (from `alloy_primitives`).
 3. Converts Wei → Gwei and compares against the threshold.
 4. Prints a colored status and returns the appropriate exit code.

--- a/rust/gas_price_checker/README
+++ b/rust/gas_price_checker/README
@@ -32,7 +32,6 @@ Gas price: 2.3456 gwei
 
 ## How It Works
 
-1. Sends a JSON-RPC eth_gasPrice request using `reqwest`.
-2. Parses the returned hex string into a U`256 (from `alloy_primitives`).
+1. Sends a JSON-RPC `eth_gasPrice` request using `reqwest`.
 3. Converts Wei → Gwei and compares against the threshold.
-4. Prints a colored status and returns the appropriate exit code.
+4. Prints a status and returns the appropriate exit code.

--- a/rust/gas_price_checker/README
+++ b/rust/gas_price_checker/README
@@ -1,0 +1,38 @@
+# Gas Price Checker
+
+A simple Rust command-line tool that fetches the current Ethereum gas price from a JSON-RPC endpoint and compares it against a user-defined threshold. If the gas price is at or below the threshold, the program exits successfully; otherwise, it exits with a non-zero code.
+
+## Usage
+
+```sh
+cargo run -- <RPC_URL> [THRESHOLD_GWEI]
+```
+
+- <RPC_URL>: The HTTP(S) URL of your Ethereum JSON-RPC endpoint.
+- [THRESHOLD_GWEI]: Optional. A floating-point gas-price threshold in Gwei. Defaults to 10.0 if omitted.
+
+## Example
+
+```sh
+cargo run -- https://eth-sepolia.g.alchemy.com/v2/<API_KEY> 5
+```
+
+This will:
+
+1. Query eth_gasPrice on the Sepolia testnet via your Alchemy endpoint.
+2. Print the current gas price in Gwei.
+3. Exit with 0 if the price is ≤ 5 Gwei, or with a non-zero code if it’s higher.
+
+Sample output:
+
+```sh
+Gas price: 2.3456 gwei
+✅ Gas price is low enough → OK
+```
+
+## How It Works
+
+1. Sends a JSON-RPC eth_gasPrice request using reqwest.
+2. Parses the returned hex string into a U256 (from alloy_primitives).
+3. Converts Wei → Gwei and compares against the threshold.
+4. Prints a colored status and returns the appropriate exit code.

--- a/rust/gas_price_checker/src/main.rs
+++ b/rust/gas_price_checker/src/main.rs
@@ -1,0 +1,81 @@
+use std::{env, process};
+
+use alloy_primitives::U256;
+use anyhow::{anyhow, bail, Context};
+use reqwest::Client;
+use serde_json::{json, Value};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 2 {
+        eprintln!("Usage: {} <RPC_URL> [THRESHOLD_GWEI]", args[0]);
+        process::exit(1);
+    }
+
+    let rpc_url = &args[1];
+    let threshold_gwei = args
+        .get(2)
+        .map(|s| s.parse::<f64>().unwrap_or(10.0))
+        .unwrap_or(10.0);
+
+    let gas_price_gwei = fetch_gas_price(rpc_url).await?;
+
+    println!("Gas price: {:.4} gwei", gas_price_gwei);
+
+    if gas_price_gwei <= threshold_gwei {
+        println!("✅ Gas price is low enough → OK");
+        Ok(())
+    } else {
+        println!("❌ Gas price is too high → SKIP");
+        process::exit(1);
+    }
+}
+
+async fn fetch_gas_price(rpc_url: &str) -> anyhow::Result<f64> {
+    let client = Client::new();
+
+    let request_body = json!({
+        "jsonrpc": "2.0",
+        "method": "eth_gasPrice",
+        "params": [],
+        "id": 1
+    });
+
+    let response = client
+        .post(rpc_url)
+        .header("Content-Type", "application/json")
+        .json(&request_body)
+        .send()
+        .await
+        .context("Failed to make RPC request")?;
+
+    let response_text = response.text().await?;
+    println!("Raw response: {}", response_text);
+
+    let response_json: Value =
+        serde_json::from_str(&response_text).context("Failed to parse JSON response")?;
+
+    let gas_price_hex = response_json
+        .get("result")
+        .and_then(|v| v.as_str())
+        .context("No 'result' field in response or not a string")?;
+
+    if gas_price_hex.is_empty() || gas_price_hex == "null" {
+        bail!("Error: Failed to fetch gas price");
+    }
+
+    let gas_price_wei = U256::from_str_radix(gas_price_hex.trim_start_matches("0x"), 16)
+        .map_err(|e| anyhow!("Failed to parse hex gas price: {}", e))?;
+
+    let as_str = gas_price_wei.to_string();
+    let wei_f64: f64 = as_str
+        .parse()
+        .context("Failed to parse gas price string into f64")?;
+    let gas_price_gwei = wei_f64 / 1e9;
+
+    dbg!(gas_price_gwei);
+
+    Ok(gas_price_gwei)
+}

--- a/rust/gas_price_checker/src/main.rs
+++ b/rust/gas_price_checker/src/main.rs
@@ -64,6 +64,8 @@ fn fetch_gas_price(rpc_url: &str) -> anyhow::Result<f64> {
         bail!("Error: 'gas_price_hex' is empty");
     }
 
+    // NOTE: casting u64 to f64 will round values >2^53. Gas prices in wei are typically < 1e11
+    // and should stay far below 2^53, so converting to f64 is safe for this use case.
     let gas_price_wei = u64::from_str_radix(gas_price_hex.trim_start_matches("0x"), 16)
         .context(format!("Failed to parse gas price hex: {}", gas_price_hex))?
         as f64;

--- a/rust/gas_price_checker/src/main.rs
+++ b/rust/gas_price_checker/src/main.rs
@@ -26,7 +26,7 @@ fn main() -> anyhow::Result<()> {
         println!("✅ Gas price is low enough → OK");
         Ok(())
     } else {
-        println!("❌ Gas price is too high → SKIP");
+        println!("❌ Gas price is too high");
         process::exit(1);
     }
 }
@@ -59,7 +59,7 @@ fn fetch_gas_price(rpc_url: &str) -> anyhow::Result<f64> {
         .context("No 'result' field in response or not a string")?;
 
     if gas_price_hex.is_empty() {
-        bail!("Error: Failed to fetch gas price");
+        bail!("Error: 'gas_price_hex' is empty");
     }
 
     let gas_price_wei =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new command-line tool to check the current Ethereum gas price from a specified RPC endpoint and compare it to a user-defined threshold.
  - Tool provides clear output indicating whether the gas price is below or above the threshold, and exits with a corresponding status code.
- **Documentation**
  - Added a README with usage instructions, example commands, and explanation of output and exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->