### PR TITLE
fix: remove unsupported logoUrl

### DIFF
--- a/book/src/javascript/web-proofs.md
+++ b/book/src/javascript/web-proofs.md
@@ -30,7 +30,6 @@ import {
 } from '@vlayer/sdk/web_proof'
 
 const webProofRequest = createWebProofRequest({
-  logoUrl: 'http://twitterswap.com/logo.png',
   steps: [
     startPage('https://x.com/i/flow/login', 'Go to x.com login page'),
     expectUrl('https://x.com/home', 'Log in'),
@@ -123,7 +122,6 @@ const proverCallCommitment = {
 
 webProofProvider.requestWebProof({
   proverCallCommitment,
-  logoUrl: 'http://twitterswap.com/logo.png',
   steps: [
     startPage('https://x.com/i/flow/login', 'Go to x.com login page'),
     expectUrl('https://x.com/home', 'Log in'),

--- a/examples/simple-web-proof/vlayer/src/hooks/useTwitterAccountProof.ts
+++ b/examples/simple-web-proof/vlayer/src/hooks/useTwitterAccountProof.ts
@@ -20,7 +20,6 @@ const webProofConfig: WebProofConfig<Abi, string> = {
     commitmentArgs: [],
     chainId: 1,
   },
-  logoUrl: "http://twitterswap.com/logo.png",
   steps: [
     startPage("https://x.com/", "Go to x.com login page"),
     expectUrl("https://x.com/home", "Log in"),

--- a/packages/sdk/src/api/lib/types/webProofProvider.ts
+++ b/packages/sdk/src/api/lib/types/webProofProvider.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../web-proof-commons";
 
 export type WebProofRequestInput = {
-  logoUrl: string;
+  logoUrl?: string;
   steps: WebProofStep[];
 };
 

--- a/packages/web-proof-commons/types/message.ts
+++ b/packages/web-proof-commons/types/message.ts
@@ -154,7 +154,7 @@ export type MessageFromExtension =
 export type WebProverSessionConfig = {
   notaryUrl: string;
   wsProxyUrl: string;
-  logoUrl: string;
+  logoUrl?: string;
   token?: string;
   steps: WebProofStep[];
 };


### PR DESCRIPTION
Problem: 
Currently `logoUrl` is ignored by vlayer browser extension. No matter what you pass, extension is not rendering it. 
Keeping that attribute in the docs and example code app is misleading. 

Solution: 
Remove `logoUrl` from docs and example app 