### PR TITLE
feat(web_prover): support JWT tokens for TLSN auth

### DIFF
--- a/.github/workflows/test_int_web_prover.yaml
+++ b/.github/workflows/test_int_web_prover.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run web_prover rust tests
         run: |
-          cargo test --locked --all-features --package web_prover
+          cargo test --locked --features integration-tests --package web_prover
         env:
           RUSTC_WRAPPER: ${{ steps.rust_pre.outputs.RUSTC_WRAPPER }}
           RUST_LOG: info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15013,6 +15013,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "constcat",
+ "derivative",
  "derive_builder 0.12.0",
  "derive_more 1.0.0",
  "hex",

--- a/rust/cli/src/commands/web_proof.rs
+++ b/rust/cli/src/commands/web_proof.rs
@@ -41,7 +41,7 @@ pub(crate) enum InputError {
 }
 
 /// Generates a web-based proof for the specified request
-#[derive(Clone, Debug, Parser)]
+#[derive(Clone, Parser, Debug)]
 pub(crate) struct WebProofArgs {
     /// Full URL of the request to notarize
     #[arg(long)]
@@ -187,6 +187,7 @@ impl TryFrom<WebProofArgs> for NotarizeParams {
 
     fn try_from(value: WebProofArgs) -> Result<Self> {
         let ProvenUrl { host, port } = parse_proven_url(&value.url)?;
+
         // If host is not provided fallback to host extracted from url
         let fallback_host = value.host.unwrap_or(host.clone());
 
@@ -213,11 +214,8 @@ impl TryFrom<WebProofArgs> for NotarizeParams {
 
         debug!("headers: {headers:#?}");
 
-        let notary_config = if let Some(notary_url) = value.notary {
-            parse_notary_url(&notary_url)?
-        } else {
-            parse_notary_url(DEFAULT_NOTARY_URL)?
-        };
+        let notary_url = value.notary.unwrap_or(DEFAULT_NOTARY_URL.to_string());
+        let notary_config = parse_notary_url(&notary_url)?;
 
         let mut notarize_params_builder = NotarizeParamsBuilder::default();
         notarize_params_builder

--- a/rust/web_prover/Cargo.toml
+++ b/rust/web_prover/Cargo.toml
@@ -5,11 +5,13 @@ edition = "2024"
 
 [features]
 integration-tests = []
+tlsn-jwt = []
 
 [dependencies]
 anyhow = { workspace = true }
 bincode = { workspace = true }
 constcat = { workspace = true }
+derivative = { workspace = true }
 derive_builder = { workspace = true }
 derive_more = { workspace = true }
 hex = { workspace = true }

--- a/rust/web_prover/src/notarize.rs
+++ b/rust/web_prover/src/notarize.rs
@@ -35,12 +35,21 @@ pub async fn notarize(params: NotarizeParams) -> Result<(Attestation, Secrets, R
         max_recv_data,
     } = params;
 
-    let notary_client = NotaryClient::builder()
+    let mut notary_client_builder = NotaryClient::builder();
+
+    notary_client_builder
         .host(notary_config.host)
         .port(notary_config.port)
         .path_prefix(notary_config.path_prefix)
-        .enable_tls(notary_config.enable_tls)
-        .build()?;
+        .enable_tls(notary_config.enable_tls);
+
+    #[cfg(feature = "tlsn-jwt")]
+    #[cfg(not(clippy))]
+    if let Some(jwt) = notary_config.jwt {
+        notary_client_builder.jwt(jwt);
+    }
+
+    let notary_client = notary_client_builder.build()?;
 
     let notarization_request = NotarizationRequest::builder()
         .max_sent_data(max_sent_data)

--- a/rust/web_prover/src/params.rs
+++ b/rust/web_prover/src/params.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, str, sync::Arc};
 
+use derivative::Derivative;
 use derive_builder::Builder;
 use derive_more::Debug;
 pub use hyper::http::Method;
@@ -8,7 +9,8 @@ use tlsn_core::transcript::Transcript;
 
 use crate::RedactionConfig;
 
-#[derive(Debug, Clone, Builder)]
+#[derive(Derivative, Clone, Builder)]
+#[derivative(Debug)]
 pub struct NotaryConfig {
     /// Notary host (domain name or IP)
     #[builder(setter(into))]
@@ -21,6 +23,11 @@ pub struct NotaryConfig {
     /// Whether to use TLS for notary connection
     #[builder(default)]
     pub enable_tls: bool,
+    /// JWT authentication token if any
+    #[cfg(feature = "tlsn-jwt")]
+    #[builder(setter(into))]
+    #[derivative(Debug = "ignore")]
+    pub jwt: Option<String>,
 }
 
 #[derive(Builder, Clone, Debug)]


### PR DESCRIPTION
Depends on #2389 

This functionality is purposely put behind a feature flag "tlsn-jwt" since at the time of writing only my fork of TLSN notary server supports JWT (pending proposal accept and PR merge by TLSN core team).

Tracking issue of this functionality in TLSN https://github.com/tlsnotary/tlsn/issues/812

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional JWT authentication support for notary configuration, available when the relevant feature is enabled.

- **Refactor**
  - Simplified the process for configuring notary settings and improved the construction flow for notary clients.

- **Chores**
  - Updated dependencies and feature flags to support new authentication options.
  - Adjusted test workflow to focus on integration tests feature instead of all features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->