### PR TITLE
fix(workflow): cancel generate artifact if already exist

### DIFF
--- a/.github/workflows/verify_image_id_onchain.yaml
+++ b/.github/workflows/verify_image_id_onchain.yaml
@@ -2,8 +2,8 @@ name: Verify image ID on mainnet chains
 on:
   workflow_dispatch:
   push:
-    # branches:
-    #   - "release/**"
+    branches:
+      - "release/**"
 
 concurrency:
   group: ${{ github.workflow }}
@@ -20,9 +20,6 @@ jobs:
         with:
           ref: ${{ github.ref }}
           submodules: recursive
-
-      - name: Verify image ID on mainnet chains
-        uses: ./.github/actions/verify-image-id-onchain
 
       - name: Verify image ID on mainnet chains
         uses: ./.github/actions/verify-image-id-onchain


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the build workflow to skip redundant guest artifact builds when artifacts are already available, resulting in faster and more efficient CI runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->