### PR TITLE
chore: rename `spec` field in `Benchmark` to `proverSpec`

### DIFF
--- a/packages/gas-benchmarks/README.md
+++ b/packages/gas-benchmarks/README.md
@@ -83,11 +83,11 @@ the prover spec and encode it as `Benchmark` type
 
 ```ts
 import { Benchmark } from "../types";
-import proverSpec from "../../../../contracts/fixtures/out/NewProver.sol/NewProver";
+import proverContractSpec from "../../../../contracts/fixtures/out/NewProver.sol/NewProver";
 
 export const benchmark: Benchmark = {
   name: "NewProver",
-  spec: proverSpec,
+  spec: proverContractSpec,
   args: [someArgs],
   functionName: "proveMe",
 };

--- a/packages/gas-benchmarks/src/bench.ts
+++ b/packages/gas-benchmarks/src/bench.ts
@@ -36,12 +36,12 @@ async function run(bench: Benchmark): Promise<Metrics> {
   const { chain, proverUrl } = createContext(config);
 
   const prover = await deployProver({
-    proverSpec: bench.proverSpec,
+    proverSpec: bench.proverContractSpec,
   });
 
   const hash = await prove(
     prover,
-    bench.proverSpec.abi,
+    bench.proverContractSpec.abi,
     bench.functionName,
     bench.args,
     chain.id,

--- a/packages/gas-benchmarks/src/bench.ts
+++ b/packages/gas-benchmarks/src/bench.ts
@@ -45,7 +45,7 @@ async function run(bench: Benchmark): Promise<Metrics> {
     bench.functionName,
     bench.args,
     chain.id,
-    proverUrl
+    proverUrl,
   );
   const { metrics } = await waitForProof(hash, proverUrl);
 
@@ -62,9 +62,9 @@ function prettyPrint(results: Results) {
         acc,
         name.length,
         `${stats.gas}`.length,
-        `${stats.cycles}`.length
+        `${stats.cycles}`.length,
       ),
-    MIN_CELL_WIDTH
+    MIN_CELL_WIDTH,
   );
   const rowWidth = (cellWidth + 2) * NUM_COLS + NUM_COLS + 1;
 

--- a/packages/gas-benchmarks/src/bench.ts
+++ b/packages/gas-benchmarks/src/bench.ts
@@ -36,16 +36,16 @@ async function run(bench: Benchmark): Promise<Metrics> {
   const { chain, proverUrl } = createContext(config);
 
   const prover = await deployProver({
-    proverSpec: bench.spec,
+    proverSpec: bench.proverSpec,
   });
 
   const hash = await prove(
     prover,
-    bench.spec.abi,
+    bench.proverSpec.abi,
     bench.functionName,
     bench.args,
     chain.id,
-    proverUrl,
+    proverUrl
   );
   const { metrics } = await waitForProof(hash, proverUrl);
 
@@ -62,9 +62,9 @@ function prettyPrint(results: Results) {
         acc,
         name.length,
         `${stats.gas}`.length,
-        `${stats.cycles}`.length,
+        `${stats.cycles}`.length
       ),
-    MIN_CELL_WIDTH,
+    MIN_CELL_WIDTH
   );
   const rowWidth = (cellWidth + 2) * NUM_COLS + NUM_COLS + 1;
 

--- a/packages/gas-benchmarks/src/benches/arith_ops.ts
+++ b/packages/gas-benchmarks/src/benches/arith_ops.ts
@@ -1,19 +1,34 @@
 import { Benchmark } from "../types";
-import proverSpec from "../../../../contracts/fixtures/out/ArithOpProver.sol/ArithOpProver";
+import proverContractSpec from "../../../../contracts/fixtures/out/ArithOpProver.sol/ArithOpProver";
 
 export const benchmarks: Benchmark[] = [
-  { name: "Addition", proverSpec, args: [1, 2], functionName: "add" },
+  {
+    name: "Addition",
+    proverContractSpec,
+    args: [1, 2],
+    functionName: "add",
+  },
   {
     name: "Multiplication",
-    proverSpec,
+    proverContractSpec,
     args: [1, 2],
     functionName: "mul",
   },
-  { name: "Subtraction", proverSpec, args: [1, 2], functionName: "sub" },
-  { name: "Division", proverSpec, args: [4, 2], functionName: "div" },
+  {
+    name: "Subtraction",
+    proverContractSpec,
+    args: [1, 2],
+    functionName: "sub",
+  },
+  {
+    name: "Division",
+    proverContractSpec,
+    args: [4, 2],
+    functionName: "div",
+  },
   {
     name: "Signed-division",
-    proverSpec,
+    proverContractSpec,
     args: [-4, 2],
     functionName: "sdiv",
   },

--- a/packages/gas-benchmarks/src/benches/arith_ops.ts
+++ b/packages/gas-benchmarks/src/benches/arith_ops.ts
@@ -1,10 +1,20 @@
 import { Benchmark } from "../types";
-import spec from "../../../../contracts/fixtures/out/ArithOpProver.sol/ArithOpProver";
+import proverSpec from "../../../../contracts/fixtures/out/ArithOpProver.sol/ArithOpProver";
 
 export const benchmarks: Benchmark[] = [
-  { name: "Addition", spec, args: [1, 2], functionName: "add" },
-  { name: "Multiplication", spec, args: [1, 2], functionName: "mul" },
-  { name: "Subtraction", spec, args: [1, 2], functionName: "sub" },
-  { name: "Division", spec, args: [4, 2], functionName: "div" },
-  { name: "Signed-division", spec, args: [-4, 2], functionName: "sdiv" },
+  { name: "Addition", proverSpec, args: [1, 2], functionName: "add" },
+  {
+    name: "Multiplication",
+    proverSpec,
+    args: [1, 2],
+    functionName: "mul",
+  },
+  { name: "Subtraction", proverSpec, args: [1, 2], functionName: "sub" },
+  { name: "Division", proverSpec, args: [4, 2], functionName: "div" },
+  {
+    name: "Signed-division",
+    proverSpec,
+    args: [-4, 2],
+    functionName: "sdiv",
+  },
 ];

--- a/packages/gas-benchmarks/src/benches/noop.ts
+++ b/packages/gas-benchmarks/src/benches/noop.ts
@@ -3,7 +3,7 @@ import spec from "../../../../contracts/fixtures/out/NoopProver.sol/NoopProver";
 
 export const benchmark: Benchmark = {
   name: "No-op",
-  spec,
+  proverSpec: spec,
   args: [],
   functionName: "noop",
 };

--- a/packages/gas-benchmarks/src/benches/noop.ts
+++ b/packages/gas-benchmarks/src/benches/noop.ts
@@ -1,9 +1,9 @@
 import { Benchmark } from "../types";
-import proverSpec from "../../../../contracts/fixtures/out/NoopProver.sol/NoopProver";
+import proverContractSpec from "../../../../contracts/fixtures/out/NoopProver.sol/NoopProver";
 
 export const benchmark: Benchmark = {
   name: "No-op",
-  proverSpec,
+  proverContractSpec,
   args: [],
   functionName: "noop",
 };

--- a/packages/gas-benchmarks/src/benches/noop.ts
+++ b/packages/gas-benchmarks/src/benches/noop.ts
@@ -1,9 +1,9 @@
 import { Benchmark } from "../types";
-import spec from "../../../../contracts/fixtures/out/NoopProver.sol/NoopProver";
+import proverSpec from "../../../../contracts/fixtures/out/NoopProver.sol/NoopProver";
 
 export const benchmark: Benchmark = {
   name: "No-op",
-  proverSpec: spec,
+  proverSpec,
   args: [],
   functionName: "noop",
 };

--- a/packages/gas-benchmarks/src/benches/noop_with_calldata.ts
+++ b/packages/gas-benchmarks/src/benches/noop_with_calldata.ts
@@ -1,6 +1,6 @@
 import { Benchmark } from "../types";
 import { bytesToHex } from "viem";
-import spec from "../../../../contracts/fixtures/out/NoopWithCalldataProver.sol/NoopWithCalldataProver";
+import proverSpec from "../../../../contracts/fixtures/out/NoopWithCalldataProver.sol/NoopWithCalldataProver";
 
 function encodeArgs(length: number): string {
   const arr = new Uint8Array(length);
@@ -12,7 +12,7 @@ function genBenches(): Array<Benchmark> {
   const calldata_lengths = [1, 2, 3, 4, 10, 20, 100, 1000];
   return calldata_lengths.map((length) => ({
     name: `No-op-with-${length}byte-calldata`,
-    spec,
+    proverSpec,
     args: [encodeArgs(length)],
     functionName: "noopWithCalldata",
   }));

--- a/packages/gas-benchmarks/src/benches/noop_with_calldata.ts
+++ b/packages/gas-benchmarks/src/benches/noop_with_calldata.ts
@@ -1,6 +1,6 @@
 import { Benchmark } from "../types";
 import { bytesToHex } from "viem";
-import proverSpec from "../../../../contracts/fixtures/out/NoopWithCalldataProver.sol/NoopWithCalldataProver";
+import proverContractSpec from "../../../../contracts/fixtures/out/NoopWithCalldataProver.sol/NoopWithCalldataProver";
 
 function encodeArgs(length: number): string {
   const arr = new Uint8Array(length);
@@ -12,7 +12,7 @@ function genBenches(): Array<Benchmark> {
   const calldata_lengths = [1, 2, 3, 4, 10, 20, 100, 1000];
   return calldata_lengths.map((length) => ({
     name: `No-op-with-${length}byte-calldata`,
-    proverSpec,
+    proverContractSpec,
     args: [encodeArgs(length)],
     functionName: "noopWithCalldata",
   }));

--- a/packages/gas-benchmarks/src/types.ts
+++ b/packages/gas-benchmarks/src/types.ts
@@ -2,7 +2,7 @@ import { ContractArg, ContractSpec } from "@vlayer/sdk";
 
 export type Benchmark = {
   name: string;
-  spec: ContractSpec;
+  proverSpec: ContractSpec;
   args: ContractArg[];
   functionName: string;
 };

--- a/packages/gas-benchmarks/src/types.ts
+++ b/packages/gas-benchmarks/src/types.ts
@@ -2,7 +2,7 @@ import { ContractArg, ContractSpec } from "@vlayer/sdk";
 
 export type Benchmark = {
   name: string;
-  proverSpec: ContractSpec;
+  proverContractSpec: ContractSpec;
   args: ContractArg[];
   functionName: string;
 };


### PR DESCRIPTION
`proverSpec` is more accurate name than `spec`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed the property `spec` to `proverContractSpec` across benchmark configurations, type definitions, and example code for improved naming consistency.
  - Updated benchmark objects and function calls to use `proverContractSpec` ensuring correct prover specifications are applied.
  - Minor formatting adjustments made to benchmark entries for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->