### PR TITLE
feat(extension): send message to browser when step was completed

### DIFF
--- a/packages/browser-extension/src/background.ts
+++ b/packages/browser-extension/src/background.ts
@@ -69,6 +69,7 @@ browser.runtime.onMessage.addListener(async (message: unknown) => {
         type: P.union(
           ExtensionInternalMessageType.ProofDone,
           ExtensionInternalMessageType.ProofError,
+          ExtensionInternalMessageType.StepCompleted,
         ),
       },
       () => {

--- a/packages/browser-extension/src/hooks/useNotifyOnStepCompleted.test.ts
+++ b/packages/browser-extension/src/hooks/useNotifyOnStepCompleted.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import browser from "webextension-polyfill";
+import { renderHook } from "@testing-library/react";
+import { ExtensionInternalMessageType } from "../web-proof-commons";
+import { steps, testData } from "./useSteps.test.data.ts";
+import { useNotifyOnStepCompleted } from "./useNotifyOnStepCompleted.ts";
+import { Step, StepStatus } from "src/constants";
+
+describe("useNotifyOnStepCompleted", () => {
+  function intoCurrentStepsProgress(idx: number) {
+    return testData[idx].output.map((status) => ({ status })) as Step[];
+  }
+
+  it("fires event once for each completed step", () => {
+    const messageSenderSpy = vi.spyOn(browser.runtime, "sendMessage");
+    const { rerender } = renderHook(
+      ({ currentSteps }) => useNotifyOnStepCompleted(steps, currentSteps),
+      {
+        initialProps: { currentSteps: intoCurrentStepsProgress(0) },
+      },
+    );
+
+    let expectedSentMessagesCount = 0;
+    expect(messageSenderSpy).toHaveBeenCalledTimes(0);
+
+    for (let i = 1; i < testData.length; i++) {
+      rerender({ currentSteps: intoCurrentStepsProgress(i) });
+      const currentlyCompletedSteps = testData[i].output.filter(
+        (status) => status === StepStatus.Completed,
+      ).length;
+
+      // Should not resend event after we had regression in completed steps
+      expectedSentMessagesCount = Math.max(
+        currentlyCompletedSteps,
+        expectedSentMessagesCount,
+      );
+      expect(messageSenderSpy).toHaveBeenCalledTimes(expectedSentMessagesCount);
+    }
+
+    expect(messageSenderSpy).toHaveBeenCalledTimes(steps.length);
+    for (let i = 0; i < steps.length; i++) {
+      expect(messageSenderSpy).nthCalledWith(i + 1, {
+        type: ExtensionInternalMessageType.StepCompleted,
+        payload: {
+          index: i,
+          step: steps[i],
+        },
+      });
+    }
+  });
+});

--- a/packages/browser-extension/src/hooks/useNotifyOnStepCompleted.ts
+++ b/packages/browser-extension/src/hooks/useNotifyOnStepCompleted.ts
@@ -1,0 +1,31 @@
+import {
+  ExtensionInternalMessageType,
+  WebProofStep,
+} from "../web-proof-commons";
+import { Step, StepStatus } from "src/constants";
+import { useRef } from "react";
+import sendMessageToServiceWorker from "lib/sendMessageToServiceWorker.ts";
+
+export const useNotifyOnStepCompleted = (
+  stepsSetup: WebProofStep[],
+  currentStepsProgress: Step[],
+) => {
+  const completedSteps = useRef(0);
+
+  const completedStepsCount = currentStepsProgress.filter(
+    (step) => step.status === StepStatus.Completed,
+  ).length;
+
+  if (completedStepsCount > completedSteps.current) {
+    for (let i = completedSteps.current; i < completedStepsCount; i++) {
+      void sendMessageToServiceWorker({
+        type: ExtensionInternalMessageType.StepCompleted,
+        payload: {
+          index: i,
+          step: stepsSetup[i],
+        },
+      });
+    }
+    completedSteps.current = completedStepsCount;
+  }
+};

--- a/packages/browser-extension/src/hooks/useSteps.test.ts
+++ b/packages/browser-extension/src/hooks/useSteps.test.ts
@@ -5,7 +5,7 @@ import browser from "webextension-polyfill";
 import { useNotifyOnStepCompleted } from "hooks/useSteps.ts";
 import { renderHook } from "@testing-library/react";
 import { Step, StepStatus } from "src/constants";
-import { MessageFromExtensionType } from "src/web-proof-commons/types/message.ts";
+import { ExtensionInternalMessageType } from "src/web-proof-commons/types/message.ts";
 
 describe("calculateSteps unit", () => {
   testData.forEach((testCase) => {
@@ -49,7 +49,7 @@ describe("sending message on step completion", () => {
     expect(messageSenderSpy).toHaveBeenCalledTimes(steps.length);
     for (let i = 0; i < steps.length; i++) {
       expect(messageSenderSpy).nthCalledWith(i + 1, {
-        type: MessageFromExtensionType.StepCompleted,
+        type: ExtensionInternalMessageType.StepCompleted,
         payload: {
           index: i,
           step: steps[i],

--- a/packages/browser-extension/src/hooks/useSteps.test.ts
+++ b/packages/browser-extension/src/hooks/useSteps.test.ts
@@ -1,11 +1,60 @@
-import { describe, it } from "vitest";
-import { testData } from "./useSteps.test.data.ts";
+import { describe, expect, it, vi } from "vitest";
+import { steps, testData } from "./useSteps.test.data.ts";
 import { expectedStatuses } from "hooks/useSteps.test.helpers.ts";
+import browser from "webextension-polyfill";
+import { useNotifyOnStepCompleted } from "hooks/useSteps.ts";
+import { renderHook } from "@testing-library/react";
+import { Step, StepStatus } from "src/constants";
+import { MessageFromExtensionType } from "src/web-proof-commons/types/message.ts";
 
 describe("calculateSteps unit", () => {
   testData.forEach((testCase) => {
     it(testCase.input.id, () => {
       expectedStatuses(testCase);
     });
+  });
+});
+
+describe("sending message on step completion", () => {
+  function intoCurrentStepsProgress(idx: number) {
+    return testData[idx].output.map((status) => ({ status })) as Step[];
+  }
+
+  it("fires event once for each completed step", () => {
+    const messageSenderSpy = vi.spyOn(browser.runtime, "sendMessage");
+    const { rerender } = renderHook(
+      ({ currentSteps }) => useNotifyOnStepCompleted(steps, currentSteps),
+      {
+        initialProps: { currentSteps: intoCurrentStepsProgress(0) },
+      },
+    );
+
+    let expectedSentMessages = 0;
+    expect(messageSenderSpy).toHaveBeenCalledTimes(0);
+
+    for (let i = 1; i < testData.length; i++) {
+      rerender({ currentSteps: intoCurrentStepsProgress(i) });
+      const currentlyCompletedSteps = testData[i].output.filter(
+        (status) => status === StepStatus.Completed,
+      ).length;
+
+      // Should not resend event after we had regression in completed steps
+      expectedSentMessages = Math.max(
+        currentlyCompletedSteps,
+        expectedSentMessages,
+      );
+      expect(messageSenderSpy).toHaveBeenCalledTimes(expectedSentMessages);
+    }
+
+    expect(messageSenderSpy).toHaveBeenCalledTimes(steps.length);
+    for (let i = 0; i < steps.length; i++) {
+      expect(messageSenderSpy).nthCalledWith(i + 1, {
+        type: MessageFromExtensionType.StepCompleted,
+        payload: {
+          index: i,
+          step: steps[i],
+        },
+      });
+    }
   });
 });

--- a/packages/browser-extension/src/hooks/useSteps.test.ts
+++ b/packages/browser-extension/src/hooks/useSteps.test.ts
@@ -1,60 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
-import { steps, testData } from "./useSteps.test.data.ts";
-import { expectedStatuses } from "hooks/useSteps.test.helpers.ts";
-import browser from "webextension-polyfill";
-import { useNotifyOnStepCompleted } from "hooks/useSteps.ts";
-import { renderHook } from "@testing-library/react";
-import { Step, StepStatus } from "src/constants";
-import { ExtensionInternalMessageType } from "src/web-proof-commons/types/message.ts";
+import { describe, it } from "vitest";
+import { testData } from "./useSteps.test.data.ts";
+import { expectedStatuses } from "./useSteps.test.helpers.ts";
 
 describe("calculateSteps unit", () => {
   testData.forEach((testCase) => {
     it(testCase.input.id, () => {
       expectedStatuses(testCase);
     });
-  });
-});
-
-describe("sending message on step completion", () => {
-  function intoCurrentStepsProgress(idx: number) {
-    return testData[idx].output.map((status) => ({ status })) as Step[];
-  }
-
-  it("fires event once for each completed step", () => {
-    const messageSenderSpy = vi.spyOn(browser.runtime, "sendMessage");
-    const { rerender } = renderHook(
-      ({ currentSteps }) => useNotifyOnStepCompleted(steps, currentSteps),
-      {
-        initialProps: { currentSteps: intoCurrentStepsProgress(0) },
-      },
-    );
-
-    let expectedSentMessages = 0;
-    expect(messageSenderSpy).toHaveBeenCalledTimes(0);
-
-    for (let i = 1; i < testData.length; i++) {
-      rerender({ currentSteps: intoCurrentStepsProgress(i) });
-      const currentlyCompletedSteps = testData[i].output.filter(
-        (status) => status === StepStatus.Completed,
-      ).length;
-
-      // Should not resend event after we had regression in completed steps
-      expectedSentMessages = Math.max(
-        currentlyCompletedSteps,
-        expectedSentMessages,
-      );
-      expect(messageSenderSpy).toHaveBeenCalledTimes(expectedSentMessages);
-    }
-
-    expect(messageSenderSpy).toHaveBeenCalledTimes(steps.length);
-    for (let i = 0; i < steps.length; i++) {
-      expect(messageSenderSpy).nthCalledWith(i + 1, {
-        type: ExtensionInternalMessageType.StepCompleted,
-        payload: {
-          index: i,
-          step: steps[i],
-        },
-      });
-    }
   });
 });

--- a/packages/browser-extension/src/hooks/useSteps.ts
+++ b/packages/browser-extension/src/hooks/useSteps.ts
@@ -1,19 +1,13 @@
 import { BrowsingHistoryItem } from "../state/history";
 import { Step, StepStatus } from "../constants";
-import {
-  ExtensionInternalMessageType,
-  UrlPattern,
-  WebProofStep,
-} from "../web-proof-commons";
+import { UrlPattern, WebProofStep } from "../web-proof-commons";
 import { useProvingSessionConfig } from "hooks/useProvingSessionConfig.ts";
 import { useBrowsingHistory } from "hooks/useBrowsingHistory.ts";
 import { useZkProvingState } from "./useZkProvingState";
 import { URLPattern } from "urlpattern-polyfill";
-import { P } from "ts-pattern";
-import { match } from "ts-pattern";
+import { match, P } from "ts-pattern";
 import { LOADING } from "@vlayer/extension-hooks";
-import { useRef } from "react";
-import sendMessageToServiceWorker from "lib/sendMessageToServiceWorker.ts";
+import { useNotifyOnStepCompleted } from "hooks/useNotifyOnStepCompleted.ts";
 
 const isUrlRequestCompleted = (
   browsingHistory: BrowsingHistoryItem[],
@@ -131,30 +125,6 @@ export const calculateSteps = ({
     };
     return [...accumulator, mappedStep];
   }, [] as Step[]);
-};
-
-export const useNotifyOnStepCompleted = (
-  stepsSetup: WebProofStep[],
-  currentStepsProgress: Step[],
-) => {
-  const completedSteps = useRef(0);
-
-  const completedStepsCount = currentStepsProgress.filter(
-    (step) => step.status === StepStatus.Completed,
-  ).length;
-
-  if (completedStepsCount > completedSteps.current) {
-    for (let i = completedSteps.current; i < completedStepsCount; i++) {
-      void sendMessageToServiceWorker({
-        type: ExtensionInternalMessageType.StepCompleted,
-        payload: {
-          index: i,
-          step: stepsSetup[i],
-        },
-      });
-    }
-    completedSteps.current = completedStepsCount;
-  }
 };
 
 export const useSteps = (): Step[] => {

--- a/packages/web-proof-commons/types/message.ts
+++ b/packages/web-proof-commons/types/message.ts
@@ -45,6 +45,7 @@ export enum ExtensionInternalMessageType {
   ProofError = "ProofError",
   ProofProcessing = "ProofProcessing",
   ResetTlsnProving = "ResetTlsnProving",
+  StepCompleted = "StepCompleted",
 }
 
 export enum MessageFromExtensionType {
@@ -54,6 +55,7 @@ export enum MessageFromExtensionType {
   ProofError = "ProofError",
   ProofProcessing = "ProofProcessing",
   Pong = "Pong",
+  StepCompleted = "StepCompleted",
 }
 
 export type LegacyMessage = {
@@ -107,6 +109,13 @@ export type ExtensionInternalMessage =
     }
   | {
       type: ExtensionInternalMessageType.ResetTlsnProving;
+    }
+  | {
+      type: ExtensionInternalMessageType.StepCompleted;
+      payload: {
+        index: number;
+        step: WebProofStep;
+      };
     };
 
 export type MessageFromExtension =
@@ -131,6 +140,13 @@ export type MessageFromExtension =
       type: MessageFromExtensionType.ProofProcessing;
       payload: {
         progress?: number;
+      };
+    }
+  | {
+      type: MessageFromExtensionType.StepCompleted;
+      payload: {
+        index: number;
+        step: WebProofStep;
       };
     };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added notifications when individual steps are completed during proof progress in the browser extension.

- **Bug Fixes**
  - Ensured that notifications for completed steps are sent exactly once per step, with no duplicates or omissions.

- **Tests**
  - Introduced comprehensive tests to verify correct notification behavior for step completion events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->