### PR TITLE
fix(CI): remove flakiness in extension playwright tests [ENGA-740]

### DIFF
--- a/packages/playwright-tests/extension.full.get.spec.ts
+++ b/packages/playwright-tests/extension.full.get.spec.ts
@@ -21,6 +21,9 @@ test("Full flow from opening sidepanel to redirection", async ({
   await page.goto(dappUrl);
   const webpage = new Webpage(page, context);
 
+  const extension = await waitForExtension(context);
+  const appPagePromise = extension.redirect();
+
   await test.step("Extension should stay ok after clicking request button multiple times", async () => {
     await webpage.clickButton("Request proof of being a wizard");
     await webpage.clickButton("Request proof of being a wizard");
@@ -30,9 +33,6 @@ test("Full flow from opening sidepanel to redirection", async ({
     expect(extension).toBeDefined();
   });
 
-  const extension = await waitForExtension(context);
-  const appPagePromise = extension.redirect();
-  await webpage.clickButton("Request proof of being a wizard");
   const appPage = await appPagePromise;
 
   await test.step("On 'redirect' click extension should open new browser tab for specified startPage url", async () => {

--- a/packages/playwright-tests/extension.full.get.spec.ts
+++ b/packages/playwright-tests/extension.full.get.spec.ts
@@ -31,7 +31,9 @@ test("Full flow from opening sidepanel to redirection", async ({
   });
 
   const extension = await waitForExtension(context);
-  const appPage = await extension.redirect();
+  const appPagePromise = extension.redirect();
+  await webpage.clickButton("Request proof of being a wizard");
+  const appPage = await appPagePromise;
 
   await test.step("On 'redirect' click extension should open new browser tab for specified startPage url", async () => {
     await appPage.waitForURL(loginUrl);

--- a/packages/playwright-tests/extension.full.put.spec.ts
+++ b/packages/playwright-tests/extension.full.put.spec.ts
@@ -22,13 +22,17 @@ test("Full flow from opening sidepanel to redirection for /dapp-put", async ({
     const webpage = new Webpage(page, context);
 
     await webpage.clickButton("Request Web Proof");
+    await webpage.clickButton("Request Web Proof");
+    await webpage.clickButton("Request Web Proof");
 
     const extension = await waitForExtension(context);
     expect(extension).toBeDefined();
   });
 
   const extension = await waitForExtension(context);
-  const appPage = await extension.redirect();
+  const appPagePromise = extension.redirect();
+  await webpage.clickButton("Request Web Proof");
+  const appPage = await appPagePromise;
 
   await test.step("On 'redirect' click extension should open new browser tab for specified startPage url", async () => {
     await appPage.waitForURL(loginUrl);

--- a/packages/playwright-tests/extension.full.put.spec.ts
+++ b/packages/playwright-tests/extension.full.put.spec.ts
@@ -17,6 +17,9 @@ test("Full flow from opening sidepanel to redirection for /dapp-put", async ({
     expect(extension).toBeDefined();
   });
 
+  const extension = await waitForExtension(context);
+  const appPagePromise = extension.redirect();
+
   await test.step("Extension should stay ok after clicking request button multiple times", async () => {
     await page.goto(dappPutUrl);
     const webpage = new Webpage(page, context);
@@ -29,9 +32,6 @@ test("Full flow from opening sidepanel to redirection for /dapp-put", async ({
     expect(extension).toBeDefined();
   });
 
-  const extension = await waitForExtension(context);
-  const appPagePromise = extension.redirect();
-  await webpage.clickButton("Request Web Proof");
   const appPage = await appPagePromise;
 
   await test.step("On 'redirect' click extension should open new browser tab for specified startPage url", async () => {


### PR DESCRIPTION
`extension.full.get.spec.ts` test was sometimes randomly failing on CI.
It turned out that it behaves the same locally. It was always happening after the test step that was testing multiple openings of extension. Test was timeouted at waiting for a new page to open.
I think the reason was that we were opening multiple times extension and it was redirecting to the another page and for some reason in this case it was happening before the step when we were awaiting the new page. I changed it so that we first start to wait for the new page and then click the button. For me locally it helped and the problem didn't occur the several times I run the test.
Additionally in the analogous  step in `extension.put.spec.ts` I added more clicks opening the extension, because I think that there weren't enough.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test reliability for extension redirect flows by restructuring redirect handling with promises.
  - Enhanced stability checks by increasing the number of rapid consecutive button clicks in specific test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->