### PR TITLE
fix: Remove unnecessary whitespace

### DIFF
--- a/docker/docker-compose.devnet.yaml
+++ b/docker/docker-compose.devnet.yaml
@@ -8,4 +8,3 @@ include:
   - websockify/service.yaml
   - websockify-test-client/service.yaml
   - notary-server/service.yaml
-


### PR DESCRIPTION
There are two newlines instead of one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed a trailing blank line from the development network Docker Compose configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->