### PR TITLE
fix: `jsonGetFloatAsInt` not present in `WebLib`

### DIFF
--- a/contracts/vlayer/src/WebProof.sol
+++ b/contracts/vlayer/src/WebProof.sol
@@ -133,22 +133,16 @@ library WebLib {
         return abi.decode(returnData, (bool));
     }
 
-    function jsonGetFloatAsInt(
-        Web memory web,
-        string memory jsonPath,
-        uint8 precision
-    ) internal view returns (int256) {
+    function jsonGetFloatAsInt(Web memory web, string memory jsonPath, uint8 precision)
+        internal
+        view
+        returns (int256)
+    {
         require(bytes(web.body).length > 0, "Body is empty");
 
-        FloatInput memory input = FloatInput({
-            json: web.body,
-            path: jsonPath,
-            precision: precision
-        });
+        FloatInput memory input = FloatInput({json: web.body, path: jsonPath, precision: precision});
         bytes memory encodedParams = abi.encode(input);
-        (bool success, bytes memory returnData) = Precompiles
-            .JSON_GET_FLOAT_AS_INT
-            .staticcall(encodedParams);
+        (bool success, bytes memory returnData) = Precompiles.JSON_GET_FLOAT_AS_INT.staticcall(encodedParams);
         Address.verifyCallResult(success, returnData);
 
         return abi.decode(returnData, (int256));

--- a/contracts/vlayer/src/WebProof.sol
+++ b/contracts/vlayer/src/WebProof.sol
@@ -19,6 +19,12 @@ struct Web {
     string url;
 }
 
+struct FloatInput {
+    string json;
+    string path;
+    uint8 precision;
+}
+
 library WebProofLib {
     using Strings for string;
     using UrlLib for string;
@@ -125,5 +131,26 @@ library WebLib {
         Address.verifyCallResult(success, returnData);
 
         return abi.decode(returnData, (bool));
+    }
+
+    function jsonGetFloatAsInt(
+        Web memory web,
+        string memory jsonPath,
+        uint8 precision
+    ) internal view returns (int256) {
+        require(bytes(web.body).length > 0, "Body is empty");
+
+        FloatInput memory input = FloatInput({
+            json: web.body,
+            path: jsonPath,
+            precision: precision
+        });
+        bytes memory encodedParams = abi.encode(input);
+        (bool success, bytes memory returnData) = Precompiles
+            .JSON_GET_FLOAT_AS_INT
+            .staticcall(encodedParams);
+        Address.verifyCallResult(success, returnData);
+
+        return abi.decode(returnData, (int256));
     }
 }

--- a/contracts/vlayer/test/vlayer/WebLib.t.sol
+++ b/contracts/vlayer/test/vlayer/WebLib.t.sol
@@ -57,4 +57,13 @@ contract JsonParsingTest is VTest {
 
         assertEq(keccak256(bytes(assetName)), keccak256(bytes("FDUSD")));
     }
+
+    function test_parsingFloatFromSimpleJson() public {
+        Web memory web = Web("{\"asset\":\"FDUSD\",\"test\":5.123}", "", "");
+
+        callProver();
+        int256 value = web.jsonGetFloatAsInt("test", 2);
+
+        assertEq(value, 512);
+    }
 }


### PR DESCRIPTION
Still thinking about where to test this precompile. I could test it in one of the existing examples, but that would overcomplicate something that’s meant to be simple. I'm considering creating a separate workflow for testing all the precompiles. @rzadp?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for extracting floating-point numbers from JSON data with specified precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->