### PR TITLE
Revert "chore(ansible): configure GAS_METER_API_KEY from env vars"

### DIFF
--- a/ansible/roles/prover/templates/vlayer.service.j2
+++ b/ansible/roles/prover/templates/vlayer.service.j2
@@ -23,9 +23,6 @@ Environment='BONSAI_API_URL={{ vlayer_bonsai_api_url }}'
 {% if vlayer_bonsai_api_key is defined %}
 Environment='BONSAI_API_KEY={{ vlayer_bonsai_api_key }}'
 {% endif %}
-{% if vlayer_prover_gas_meter_api_key is defined %}
-Environment='GAS_METER_API_KEY={{ vlayer_prover_gas_meter_api_key }}'
-{% endif %}
 ExecStart=/home/{{ ansible_user }}/.vlayer/bin/call_server
 {{- ' --host ' ~ vlayer_prover_host if vlayer_prover_host is defined else '' }}
 {{- ' --port ' ~ vlayer_prover_port if vlayer_prover_port is defined else '' }}
@@ -35,6 +32,7 @@ ExecStart=/home/{{ ansible_user }}/.vlayer/bin/call_server
 {% endfor %}
 {% if vlayer_prover_gas_meter_url is defined %}
 {{- ' --gas-meter-url ' ~ vlayer_prover_gas_meter_url }}
+{{- ' --gas-meter-api-key ' ~ vlayer_prover_gas_meter_api_key -}}
 {% endif %}
 {% if vlayer_prover_chain_proof_url is defined %}
 {{- ' --chain-proof-url ' ~ vlayer_prover_chain_proof_url -}}


### PR DESCRIPTION
Reverts vlayer-xyz/vlayer#2433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - The gas meter API key is now provided as a command-line argument rather than an environment variable when starting the service. This change affects how the API key is passed to the application but does not impact user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->