### PR TITLE
chore(version): bump version to 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13946,7 +13946,7 @@ dependencies = [
 
 [[package]]
 name = "version"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "regex",

--- a/rust/version/Cargo.toml
+++ b/rust/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "version"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 build = "build.rs"
 


### PR DESCRIPTION
Contains chain service ELF ID history pruning.

- [x] Testnet imageIDs support in Repositories (automatic)
- [x] Legacy Base mainnet contract in vlayer testnet
- [x] Mainnet Repositories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package version to 1.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->