### PR TITLE
ci: fix incorrectly scoped restart handlers

### DIFF
--- a/ansible/roles/chain_server/handlers/main.yml
+++ b/ansible/roles/chain_server/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Restart vlayer
+- name: Restart chain server
   become: true
   ansible.builtin.systemd_service:
     name: vlayer-chain-server

--- a/ansible/roles/chain_server/tasks/main.yml
+++ b/ansible/roles/chain_server/tasks/main.yml
@@ -34,7 +34,7 @@
   async: 600  # 10 minutes to complete
   poll: 10  # check every 10 seconds
   retries: 2
-  notify: "Restart vlayer"
+  notify: "Restart chain server"
 
 - name: Install service file
   become: true
@@ -43,7 +43,7 @@
     src: vlayer-chain-server.service.j2
     dest: /etc/systemd/system/vlayer-chain-server.service
     mode: '644'
-  notify: "Restart vlayer"
+  notify: "Restart chain server"
 
 - name: Enable and start the vlayer service
   become: true

--- a/ansible/roles/chain_worker/handlers/main.yml
+++ b/ansible/roles/chain_worker/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Restart vlayer
+- name: Restart {{ chain_worker_identifier }} chain worker
   become: true
   ansible.builtin.systemd_service:
     name: vlayer-chain-worker-{{ chain_worker_identifier }}

--- a/ansible/roles/chain_worker/handlers/main.yml
+++ b/ansible/roles/chain_worker/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Restart {{ chain_worker_identifier }} chain worker
+- name: Restart chain worker {{ chain_worker_identifier }}
   become: true
   ansible.builtin.systemd_service:
     name: vlayer-chain-worker-{{ chain_worker_identifier }}

--- a/ansible/roles/chain_worker/tasks/main.yml
+++ b/ansible/roles/chain_worker/tasks/main.yml
@@ -24,7 +24,7 @@
   async: 600  # 10 minutes to complete
   poll: 10  # check every 10 seconds
   retries: 2
-  notify: "Restart vlayer"
+  notify: "Restart {{ chain_worker_identifier }} chain worker"
 
 - name: Install service file
   become: true
@@ -33,7 +33,7 @@
     src: vlayer-chain-worker.service.j2
     dest: /etc/systemd/system/vlayer-chain-worker-{{ chain_worker_identifier }}.service
     mode: '644'
-  notify: "Restart vlayer"
+  notify: "Restart {{ chain_worker_identifier }} chain worker"
 
 - name: Enable and start the vlayer service
   become: true

--- a/ansible/roles/chain_worker/tasks/main.yml
+++ b/ansible/roles/chain_worker/tasks/main.yml
@@ -24,7 +24,7 @@
   async: 600  # 10 minutes to complete
   poll: 10  # check every 10 seconds
   retries: 2
-  notify: "Restart {{ chain_worker_identifier }} chain worker"
+  notify: "Restart chain worker {{ chain_worker_identifier }}"
 
 - name: Install service file
   become: true
@@ -33,7 +33,7 @@
     src: vlayer-chain-worker.service.j2
     dest: /etc/systemd/system/vlayer-chain-worker-{{ chain_worker_identifier }}.service
     mode: '644'
-  notify: "Restart {{ chain_worker_identifier }} chain worker"
+  notify: "Restart chain worker {{ chain_worker_identifier }}"
 
 - name: Enable and start the vlayer service
   become: true


### PR DESCRIPTION
I used the same name for Ansible [handlers](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_handlers.html), but they are globally scoped and they overwrote each other.

This change makes sure that each handler is correctly applied after a relevant `notify`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated handler names in server and worker roles for improved clarity and specificity.
	- Notifications now use more descriptive and dynamic handler names, reflecting the target service or instance.
- **Chores**
	- Standardized naming conventions across Ansible tasks and handlers for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->