### PR TITLE
chore(call_server): use custom serde deserializer for seq of string *or* struct

### DIFF
--- a/rust/services/call/server/src/main.rs
+++ b/rust/services/call/server/src/main.rs
@@ -1,7 +1,7 @@
 use call_server_lib::{
     Cli, Config, ProofMode,
     cli::Parser,
-    config::{AuthOptions, ConfigOptionsWithVersion, JwtOptions, RpcUrl, RpcUrlOrString},
+    config::{AuthOptions, ConfigOptionsWithVersion, JwtOptions, RpcUrl},
     serve,
 };
 use common::{LogFormat, extract_rpc_url_token, init_tracing};
@@ -37,16 +37,12 @@ async fn main() -> anyhow::Result<()> {
 
 fn init_tracing_with_secrets<'a>(
     log_format: LogFormat,
-    rpc_urls: impl IntoIterator<Item = &'a RpcUrlOrString>,
+    rpc_urls: impl IntoIterator<Item = &'a RpcUrl>,
 ) {
     let secrets: Vec<String> = rpc_urls
         .into_iter()
         .cloned()
-        .filter_map(|rpc_url_or_string| {
-            RpcUrl::try_from(rpc_url_or_string)
-                .ok()
-                .and_then(|RpcUrl { url, .. }| extract_rpc_url_token(&url))
-        })
+        .filter_map(|RpcUrl { url, .. }| extract_rpc_url_token(&url))
         .collect();
     init_tracing(log_format, secrets);
 }


### PR DESCRIPTION
This way, we can remove enums that acted as DTOs/transformers for guiding serde in deserializing RPC urls and JWT claims from vectors of strings or structs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved configuration flexibility by allowing lists of JWT claims and RPC URLs to be specified as either strings or structured objects in configuration files.

- **Refactor**
  - Simplified configuration handling by removing intermediate wrapper types and consolidating deserialization logic, resulting in more streamlined and maintainable configuration processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->