### PR TITLE
fix: remove obsolete traces of VITE_PRIVATE_KEY

### DIFF
--- a/examples/simple-email-proof/vlayer/deploy.ts
+++ b/examples/simple-email-proof/vlayer/deploy.ts
@@ -22,7 +22,6 @@ await writeEnvVariables(".env", {
   VITE_CHAIN_NAME: config.chainName,
   VITE_PROVER_URL: config.proverUrl,
   VITE_JSON_RPC_URL: config.jsonRpcUrl,
-  VITE_PRIVATE_KEY: config.privateKey,
   VITE_DNS_SERVICE_URL: config.dnsServiceUrl,
   VITE_VLAYER_API_TOKEN: config.token,
   VITE_EMAIL_SERVICE_URL: process.env.EMAIL_SERVICE_URL || "",

--- a/examples/simple-teleport/vlayer/deploy.ts
+++ b/examples/simple-teleport/vlayer/deploy.ts
@@ -64,7 +64,6 @@ await writeEnvVariables(".env", {
   VITE_VERIFIER_ADDRESS: verifier,
   VITE_CHAIN_NAME: config.chainName,
   VITE_PROVER_URL: config.proverUrl,
-  VITE_PRIVATE_KEY: config.privateKey,
   VITE_VLAYER_API_TOKEN: config.token,
   VITE_TOKENS_TO_CHECK: `"${JSON.stringify(tokensToCheck)}"`,
   VITE_DEFAULT_TOKEN_HOLDER: teleportConfig.tokenHolder,

--- a/examples/simple-time-travel/vlayer/deploy.ts
+++ b/examples/simple-time-travel/vlayer/deploy.ts
@@ -37,7 +37,6 @@ await writeEnvVariables(".env", {
   VITE_VERIFIER_ADDRESS: verifier,
   VITE_CHAIN_NAME: config.chainName,
   VITE_PROVER_URL: config.proverUrl,
-  VITE_PRIVATE_KEY: config.privateKey,
   VITE_VLAYER_API_TOKEN: config.token,
   VITE_PROVER_ERC20_HOLDER_ADDR: timeTravelConfig.tokenOwner,
   VITE_START_BLOCK: startBlock.toString(),

--- a/examples/simple-web-proof/vlayer/deploy.ts
+++ b/examples/simple-web-proof/vlayer/deploy.ts
@@ -20,7 +20,6 @@ await writeEnvVariables(".env", {
   VITE_PROVER_URL: config.proverUrl,
   VITE_JSON_RPC_URL: config.jsonRpcUrl,
   VITE_CLIENT_AUTH_MODE: config.clientAuthMode,
-  VITE_PRIVATE_KEY: config.privateKey,
   VITE_VLAYER_API_TOKEN: config.token,
   VITE_NOTARY_URL: config.notaryUrl,
   VITE_WS_PROXY_URL: config.wsProxyUrl,

--- a/packages/sdk/src/config/filterOverrides.test.ts
+++ b/packages/sdk/src/config/filterOverrides.test.ts
@@ -5,17 +5,5 @@ describe("filterOverrides", () => {
   test("correctly filter env overrides that were not defined", () => {
     expect(filterOverrides({ a: "d", b: "c" })).toEqual({ a: "d", b: "c" });
     expect(filterOverrides({ a: undefined, b: "c" })).toEqual({ b: "c" });
-    expect(
-      filterOverrides({
-        VITE_VLAYER_API_TOKEN: undefined,
-        VITE_PRIVATE_KEY: "sk_...",
-      }),
-    ).toEqual({ VITE_PRIVATE_KEY: "sk_..." });
-    expect(
-      filterOverrides({
-        VITE_VLAYER_API_TOKEN: "AAAA===",
-        VITE_PRIVATE_KEY: "sk_...",
-      }),
-    ).toEqual({ VITE_PRIVATE_KEY: "sk_...", VITE_VLAYER_API_TOKEN: "AAAA===" });
   });
 });


### PR DESCRIPTION
This is not used or needed, and is dangerously close to leaking the keys in the frontend build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed the `VITE_PRIVATE_KEY` environment variable from deployment scripts and `.env` file generation in several example projects.
- **Tests**
  - Simplified test coverage by removing specific test cases related to `VITE_PRIVATE_KEY` and `VITE_VLAYER_API_TOKEN` environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->