### PR TITLE
ci: add timeouts to jobs with potentially hanging bun install

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -179,6 +179,7 @@ jobs:
     name: Publish SDK to NPM
     needs: [build-release, build-examples, build-extension, push-contracts]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - name: Install TypeScript prerequisites
@@ -215,6 +216,7 @@ jobs:
     name: Publish React hooks to NPM
     needs: [build-release, publish-sdk-to-npm]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - name: Install TypeScript prerequisites


### PR DESCRIPTION
From time to time those jobs hang on `bun install`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Set a 5-minute timeout for publishing SDK and React hooks to NPM, ensuring jobs do not run longer than intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->