### PR TITLE
fix(email example): handling errors from preverify [ENGA-703]

### DIFF
--- a/examples/simple-email-proof/vlayer/src/shared/errors/appErrors.ts
+++ b/examples/simple-email-proof/vlayer/src/shared/errors/appErrors.ts
@@ -36,3 +36,9 @@ export class UseChainError extends AppError {
     super("UseChainError", message);
   }
 }
+
+export class PreverifyError extends AppError {
+  constructor(message: string) {
+    super("PreverifyError", message);
+  }
+}


### PR DESCRIPTION
Errors from `preverifyEmail` were not handled by Error Boundary, because they were thrown in asynchronous function. Because of that they only appeared in console instead of being displayed in the App. This PR fixes this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved error handling during the email pre-verification process, providing clearer feedback if preverification fails.

- **Bug Fixes**
  - Enhanced stability by catching and managing errors that occur during email pre-verification, preventing unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->