### PR TITLE
feat: push-testnet-image-id to base

### DIFF
--- a/bash/verifiers_management/push-testnet-image-id.sh
+++ b/bash/verifiers_management/push-testnet-image-id.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
-NETWORKS=( "sepolia" "base-sepolia" "optimism-sepolia" "arbitrum-sepolia" "worldchain-sepolia" )
+NETWORKS=( "sepolia" "base-sepolia" "optimism-sepolia" "arbitrum-sepolia" "worldchain-sepolia" "base" )
 
 set -ueo pipefail
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added support for the "base" network in the testnet image push process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->