### PR TITLE
chore: get rid of an unused step

### DIFF
--- a/packages/browser-extension/src/background.ts
+++ b/packages/browser-extension/src/background.ts
@@ -251,17 +251,9 @@ const validateProofRequest = (
           },
           ({ url }) => assertUrlPattern(url),
         )
-        .with(
-          {
-            step: P.union(
-              EXTENSION_STEP.extractVariables,
-              EXTENSION_STEP.clickButton,
-            ),
-          },
-          () => {
-            console.warn("Unsupported step type: ", step);
-          },
-        )
+        .with({ step: EXTENSION_STEP.extractVariables }, () => {
+          console.warn("Unsupported step type: ", step);
+        })
         .exhaustive();
     });
   } catch (e) {

--- a/packages/browser-extension/src/components/molecules/StepActions/StepActions.tsx
+++ b/packages/browser-extension/src/components/molecules/StepActions/StepActions.tsx
@@ -1,4 +1,4 @@
-import { match, P } from "ts-pattern";
+import { match } from "ts-pattern";
 import React from "react";
 
 import { ExpectUrlStepActions } from "./ExpectUrl";
@@ -46,13 +46,10 @@ export const StepActions: React.FC<{
             status={status}
           />
         ))
-        .with(
-          P.union(EXTENSION_STEP.extractVariables, EXTENSION_STEP.clickButton),
-          () => {
-            console.warn("Unsupported step type:", kind);
-            return <></>;
-          },
-        )
+        .with(EXTENSION_STEP.extractVariables, () => {
+          console.warn("Unsupported step type:", kind);
+          return <></>;
+        })
         .exhaustive()}
     </>
   );

--- a/packages/browser-extension/src/hooks/useSteps.ts
+++ b/packages/browser-extension/src/hooks/useSteps.ts
@@ -50,16 +50,12 @@ const isNotarizeStepCompleted = hasProof;
 const isExtractVariablesStepReady = () => true;
 const isExtractVariablesStepCompleted = () => true;
 
-const isClickButtonStepReady = () => true;
-const isClickButtonStepCompleted = () => true;
-
 const checkStepCompletion = {
   startPage: isStartPageStepCompleted,
   redirect: isRedirectStepCompleted,
   expectUrl: isExpectUrlStepCompleted,
   notarize: isNotarizeStepCompleted,
   extractVariables: isExtractVariablesStepCompleted,
-  clickButton: isClickButtonStepCompleted,
 };
 
 const checkStepReadiness = {
@@ -68,7 +64,6 @@ const checkStepReadiness = {
   expectUrl: isExpectUrlStepReady,
   notarize: isNotarizeStepReady,
   extractVariables: isExtractVariablesStepReady,
-  clickButton: isClickButtonStepReady,
 };
 
 const calculateStepStatus = ({

--- a/packages/web-proof-commons/types/message.ts
+++ b/packages/web-proof-commons/types/message.ts
@@ -12,7 +12,6 @@ export const EXTENSION_STEP = {
   redirect: "redirect",
   notarize: "notarize",
   extractVariables: "extractVariables",
-  clickButton: "clickButton",
 } as const;
 
 export enum ZkProvingStatus {
@@ -146,9 +145,8 @@ export type WebProofStep =
   | WebProofStepNotarize
   | WebProofStepExpectUrl
   | WebProofStepStartPage
-  | WebProofStepRedirect
   | WebProofStepExtractVariables
-  | WebProofStepClickButton;
+  | WebProofStepRedirect;
 
 export type UrlPattern = Branded<string, "UrlPattern">;
 
@@ -197,15 +195,6 @@ export type WebProofStepExtractVariables = BrandedStep<
     label: string;
     url: UrlPattern;
     variables: Variables;
-  }
->;
-
-export type WebProofStepClickButton = BrandedStep<
-  typeof EXTENSION_STEP.clickButton,
-  {
-    label: string;
-    url: UrlPattern;
-    selector: string;
   }
 >;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed support for the "clickButton" step throughout the browser extension, simplifying step handling and validation logic.

- **Bug Fixes**
  - Updated step validation and status checks to no longer consider the "clickButton" step, ensuring more accurate step processing.

- **Chores**
  - Cleaned up unused code and imports related to the removed "clickButton" step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->