### PR TITLE
chore(ci): check user permissions before triggering a workflow

### DIFF
--- a/.github/workflows/performance_rust_compilation.yaml
+++ b/.github/workflows/performance_rust_compilation.yaml
@@ -19,9 +19,25 @@ permissions:
   pull-requests: write
 
 jobs:
+  permissions:
+    runs-on: ubuntu-latest
+    outputs:
+      has-permissions: ${{ steps.check-permissions.outputs.require-result }}
+    steps:
+      - name: Check user permissions
+        id: check-permissions
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+
   performance-rust-compilation:
     name: Rust incremental compilation performance
     runs-on: aws-linux-medium
+    needs: permissions
+    if: needs.permissions.outputs.has-permissions == 'true'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test_e2e_sepolias.yaml
+++ b/.github/workflows/test_e2e_sepolias.yaml
@@ -27,11 +27,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  permissions:
+    runs-on: ubuntu-latest
+    outputs:
+      has-permissions: ${{ steps.check-permissions.outputs.require-result }}
+    steps:
+      - name: Check user permissions
+        id: check-permissions
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+
   changes:
     runs-on: ubuntu-latest
+    needs: permissions
     outputs:
       code-changes: ${{ steps.filter.outputs.code-changes }}
       workflow-changes: ${{ steps.filter.outputs.workflow-changes }}
+    if: needs.permissions.outputs.has-permissions == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -67,9 +83,12 @@ jobs:
   # `rust/zkvm-benchmarks/benchmarks/src/benchmarks/precompiles/gas_price_checker.rs`
   check-gas:
     name: Check gas price
+    needs: permissions
     runs-on: ubuntu-latest
     outputs:
       gas-ok: ${{ steps.set-result.outputs.gas-ok }}
+    if: needs.permissions.outputs.has-permissions == 'true'
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test_e2e_web_apps.yaml
+++ b/.github/workflows/test_e2e_web_apps.yaml
@@ -12,10 +12,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changes:
+  permissions:
     runs-on: ubuntu-latest
     outputs:
+      has-permissions: ${{ steps.check-permissions.outputs.require-result }}
+    steps:
+      - name: Check user permissions
+        id: check-permissions
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+
+  changes:
+    runs-on: ubuntu-latest
+    needs: permissions
+    outputs:
       relevant-changes: ${{ steps.filter.outputs.relevant-changes }}
+    if: needs.permissions.outputs.has-permissions == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test_e2e_web_apps_opsepolia.yaml
+++ b/.github/workflows/test_e2e_web_apps_opsepolia.yaml
@@ -20,11 +20,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  permissions:
+    runs-on: ubuntu-latest
+    outputs:
+      has-permissions: ${{ steps.check-permissions.outputs.require-result }}
+    steps:
+      - name: Check user permissions
+        id: check-permissions
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+
   changes:
     runs-on: ubuntu-latest
+    needs: permissions
     outputs:
       code-changes: ${{ steps.filter.outputs.code-changes }}
       workflow-changes: ${{ steps.filter.outputs.workflow-changes }}
+    if: needs.permissions.outputs.has-permissions == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test_e2e_web_flow.yaml
+++ b/.github/workflows/test_e2e_web_flow.yaml
@@ -6,10 +6,26 @@ on:
     branches:
       - main
 jobs:
-  changes:
+  permissions:
     runs-on: ubuntu-latest
     outputs:
+      has-permissions: ${{ steps.check-permissions.outputs.require-result }}
+    steps:
+      - name: Check user permissions
+        id: check-permissions
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+
+  changes:
+    runs-on: ubuntu-latest
+    needs: permissions
+    outputs:
       relevant-changes: ${{ steps.filter.outputs.relevant-changes }}
+    if: needs.permissions.outputs.has-permissions == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Uses GH action which checks user permissions and skips workflows that require access to secrets if such a user does not have `write` permissions to the repo.