### PR TITLE
chore(call_server): address post-merge feedback

### DIFF
--- a/book/src/appendix/architecture/prover.md
+++ b/book/src/appendix/architecture/prover.md
@@ -81,13 +81,13 @@ timeout = 240 # Optional timeout in seconds
 public_key = "/path/to/signing/key.pem"
 algorithm = "rs256" # Signing algorithm to use, defaults to rs256
 
-# Optional list of user-defined JWT claims that the server will validate
+# Optional list of user-defined JWT claims
 [[auth.jwt.claims]]
 name = "sub" # Specifying just the name of the claim will assert the claims existence with any value
 
 [[auth.jwt.claims]]
 name = "environment"
-values = ["test"] # Here, `environment` can only accept a single value of `test` which the server will assert
+values = ["test"] # `environment` can only accept a single value: `test`
 
 # Optional gas-meter integration for billing and usage tracking
 [gas_meter]

--- a/rust/server_utils/src/jwt/config.rs
+++ b/rust/server_utils/src/jwt/config.rs
@@ -20,36 +20,63 @@ pub struct Config {
 
 impl Config {
     pub fn validate(&self, claims: &Value) -> Result<()> {
-        Self::validate_claims(&self.claims, claims)
+        validate_claims(&self.claims, claims)
     }
+}
 
-    fn validate_claims(expected: &[JwtClaim], claims: &Value) -> Result<()> {
+fn validate_claims(expected: &[JwtClaim], claims: &Value) -> Result<()> {
+    expected
+        .iter()
+        .try_for_each(|expected| validate_claim(expected, claims))
+}
+
+fn validate_claim(expected: &JwtClaim, given: &Value) -> Result<()> {
+    let name = &expected.name;
+    let field = extract_claim_by_name(name, given)?;
+    if let Some(typed) = field.as_str() {
+        validate_string_claim(expected, typed)
+    } else {
+        Err(unexpected_type(name))
+    }
+}
+
+fn extract_claim_by_name<'a>(name: &'a str, given: &'a Value) -> Result<&'a Value> {
+    let pointer = format!("/{}", name.replace(".", "/"));
+    given
+        .pointer(&pointer)
+        .ok_or(ValidationError(format!("missing claim '{name}'")))
+}
+
+fn validate_string_claim(expected: &JwtClaim, given: &str) -> Result<()> {
+    if !expected.values.is_empty() {
         expected
+            .values
             .iter()
-            .try_for_each(|expected| Self::validate_claim(expected, claims))
+            .any(|exp| exp == given)
+            .then_some(())
+            .ok_or_else(|| unexpected_value(expected, &given))?;
     }
+    Ok(())
+}
 
-    fn validate_claim(expected: &JwtClaim, given: &Value) -> Result<()> {
-        let pointer = format!("/{}", expected.name.replace(".", "/"));
-        let field = given
-            .pointer(&pointer)
-            .ok_or(ValidationError(format!("missing claim '{}'", expected.name)))?;
+fn unexpected_type(name: &str) -> ValidationError {
+    ValidationError(format!(
+        "unexpected type for claim '{name}': only strings are supported for claim values",
+    ))
+}
 
-        let field_typed = field.as_str().ok_or(ValidationError(format!(
-            "unexpected type for claim '{}': only strings are supported for claim values",
-            expected.name,
-        )))?;
-        if !expected.values.is_empty() {
-            expected.values.iter().any(|exp| exp == field_typed).then_some(()).ok_or_else(|| {
-                        let expected_values = expected.values.iter().map(|x| format!("'{x}'")).collect::<Vec<String>>().join(", ");
-                        ValidationError(format!(
-                            "unexpected value for claim '{}': expected one of [ {expected_values} ], received '{field_typed}'", expected.name
-                        ))
-                    })?;
-        }
-
-        Ok(())
-    }
+fn unexpected_value(expected: &JwtClaim, given: &impl ToString) -> ValidationError {
+    let name = &expected.name;
+    let given = given.to_string();
+    let expected_values = expected
+        .values
+        .iter()
+        .map(|x| format!("'{x}'"))
+        .collect::<Vec<String>>()
+        .join(", ");
+    ValidationError(format!(
+        "unexpected value for claim '{name}': expected one of [ {expected_values} ], received '{given}'"
+    ))
 }
 
 #[cfg(test)]
@@ -58,90 +85,98 @@ mod test {
 
     use super::*;
 
-    #[test]
-    fn validates_presence() {
-        let expected = JwtClaim {
-            name: "sub".to_string(),
-            ..Default::default()
-        };
-        let given = json!({
-            "exp": 12345,
-            "sub": "test",
-        });
-        Config::validate_claim(&expected, &given).unwrap();
+    mod validate_claims {
+        use super::*;
+
+        #[test]
+        fn validates_with_unknown_claims() {
+            let given = json!({
+                "exp": 12345,
+                "sub": "test",
+                "what": "is_this",
+            });
+            validate_claims(&[], &given).unwrap();
+        }
     }
 
-    #[test]
-    fn validates_expected_value() {
-        let expected = JwtClaim {
-            name: "custom.host".to_string(),
-            values: vec!["tlsn.com".to_string(), "api.tlsn.com".to_string()],
-        };
-        let given = json!({
-            "exp": 12345,
-            "custom": {
-                "host": "api.tlsn.com",
-            },
-        });
-        Config::validate_claim(&expected, &given).unwrap();
-    }
+    mod validate_claim {
+        use super::*;
 
-    #[test]
-    fn validates_with_unknown_claims() {
-        let given = json!({
-            "exp": 12345,
-            "sub": "test",
-            "what": "is_this",
-        });
-        Config::validate_claims(&[], &given).unwrap();
-    }
+        #[test]
+        fn validates_presence() {
+            let expected = JwtClaim {
+                name: "sub".to_string(),
+                ..Default::default()
+            };
+            let given = json!({
+                "exp": 12345,
+                "sub": "test",
+            });
+            validate_claim(&expected, &given).unwrap();
+        }
 
-    #[test]
-    fn fails_if_claim_missing() {
-        let expected = JwtClaim {
-            name: "sub".to_string(),
-            ..Default::default()
-        };
-        let given = json!({
-            "exp": 12345,
-            "host": "localhost",
-        });
-        assert_eq!(
-            Config::validate_claim(&expected, &given),
-            Err(ValidationError("missing claim 'sub'".to_string()))
-        )
-    }
+        #[test]
+        fn validates_expected_value() {
+            let expected = JwtClaim {
+                name: "custom.host".to_string(),
+                values: vec!["tlsn.com".to_string(), "api.tlsn.com".to_string()],
+            };
+            let given = json!({
+                "exp": 12345,
+                "custom": {
+                    "host": "api.tlsn.com",
+                },
+            });
+            validate_claim(&expected, &given).unwrap();
+        }
 
-    #[test]
-    fn fails_if_claim_has_unknown_value() {
-        let expected = JwtClaim {
-            name: "sub".to_string(),
-            values: vec!["tlsn_prod".to_string(), "tlsn_test".to_string()],
-        };
-        let given = json!({
-            "sub": "tlsn",
-        });
-        assert_eq!(
-                Config::validate_claim(&expected, &given),
+        #[test]
+        fn fails_if_claim_missing() {
+            let expected = JwtClaim {
+                name: "sub".to_string(),
+                ..Default::default()
+            };
+            let given = json!({
+                "exp": 12345,
+                "host": "localhost",
+            });
+            assert_eq!(
+                validate_claim(&expected, &given),
+                Err(ValidationError("missing claim 'sub'".to_string()))
+            )
+        }
+
+        #[test]
+        fn fails_if_claim_has_unknown_value() {
+            let expected = JwtClaim {
+                name: "sub".to_string(),
+                values: vec!["tlsn_prod".to_string(), "tlsn_test".to_string()],
+            };
+            let given = json!({
+                "sub": "tlsn",
+            });
+            assert_eq!(
+                validate_claim(&expected, &given),
                 Err(ValidationError("unexpected value for claim 'sub': expected one of [ 'tlsn_prod', 'tlsn_test' ], received 'tlsn'".to_string()))
             )
-    }
+        }
 
-    #[test]
-    fn fails_if_claim_has_invalid_value_type() {
-        let expected = JwtClaim {
-            name: "sub".to_string(),
-            ..Default::default()
-        };
-        let given = json!({
-            "sub": { "name": "john" }
-        });
-        assert_eq!(
-            Config::validate_claim(&expected, &given),
-            Err(ValidationError(
-                "unexpected type for claim 'sub': only strings are supported for claim values"
-                    .to_string()
-            ))
-        )
+        #[test]
+        fn fails_if_claim_has_invalid_value_type() {
+            let expected = JwtClaim {
+                name: "sub".to_string(),
+                ..Default::default()
+            };
+            let given = json!({
+                "sub": { "name": "john" }
+            });
+            assert_eq!(
+                validate_claim(&expected, &given),
+                Err(ValidationError(
+                    "unexpected type for claim 'sub': only strings are supported for claim values"
+                        .to_string()
+                ))
+            )
+        }
     }
 }

--- a/rust/services/call/server_lib/src/config.rs
+++ b/rust/services/call/server_lib/src/config.rs
@@ -580,13 +580,13 @@ pub(crate) mod tests {
 
         #[test]
         fn correctly_parses_rpc_url() {
-            let as_string = "31337:http://127.0.0.1:8545";
+            let rpc_url_as_string = "31337:http://127.0.0.1:8545";
             assert_eq!(
                 RpcUrl {
                     chain_id: 31337,
                     url: "http://127.0.0.1:8545".to_string()
                 },
-                RpcUrl::from_str(as_string).unwrap()
+                RpcUrl::from_str(rpc_url_as_string).unwrap()
             );
         }
 


### PR DESCRIPTION
Addresses @AdamDawidKrol's post-merge feedback of #2461 (thanks!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved clarity of comments in the configuration example for JWT claims.
- **Refactor**
  - Modularized JWT claim validation logic for better readability and maintenance.
  - Enhanced error handling and reorganized related tests for improved structure.
- **Style**
  - Renamed a local variable in a test for clearer naming; no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->