### PR TITLE
Fix typo in documentation headers

### DIFF
--- a/book/src/javascript/web-proofs.md
+++ b/book/src/javascript/web-proofs.md
@@ -163,7 +163,7 @@ By default, the transcript is not redacted at all and redaction of each HTTP req
 
 You can redact specific headers from both the request and the response. To do so, use `request.headers`, `request.headers_except`, `response.headers`, or `response.headers_except` with a header name (e.g. `Authorization`, `Cookie`). Using `headers` or `headers_except` allows you to control which HTTP headers are redacted: either by explicitly specifying the headers to remove, or by redacting all except a given subset.
 
-#### Redact specifc headers
+#### Redact specific headers
 
 ```ts
 notarize("https://api.example.com/profile", "GET", "Proof", [
@@ -202,7 +202,7 @@ notarize("https://api.example.com/profile", "GET", "Proof", [
 
 You can redact specific query parameters from a URL. Use `url_query` to redact only selected parameters, or `url_query_except` to redact all parameters except those you specify.
 
-#### Redact specifc queries
+#### Redact specific queries
 
 ```ts
 notarize("https://api.example.com/profile", "GET", "Proof", [


### PR DESCRIPTION


**Description:**
This pull request corrects a typo in the documentation headers within the file `book/src/javascript/web-proofs.md`. The word "specifc" has been updated to "specific" in the section headers "Redact specific headers" and "Redact specific queries" to improve clarity and accuracy. No functional code changes were made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Fixed typographical errors in section headers to improve clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->