### PR TITLE
Fix broken link to JavaScript Redaction section

### DIFF
--- a/book/src/web-proof/redaction.md
+++ b/book/src/web-proof/redaction.md
@@ -6,7 +6,7 @@ Redaction feature lets you **hide sensitive portions** of an HTTPS transcript fr
 
 > ⚠️ **Warning!** Unsafe byte-range redaction can introduce ambiguities and vulnerabilities. This guide explains how to use redaction safely.
 
-To learn how to enable and configure redaction using the vlayer SDK, see the [Redaction](../../javascript/web-proofs.md#redaction) section in our JavaScript documentation.
+To learn how to enable and configure redaction using the vlayer SDK, see the [Redaction](../javascript/web-proofs.md#redaction) section in our JavaScript documentation.
 
 ### Currently supported redaction targets:
 * URL path


### PR DESCRIPTION
Corrected the documentation link in redaction.md to point to the proper location and anchor for the Redaction section in the JavaScript documentation. This resolves a previous error where the file or anchor could not be found, ensuring users are directed to the correct information about configuring redaction with the vlayer SDK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a link path in the redaction documentation for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->