### PR TITLE
ci: Update production backpropagation

### DIFF
--- a/ansible/host_vars/stable_prod_chain_service.yml
+++ b/ansible/host_vars/stable_prod_chain_service.yml
@@ -15,7 +15,7 @@ chain_workers:
     chain_worker_rpc_url: https://clean-proud-spring.quiknode.pro/{{ vlayer_quicknode_api_key }}
     chain_worker_chain_id: 1
     chain_worker_proof_mode: succinct
-    chain_worker_max_back_propagation_blocks: 10
+    chain_worker_max_back_propagation_blocks: 0
     chain_worker_max_head_blocks: 10
     chain_worker_confirmations: 8
     chain_worker_bonsai_api_url: "https://api.bonsai.xyz/"
@@ -31,7 +31,7 @@ chain_workers:
     chain_worker_rpc_url: https://clean-proud-spring.base-mainnet.quiknode.pro/{{ vlayer_quicknode_api_key }}
     chain_worker_chain_id: 8453
     chain_worker_proof_mode: succinct
-    chain_worker_max_back_propagation_blocks: 10
+    chain_worker_max_back_propagation_blocks: 0
     chain_worker_max_head_blocks: 100
     chain_worker_confirmations: 8
     chain_worker_bonsai_api_url: "https://api.bonsai.xyz/"
@@ -47,7 +47,7 @@ chain_workers:
     chain_worker_rpc_url: https://clean-proud-spring.optimism.quiknode.pro/{{ vlayer_quicknode_api_key }}
     chain_worker_chain_id: 10
     chain_worker_proof_mode: succinct
-    chain_worker_max_back_propagation_blocks: 10
+    chain_worker_max_back_propagation_blocks: 0
     chain_worker_max_head_blocks: 100
     chain_worker_confirmations: 8
     chain_worker_bonsai_api_url: "https://api.bonsai.xyz/"


### PR DESCRIPTION
Change it to 0 - amount of indexed blocks and the window of indexed range still updates, but only forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to set the maximum back propagation blocks to zero for Ethereum, Base, and Optimism chain workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->