### PR TITLE
Memorize completed steps count and don't allow for regression

### DIFF
--- a/packages/browser-extension/src/hooks/useSteps.test.data.ts
+++ b/packages/browser-extension/src/hooks/useSteps.test.data.ts
@@ -243,6 +243,30 @@ export const testData = [
   },
   {
     input: {
+      isZkProvingDone: false,
+      history: [
+        { url: "https://example.com/start", ready: true },
+        { url: "https://example.com/redirect", ready: true },
+        { url: "https://example.com/path/expect", ready: true },
+        { url: "https://example.com/notarize", ready: true },
+      ] as BrowsingHistoryItem[],
+      activeTabContext: {
+        url: "https://example.com/path/expect",
+        innerHTML: "<button data-clicked='false'>Click here now</button>",
+      },
+      alreadyCompletedStepsCount: 4,
+      id: "Once step was completed, it will stay completed",
+    },
+    output: [
+      StepStatus.Completed,
+      StepStatus.Completed,
+      StepStatus.Completed,
+      StepStatus.Completed,
+      StepStatus.Current,
+    ],
+  },
+  {
+    input: {
       isZkProvingDone: true,
       history: [
         { url: "https://example.com/start", ready: true },

--- a/packages/browser-extension/src/hooks/useSteps.test.helpers.ts
+++ b/packages/browser-extension/src/hooks/useSteps.test.helpers.ts
@@ -16,6 +16,7 @@ export type StepTestCase = {
     isZkProvingDone: boolean;
     history: BrowsingHistoryItem[];
     activeTabContext?: TestActiveTab;
+    alreadyCompletedStepsCount?: number;
   };
   output: StepStatus[];
 };
@@ -38,6 +39,7 @@ export const expectedStatuses = async ({ input, output }: StepTestCase) => {
   }
   (
     await calculateSteps({
+      alreadyCompletedStepsCount: 0,
       stepsSetup: steps,
       ...input,
     })

--- a/packages/browser-extension/src/hooks/useSteps.ts
+++ b/packages/browser-extension/src/hooks/useSteps.ts
@@ -219,6 +219,12 @@ export const useSteps = (): Step[] => {
     .with({ steps: P.array(P.any) }, ({ steps }) => steps)
     .exhaustive();
 
+  useEffect(() => {
+    if (history.length === 0) {
+      completedSteps.current = 0;
+    }
+  }, [history]);
+
   const recalculateSteps = useCallback(async () => {
     const steps = await calculateSteps({
       alreadyCompletedStepsCount: completedSteps.current,


### PR DESCRIPTION
for example, when button was user was unfollowed; the twitter followership proof will still be available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Enhanced step tracking to optimize performance, resulting in faster and smoother updates when navigating through steps.  
  - Improved step completion status retention to ensure completed steps remain marked as such across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->