### PR TITLE
fix(config): update Ethereum RPC endpoint

### DIFF
--- a/contracts/vlayer/foundry.toml
+++ b/contracts/vlayer/foundry.toml
@@ -24,7 +24,7 @@ forge-std = "1.9.4"
 risc0-ethereum = { version = "2.0.0", url = "https://github.com/vlayer-xyz/risc0-ethereum/releases/download/v2.0.0-soldeer/contracts.zip" }
 
 [rpc_endpoints]
-ethereum = "https://eth.llamarpc.com"
+ethereum = "https://eth.drpc.org"
 optimism = "https://mainnet.optimism.io"
 base = "https://mainnet.base.org"
 


### PR DESCRIPTION
Current rpc url is down (https://chainlist.org/chain/1):
<img width="807" alt="image" src="https://github.com/user-attachments/assets/e3c2273b-e428-40e4-b812-d45d725b4d00" />

and new one:
<img width="911" alt="image" src="https://github.com/user-attachments/assets/0400b871-0d60-43f0-9dd4-a14c556f86a4" />

