### PR TITLE
fix(ansible): remove trailing newlines from API keys

### DIFF
--- a/ansible/host_vars/nightly_fake_prover.yml
+++ b/ansible/host_vars/nightly_fake_prover.yml
@@ -16,19 +16,19 @@ vlayer_alchemy_api_key: !vault |
   63343030643438373066326432356565363534623131306166383939656563623537656535626161
   6164386166343532386262626237643763623366376537663030
 vlayer_prover_rpc_urls:
- - "11155111:https://omniscient-flashy-frog.ethereum-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
- - "11155420:https://omniscient-flashy-frog.optimism-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
+ - "11155111:https://omniscient-flashy-frog.ethereum-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
+ - "11155420:https://omniscient-flashy-frog.optimism-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
  # Base mainnet remains in fake provers for the time being, supporting one use case.
- - "8453:https://omniscient-flashy-frog.base-mainnet.quiknode.pro/{{ vlayer_quicknode_api_key }}"
- - "84532:https://omniscient-flashy-frog.base-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
- - "4801:https://omniscient-flashy-frog.worldchain-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}"
- - "80002:https://polygon-amoy.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "421614:https://arb-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "300:https://zksync-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "545:https://flow-testnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "534351:https://scroll-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "59141:https://linea-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
- - "10200:https://gnosis-chiado.g.alchemy.com/v2/{{ vlayer_alchemy_api_key }}"
+ - "8453:https://omniscient-flashy-frog.base-mainnet.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
+ - "84532:https://omniscient-flashy-frog.base-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
+ - "4801:https://omniscient-flashy-frog.worldchain-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
+ - "80002:https://polygon-amoy.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
+ - "421614:https://arb-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
+ - "300:https://zksync-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
+ - "545:https://flow-testnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
+ - "534351:https://scroll-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
+ - "59141:https://linea-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
+ - "10200:https://gnosis-chiado.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
  # https://docs.bitkubchain.org/rpc-service/rpc
  # The rate limit of RPC endpoint on Mainnet and Testnet is 2K/1min.
  - "25925:https://rpc-testnet.bitkubchain.io"


### PR DESCRIPTION
Not sure if this is the right solution, so would appreciate if you could double check @rzadp. tl;dr the keys when inserted from the vault may contain trailing newline chars which then mess up with setting up env vars for the prover to consume.