### PR TITLE
fix(ansible): fix JWT public key env var in provers

### DIFF
--- a/ansible/roles/prover/templates/vlayer.service.j2
+++ b/ansible/roles/prover/templates/vlayer.service.j2
@@ -39,7 +39,7 @@ Environment=VLAYER_PROOF_MODE={{ vlayer_proof_type }}
 {% if vlayer_prover_chain_proof_url is defined %}
 Environment=VLAYER_CHAIN_CLIENT__URL={{ vlayer_prover_chain_proof_url }}
 {% endif %}
-Environment=VLAYER_AUTH__JWT__URL={{ vlayer_jwt_public_key_location }}
+Environment=VLAYER_AUTH__JWT__PUBLIC_KEY={{ vlayer_jwt_public_key_location }}
 Environment=VLAYER_AUTH__JWT__ALGORITHM={{ vlayer_jwt_algorithm }}
 Environment='VLAYER_RPC_URLS={{ vlayer_prover_rpc_urls | join(' ') }}'
 ExecStart=/home/{{ ansible_user }}/.vlayer/bin/call_server


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the environment variable name for the JWT public key location in the service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->