### PR TITLE
fix: Remove `prove:mainnet` from `simple-web-proof`

### DIFF
--- a/examples/simple-web-proof/vlayer/package.json
+++ b/examples/simple-web-proof/vlayer/package.json
@@ -8,7 +8,6 @@
     "lint-fix:solidity": "solhint '../src/**/*.sol' --fix --noPrompt && forge fmt ../src",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "prove:mainnet": "VLAYER_ENV=mainnet bun run prove.ts",
     "prove:testnet": "VLAYER_ENV=testnet bun run prove.ts",
     "prove:dev": "VLAYER_ENV=dev bun run prove.ts",
     "deploy:mainnet": "VLAYER_ENV=mainnet bun run deploy.ts",


### PR DESCRIPTION
`prove:mainnet` command doesn't work for web proof example. `web:mainnet` command should be used instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the "prove:mainnet" script from the available commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->