### PR TITLE
ci: remove mainnet RPC URLs from fake provers

### DIFF
--- a/ansible/host_vars/nightly_fake_prover.yml
+++ b/ansible/host_vars/nightly_fake_prover.yml
@@ -18,27 +18,16 @@ vlayer_alchemy_api_key: !vault |
 vlayer_prover_rpc_urls:
  - "11155111:https://omniscient-flashy-frog.ethereum-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
  - "11155420:https://omniscient-flashy-frog.optimism-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
- - "1:https://eth-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  # Base mainnet remains in fake provers for the time being, supporting one use case.
  - "8453:https://omniscient-flashy-frog.base-mainnet.quiknode.pro/{{ vlayer_quicknode_api_key }}"
- - "10:https://omniscient-flashy-frog.optimism.quiknode.pro/{{ vlayer_quicknode_api_key }}"
  - "84532:https://omniscient-flashy-frog.base-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
  - "4801:https://omniscient-flashy-frog.worldchain-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
  - "80002:https://polygon-amoy.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "421614:https://arb-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "300:https://zksync-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "42161:https://arb-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "42170:https://arbnova-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "137:https://polygon-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "324:https://zksync-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "747:https://flow-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "545:https://flow-testnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "534352:https://scroll-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "534351:https://scroll-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "5000:https://mantle-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "59144:https://linea-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "59141:https://linea-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "100:https://gnosis-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "10200:https://gnosis-chiado.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  # https://docs.bitkubchain.org/rpc-service/rpc
  # The rate limit of RPC endpoint on Mainnet and Testnet is 2K/1min.

--- a/ansible/host_vars/stable_fake_prover.yml
+++ b/ansible/host_vars/stable_fake_prover.yml
@@ -18,27 +18,16 @@ vlayer_alchemy_api_key: !vault |
 vlayer_prover_rpc_urls:
  - "11155111:https://omniscient-flashy-frog.ethereum-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
  - "11155420:https://omniscient-flashy-frog.optimism-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
- - "1:https://eth-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  # Base mainnet remains in fake provers for the time being, supporting one use case.
  - "8453:https://omniscient-flashy-frog.base-mainnet.quiknode.pro/{{ vlayer_quicknode_api_key }}"
- - "10:https://omniscient-flashy-frog.optimism.quiknode.pro/{{ vlayer_quicknode_api_key }}"
  - "84532:https://omniscient-flashy-frog.base-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
  - "4801:https://omniscient-flashy-frog.worldchain-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
  - "80002:https://polygon-amoy.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "421614:https://arb-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "300:https://zksync-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "42161:https://arb-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "42170:https://arbnova-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "137:https://polygon-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "324:https://zksync-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "747:https://flow-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "545:https://flow-testnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "534352:https://scroll-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "534351:https://scroll-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "5000:https://mantle-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "59144:https://linea-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "59141:https://linea-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "100:https://gnosis-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  - "10200:https://gnosis-chiado.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
  # https://docs.bitkubchain.org/rpc-service/rpc
  # The rate limit of RPC endpoint on Mainnet and Testnet is 2K/1min.


### PR DESCRIPTION
Follow-up to https://github.com/vlayer-xyz/vlayer/pull/2442