### PR TITLE
fix: Updated teleport example blocks to newer ones

### DIFF
--- a/examples/simple-teleport/vlayer/constants.ts
+++ b/examples/simple-teleport/vlayer/constants.ts
@@ -21,7 +21,7 @@ export const chainToTeleportConfig: Record<string, TeleportConfig> = {
     prover: {
       erc20Addresses: "0xc6e1fb449b08b26b2063c289df9bbcb79b91c992",
       erc20ChainIds: "11155420",
-      erc20BlockNumbers: "25181931",
+      erc20BlockNumbers: "26657710",
     },
   },
   mainnet: {
@@ -29,7 +29,7 @@ export const chainToTeleportConfig: Record<string, TeleportConfig> = {
     prover: {
       erc20Addresses: "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
       erc20ChainIds: "10",
-      erc20BlockNumbers: "135459541",
+      erc20BlockNumbers: "136991504",
     },
   },
 };


### PR DESCRIPTION
So that they are already synced by our block indexers.