### PR TITLE
ci: Remove Base from testnet imageid management

### DIFF
--- a/bash/verifiers_management/push-testnet-image-id.sh
+++ b/bash/verifiers_management/push-testnet-image-id.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
-NETWORKS=( "sepolia" "base-sepolia" "optimism-sepolia" "arbitrum-sepolia" "worldchain-sepolia" "base" "flow-evm-testnet" )
+NETWORKS=( "sepolia" "base-sepolia" "optimism-sepolia" "arbitrum-sepolia" "worldchain-sepolia" "flow-evm-testnet" )
 
 # Simple function to get Repository address from .sol file
 repository_address() {


### PR DESCRIPTION
Leftover from legacy "Base testnet" contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the "base" network from the list of supported networks in the testnet image push process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->