### PR TITLE
fix: trigger test nightly release

### DIFF
--- a/.github/workflows/test_release.yaml
+++ b/.github/workflows/test_release.yaml
@@ -1,7 +1,7 @@
 name: Test Release
 on:
   workflow_run:
-    workflows: ["Deploy Stable Provers"]
+    workflows: ["Deploy Stable Provers", "Deploy Nightly Provers"]
     types: [completed]
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow triggers so that the "Test Release" process now runs after either the "Deploy Stable Provers" or "Deploy Nightly Provers" workflows complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->