### PR TITLE
ci: add worldchain RPC URLs to provers

### DIFF
--- a/ansible/host_vars/nightly_fake_prover.yml
+++ b/ansible/host_vars/nightly_fake_prover.yml
@@ -22,6 +22,7 @@ vlayer_prover_rpc_urls:
  - "8453:https://base-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "10:https://opt-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "84532:https://omniscient-flashy-frog.base-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
+ - "4801:https://omniscient-flashy-frog.worldchain-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
  - "80002:https://polygon-amoy.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "421614:https://arb-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "300:https://zksync-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"

--- a/ansible/host_vars/stable_fake_prover.yml
+++ b/ansible/host_vars/stable_fake_prover.yml
@@ -22,6 +22,7 @@ vlayer_prover_rpc_urls:
  - "8453:https://omniscient-flashy-frog.base-mainnet.quiknode.pro/{{ vlayer_quicknode_api_key }}"
  - "10:https://omniscient-flashy-frog.optimism.quiknode.pro/{{ vlayer_quicknode_api_key }}"
  - "84532:https://omniscient-flashy-frog.base-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
+ - "4801:https://omniscient-flashy-frog.worldchain-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
  - "80002:https://polygon-amoy.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "421614:https://arb-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "300:https://zksync-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"

--- a/ansible/host_vars/stable_prod_prover.yml
+++ b/ansible/host_vars/stable_prod_prover.yml
@@ -30,6 +30,7 @@ vlayer_prover_rpc_urls:
  - "1:https://eth-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "8453:https://omniscient-flashy-frog.base-mainnet.quiknode.pro/{{ vlayer_quicknode_api_key }}"
  - "10:https://omniscient-flashy-frog.optimism.quiknode.pro/{{ vlayer_quicknode_api_key }}"
+ - "480:https://omniscient-flashy-frog.worldchain-mainnet.quiknode.pro/{{ vlayer_quicknode_api_key }}"
  - "42161:https://arb-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "42170:https://arbnova-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "137:https://polygon-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Worldchain Sepolia test network and Worldchain mainnet by including new RPC endpoints in the configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->