### PR TITLE
Add scripting and activeTab permissions to extension

### DIFF
--- a/packages/browser-extension/src/manifest.json
+++ b/packages/browser-extension/src/manifest.json
@@ -17,7 +17,9 @@
     "sidePanel",
     "storage",
     "webRequest",
-    "cookies"
+    "cookies",
+    "scripting",
+    "activeTab"
   ],
   "externally_connectable": {
     "matches": ["<all_urls>"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated browser extension permissions to include "scripting" and "activeTab".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->