### PR TITLE
ci: Optimize `vlayerup` in chain services installation

### DIFF
--- a/ansible/roles/chain_server/handlers/main.yml
+++ b/ansible/roles/chain_server/handlers/main.yml
@@ -1,11 +1,4 @@
 ---
-- name: Restart chain server
-  become: true
-  ansible.builtin.systemd_service:
-    name: vlayer-chain-server
-    state: restarted
-    daemon_reload: true
-
 - name: Restart rsyslog
   become: true
   ansible.builtin.systemd_service:

--- a/ansible/roles/chain_server/tasks/main.yml
+++ b/ansible/roles/chain_server/tasks/main.yml
@@ -35,6 +35,10 @@
   poll: 10  # check every 10 seconds
   retries: 2
   notify: "Restart chain server"
+  when: not vlayerup_executed | default(false)
+- name: Mark vlayerup as executed
+  ansible.builtin.set_fact:
+    vlayerup_executed: true
 
 - name: Install service file
   become: true

--- a/ansible/roles/chain_server/tasks/main.yml
+++ b/ansible/roles/chain_server/tasks/main.yml
@@ -34,7 +34,6 @@
   async: 600  # 10 minutes to complete
   poll: 10  # check every 10 seconds
   retries: 2
-  notify: "Restart chain server"
   when: not vlayerup_executed | default(false)
 - name: Mark vlayerup as executed
   ansible.builtin.set_fact:
@@ -47,7 +46,6 @@
     src: vlayer-chain-server.service.j2
     dest: /etc/systemd/system/vlayer-chain-server.service
     mode: '644'
-  notify: "Restart chain server"
 
 - name: Enable and start the vlayer service
   become: true
@@ -56,3 +54,10 @@
     name: vlayer-chain-server
     enabled: true
     state: started
+
+- name: Restart chain server
+  become: true
+  ansible.builtin.systemd_service:
+    name: vlayer-chain-server
+    state: restarted
+    daemon_reload: true

--- a/ansible/roles/chain_worker/handlers/main.yml
+++ b/ansible/roles/chain_worker/handlers/main.yml
@@ -1,11 +1,4 @@
 ---
-- name: Restart chain worker {{ chain_worker_identifier }}
-  become: true
-  ansible.builtin.systemd_service:
-    name: vlayer-chain-worker-{{ chain_worker_identifier }}
-    state: restarted
-    daemon_reload: true
-
 - name: Restart rsyslog
   become: true
   ansible.builtin.systemd_service:

--- a/ansible/roles/chain_worker/tasks/main.yml
+++ b/ansible/roles/chain_worker/tasks/main.yml
@@ -25,6 +25,10 @@
   poll: 10  # check every 10 seconds
   retries: 2
   notify: "Restart chain worker {{ chain_worker_identifier }}"
+  when: not vlayerup_executed | default(false)
+- name: Mark vlayerup as executed
+  ansible.builtin.set_fact:
+    vlayerup_executed: true
 
 - name: Install service file
   become: true

--- a/ansible/roles/chain_worker/tasks/main.yml
+++ b/ansible/roles/chain_worker/tasks/main.yml
@@ -24,7 +24,6 @@
   async: 600  # 10 minutes to complete
   poll: 10  # check every 10 seconds
   retries: 2
-  notify: "Restart chain worker {{ chain_worker_identifier }}"
   when: not vlayerup_executed | default(false)
 - name: Mark vlayerup as executed
   ansible.builtin.set_fact:
@@ -37,7 +36,6 @@
     src: vlayer-chain-worker.service.j2
     dest: /etc/systemd/system/vlayer-chain-worker-{{ chain_worker_identifier }}.service
     mode: '644'
-  notify: "Restart chain worker {{ chain_worker_identifier }}"
 
 - name: Enable and start the vlayer service
   become: true
@@ -46,3 +44,10 @@
     name: vlayer-chain-worker-{{ chain_worker_identifier }}
     enabled: true
     state: started
+
+- name: Restart chain worker {{ chain_worker_identifier }}
+  become: true
+  ansible.builtin.systemd_service:
+    name: vlayer-chain-worker-{{ chain_worker_identifier }}
+    state: restarted
+    daemon_reload: true


### PR DESCRIPTION
- Add a flag to make sure we are not calling `vlayerup` multiple times on the same host which contains a chain server and multiple chain worker
- Remove restart handlers and do a simple restart - since we're restarting always anyway (because we're calling `vlayerup` always), there is no need for the `notify-handle` flow in this case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Changed the way chain server and chain worker services are restarted: restarts now occur through explicit tasks at the end of the process rather than through automatic notifications.
  - Improved installation logic to ensure binaries are only installed once per playbook run, preventing repeated executions.
- **Chores**
  - Removed unused handlers related to restarting chain server and chain worker services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->