### PR TITLE
fix: Add `--build` flag to devnet

### DIFF
--- a/examples/kraken-web-proof/vlayer/package.json
+++ b/examples/kraken-web-proof/vlayer/package.json
@@ -2,7 +2,7 @@
   "name": "kraken-web-proof",
   "type": "module",
   "scripts": {
-    "devnet:up": "docker compose --file docker-compose.devnet.yaml up -d",
+    "devnet:up": "docker compose --file docker-compose.devnet.yaml up --build -d",
     "devnet:down": "docker compose --file docker-compose.devnet.yaml down",
     "lint:solidity": "solhint '../src/**/*.sol' --max-warnings 0 && forge fmt ../src --check",
     "lint-fix:solidity": "solhint '../src/**/*.sol' --fix --noPrompt && forge fmt ../src",

--- a/examples/simple-email-proof/vlayer/package.json
+++ b/examples/simple-email-proof/vlayer/package.json
@@ -3,7 +3,7 @@
   "module": "prove.ts",
   "type": "module",
   "scripts": {
-    "devnet:up": "docker compose --file docker-compose.devnet.yaml up -d",
+    "devnet:up": "docker compose --file docker-compose.devnet.yaml up --build -d",
     "devnet:down": "docker compose --file docker-compose.devnet.yaml down",
     "lint:solidity": "solhint '../src/**/*.sol' --max-warnings 0 && forge fmt ../src --check",
     "lint-fix:solidity": "solhint '../src/**/*.sol' --fix --noPrompt && forge fmt ../src",

--- a/examples/simple-teleport/vlayer/package.json
+++ b/examples/simple-teleport/vlayer/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -b && vite build",
-    "devnet:up": "docker compose --file docker-compose.devnet.yaml up -d",
+    "devnet:up": "docker compose --file docker-compose.devnet.yaml up --build -d",
     "devnet:down": "docker compose --file docker-compose.devnet.yaml down",
     "lint:solidity": "solhint '../src/**/*.sol'",
     "lint-fix:solidity": "solhint '../src/**/*.sol' --fix --noPrompt && forge fmt ../src",

--- a/examples/simple-time-travel/vlayer/package.json
+++ b/examples/simple-time-travel/vlayer/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -b && vite build",
-    "devnet:up": "docker compose --file docker-compose.devnet.yaml up -d",
+    "devnet:up": "docker compose --file docker-compose.devnet.yaml up --build -d",
     "devnet:down": "docker compose --file docker-compose.devnet.yaml down",
     "lint:solidity": "solhint '../src/**/*.sol'",
     "lint-fix:solidity": "solhint '../src/**/*.sol' --fix --noPrompt && forge fmt ../src",

--- a/examples/simple-web-proof/vlayer/package.json
+++ b/examples/simple-web-proof/vlayer/package.json
@@ -2,7 +2,7 @@
   "name": "simple-web-proof",
   "type": "module",
   "scripts": {
-    "devnet:up": "docker compose --file docker-compose.devnet.yaml up -d",
+    "devnet:up": "docker compose --file docker-compose.devnet.yaml up --build -d",
     "devnet:down": "docker compose --file docker-compose.devnet.yaml down",
     "lint:solidity": "solhint '../src/**/*.sol' --max-warnings 0 && forge fmt ../src --check",
     "lint-fix:solidity": "solhint '../src/**/*.sol' --fix --noPrompt && forge fmt ../src",

--- a/examples/simple/vlayer/package.json
+++ b/examples/simple/vlayer/package.json
@@ -4,7 +4,7 @@
   "type": "module",
 
   "scripts": {
-    "devnet:up": "docker compose --file docker-compose.devnet.yaml up -d",
+    "devnet:up": "docker compose --file docker-compose.devnet.yaml up --build -d",
     "devnet:down": "docker compose --file docker-compose.devnet.yaml down",
     "lint:solidity": "solhint '../src/**/*.sol' --max-warnings 0 && forge fmt ../src --check",
     "lint-fix:solidity": "solhint '../src/**/*.sol' --fix --noPrompt && forge fmt ../src",


### PR DESCRIPTION
Without this, we end up with stale versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated development environment scripts to always rebuild Docker images before starting containers, ensuring the latest changes are included when bringing up the devnet across multiple example projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->