### PR TITLE
feat(cli): add simple tool for pretty-printing TLSN output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3167,6 +3167,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.19",
  "version",
+ "web_proof",
  "web_prover",
 ]
 

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -33,6 +33,7 @@ toml = { workspace = true, features = ["parse"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 version = { workspace = true }
+web_proof = { workspace = true }
 web_prover = { workspace = true }
 
 [dev-dependencies]

--- a/rust/web_proof/src/lib.rs
+++ b/rust/web_proof/src/lib.rs
@@ -10,4 +10,4 @@ mod request_transcript;
 mod response_transcript;
 mod transcript_parser;
 mod utils;
-mod web;
+pub mod web;


### PR DESCRIPTION
While debugging failing nightly release, we had to quickly parse and pretty-print TLSN output and so a tool like this would really come in handy. This PR extends our CLI by adding a hidden subcommand `vlayer web-proof-debug` which accepts TLSN web-proof either as JSON string directly or as path to a file with the web-proof in it:

```
Usage: vlayer web-proof-debug <JSON|-f <FILE>>

Arguments:
  [JSON]  Web-proof encoded as JSON

Options:
  -f <FILE>      Path to web-proof encoded as JSON
  -h, --help     Print help
  -V, --version  Print version
```