### PR TITLE
fix: ensure unicode transcripts are supported

### DIFF
--- a/packages/browser-extension/src/hooks/tlsnProve/redaction/utils/decodedTranscript/DecodedTranscript.test.ts
+++ b/packages/browser-extension/src/hooks/tlsnProve/redaction/utils/decodedTranscript/DecodedTranscript.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+import { Transcript } from "tlsn-js";
+import { DecodedTranscript } from "./DecodedTranscript";
+
+// hello world
+const TEXT = [0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64];
+// kąsać
+const UNICODE_TEXT = [0x6b, 0xc4, 0x85, 0x73, 0x61, 0xc4, 0x87];
+
+// "recv: "
+const RECV = [0x72, 0x65, 0x63, 0x76, 0x3a, 0x20];
+// "sent: "
+const SENT = [0x73, 0x65, 0x6e, 0x74, 0x3a, 0x20];
+
+const transcript = (text: number[]) =>
+  new Transcript({ sent: [...SENT, ...text], recv: [...RECV, ...text] });
+
+describe("DecodedTranscript", () => {
+  describe("plain ascii text", () => {
+    test("returns valid strings if no redaction made", () => {
+      expect(new DecodedTranscript(transcript(TEXT))).toMatchObject({
+        recv: "recv: hello world",
+        sent: "sent: hello world",
+      });
+    });
+
+    test("returns valid strings if redaction made", () => {
+      expect(
+        new DecodedTranscript(transcript([0, ...TEXT, 0, 0])),
+      ).toMatchObject({
+        recv: "recv: *hello world**",
+        sent: "sent: *hello world**",
+      });
+    });
+  });
+
+  describe("unicode text", () => {
+    test("returns valid strings if no redaction made", () => {
+      expect(new DecodedTranscript(transcript(UNICODE_TEXT))).toMatchObject({
+        recv: "recv: kąsać",
+        sent: "sent: kąsać",
+      });
+    });
+    test("returns valid strings if redaction made", () => {
+      expect(
+        new DecodedTranscript(transcript([0, ...UNICODE_TEXT, 0, 0])),
+      ).toMatchObject({
+        recv: "recv: *kąsać**",
+        sent: "sent: *kąsać**",
+      });
+    });
+  });
+});

--- a/packages/browser-extension/src/hooks/tlsnProve/redaction/utils/decodedTranscript/DecodedTranscript.ts
+++ b/packages/browser-extension/src/hooks/tlsnProve/redaction/utils/decodedTranscript/DecodedTranscript.ts
@@ -1,0 +1,22 @@
+import { Transcript } from "tlsn-js";
+
+export class DecodedTranscript {
+  public sent: string;
+  public recv: string;
+  constructor(transcript: Transcript) {
+    this.recv = bytesToUtf8(replaceRedactions(transcript.raw.recv));
+    this.sent = bytesToUtf8(replaceRedactions(transcript.raw.sent));
+  }
+}
+
+function bytesToUtf8(array: number[]): string {
+  return Buffer.from(array).toString("utf8");
+}
+
+function replaceRedactions(
+  array: number[],
+  replaceCharacter: string = "*",
+): number[] {
+  const replaceCharByte = replaceCharacter.charCodeAt(0);
+  return array.map((byte) => (byte === 0 ? replaceCharByte : byte));
+}

--- a/packages/browser-extension/src/hooks/tlsnProve/redaction/utils/decodedTranscript/index.ts
+++ b/packages/browser-extension/src/hooks/tlsnProve/redaction/utils/decodedTranscript/index.ts
@@ -1,0 +1,1 @@
+export * from "./DecodedTranscript";

--- a/packages/browser-extension/src/hooks/tlsnProve/redaction/utils/index.ts
+++ b/packages/browser-extension/src/hooks/tlsnProve/redaction/utils/index.ts
@@ -2,3 +2,4 @@ export * from "./error";
 export * from "./getStringPaths";
 export * from "./encodeString";
 export * from "./queryParams";
+export * from "./decodedTranscript";

--- a/packages/browser-extension/src/hooks/tlsnProve/tlsnProve.ts
+++ b/packages/browser-extension/src/hooks/tlsnProve/tlsnProve.ts
@@ -17,6 +17,7 @@ import {
   calculateRequestSize,
   DEFAULT_MAX_RECV_DATA,
 } from "./requestSizeCalculator";
+import { DecodedTranscript } from "./redaction/utils/decodedTranscript/DecodedTranscript";
 
 type ProverConfig = {
   serverDns: string;
@@ -54,10 +55,7 @@ export async function tlsnProve(
   requestBody?: string,
 ): Promise<{
   presentationJson: PresentationJSON;
-  decodedTranscript: {
-    sent: string;
-    recv: string;
-  };
+  decodedTranscript: DecodedTranscript;
 }> {
   try {
     // tlsn-wasm needs to run in a worker
@@ -117,18 +115,18 @@ export async function tlsnProve(
     const decodedProof = await presentation.verify();
     log("Decoded proof", decodedProof);
 
-    const decodedTranscript = new Transcript({
-      sent: decodedProof?.transcript.sent,
-      recv: decodedProof?.transcript.recv,
-    });
+    const decodedTranscript = new DecodedTranscript(
+      new Transcript({
+        sent: decodedProof?.transcript.sent,
+        recv: decodedProof?.transcript.recv,
+      }),
+    );
+
     log("Decoded transcript", decodedTranscript);
 
     return {
       presentationJson,
-      decodedTranscript: {
-        sent: decodedTranscript.sent(),
-        recv: decodedTranscript.recv(),
-      },
+      decodedTranscript,
     };
   } catch (e) {
     log("Error while proving TLSN", e);


### PR DESCRIPTION
This is a workaround a bug in `tlsn-js` library, I'll post a PR to their repo and will replace this workaround with `transcript.recv()` and `transcript.sent()` functions once the fix is merged.

Relative lines:
https://github.com/tlsnotary/tlsn-js/blob/f51ddbf3dec973dc7b019e3a5109a67d92e053fb/src/transcript.ts#L19
https://github.com/tlsnotary/tlsn-js/blob/f51ddbf3dec973dc7b019e3a5109a67d92e053fb/src/transcript.ts#L27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new class for decoding and redacting transcript data, providing clearer display of sent and received messages with redacted sections shown as asterisks.
- **Bug Fixes**
  - Improved handling of both ASCII and Unicode text in transcripts, ensuring accurate display and redaction.
- **Tests**
  - Added comprehensive tests to verify correct decoding and redaction of transcript data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->