### PR TITLE
fix: redirect step in extension

### DIFF
--- a/packages/browser-extension/src/components/molecules/StepActions/Redirect/RedirectStepActions.tsx
+++ b/packages/browser-extension/src/components/molecules/StepActions/Redirect/RedirectStepActions.tsx
@@ -10,11 +10,16 @@ type RedirectStepActionProps = {
 };
 
 const redirect = async (link: string): Promise<void> => {
-  const tabs = await browser.tabs.query({
+  const [activeTab] = await browser.tabs.query({
     active: true,
     currentWindow: true,
   });
-  await browser.tabs.update(tabs[0].id, { url: link });
+
+  if (!activeTab || !activeTab.id) {
+    throw new Error("No active tab found");
+  }
+
+  await browser.tabs.update(activeTab.id, { url: link });
 };
 
 export const RedirectStepActions: FC<RedirectStepActionProps> = ({

--- a/packages/browser-extension/src/components/molecules/StepActions/Redirect/RedirectStepActions.tsx
+++ b/packages/browser-extension/src/components/molecules/StepActions/Redirect/RedirectStepActions.tsx
@@ -1,11 +1,20 @@
 import React, { FC, useEffect } from "react";
 import { StepStatus } from "constants/step";
+import browser from "webextension-polyfill";
 
 type RedirectStepActionProps = {
   isVisited: boolean;
   link: string;
   status: StepStatus;
   buttonText: string;
+};
+
+const redirect = async (link: string): Promise<void> => {
+  const tabs = await browser.tabs.query({
+    active: true,
+    currentWindow: true,
+  });
+  await browser.tabs.update(tabs[0].id, { url: link });
 };
 
 export const RedirectStepActions: FC<RedirectStepActionProps> = ({
@@ -15,7 +24,9 @@ export const RedirectStepActions: FC<RedirectStepActionProps> = ({
 }) => {
   useEffect(() => {
     if (!isVisited && status == StepStatus.Current) {
-      window.location.href = link;
+      redirect(link).catch((error) => {
+        console.error("Error during redirecting:", error);
+      });
     }
   }, [isVisited, link, status]);
 

--- a/packages/sdk/src/api/webProof/steps/index.ts
+++ b/packages/sdk/src/api/webProof/steps/index.ts
@@ -12,4 +12,4 @@ const steps = {
   userAction,
 };
 
-export { expectUrl, startPage, notarize, userAction, steps };
+export { expectUrl, startPage, notarize, userAction, redirect, steps };


### PR DESCRIPTION
`Redirect` step was trying to redirect webpage while being in extension context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved browser tab redirection for a smoother and more reliable experience, with enhanced error handling.
- **Chores**
  - Updated internal exports to improve module accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->