### PR TITLE
Add files copied to vouch to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -186,4 +186,6 @@
 
 # Soon to be marked as deprecated. If updates needed, shall be reflected in the vouch repository.
 /packages/sdk/api/web_proof/* @marekkirejczyk @wgromniak2 @akoszowski
+/packages/sdk/src/api/lib/types/webProofProvider.ts @marekkirejczyk @wgromniak2 @akoszowski
+/packages/sdk/src/api/lib/types/viem.ts @marekkirejczyk @wgromniak2 @akoszowski
 /packages/web-proof-commons/* @marekkirejczyk @wgromniak2 @akoszowski


### PR DESCRIPTION
These two files were copied along with `sdk/webProof` part to vouch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership assignments to include two additional files in the SDK package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->