### PR TITLE
fix: redirect to tx on blockchain explorer

### DIFF
--- a/examples/simple-email-proof/vlayer/src/pages/success/index.tsx
+++ b/examples/simple-email-proof/vlayer/src/pages/success/index.tsx
@@ -14,11 +14,7 @@ export const SuccessContainer = () => {
         Your <b>{domain}</b> NFT was minted to {truncateHashOrAddr(recipient)}
         <br />
         <a
-          href={
-            account.chain?.blockExplorers?.default.name === "Etherscan"
-              ? `${account.chain?.blockExplorers?.default.url}/token/${txHash}`
-              : `${account.chain?.blockExplorers?.default.url}/tx/${txHash}`
-          }
+          href={`${account.chain?.blockExplorers?.default.url}/tx/${txHash}`}
           target="_blank"
           rel="noreferrer"
           className="text-violet-500 font-bold block mt-5"

--- a/examples/simple-time-travel/vlayer/src/pages/success/index.tsx
+++ b/examples/simple-time-travel/vlayer/src/pages/success/index.tsx
@@ -5,7 +5,6 @@ export const SuccessPage = () => {
   const account = useAccount();
   const [searchParams] = useSearchParams();
   const txHash = searchParams.get("txHash");
-  console.log(account.chain);
 
   return (
     <>
@@ -13,11 +12,7 @@ export const SuccessPage = () => {
         <div>
           Here is your NFT:{" "}
           <a
-            href={
-              account.chain?.blockExplorers?.default.name === "Etherscan"
-                ? `${account.chain?.blockExplorers?.default.url}/token/${txHash}`
-                : `${account.chain?.blockExplorers?.default.url}/tx/${txHash}`
-            }
+            href={`${account.chain?.blockExplorers?.default.url}/tx/${txHash}`}
             className="text-blue-700 text-center text-block font-bold"
           >
             {shortenAndFormatHash(txHash)}


### PR DESCRIPTION
Problem: Currently we have redirect to token page which result in 404 and is tricky to implement as after mint we don't know id of NFT

Solution:  Redirect to transaction page in blockchain explorer. There user can find NFT. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the logic for constructing transaction links by always using the transaction URL format, regardless of the block explorer's name.
- **Style**
  - Removed unnecessary console log statements for cleaner output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->