### PR TITLE
fix: Change default Ethereum RPC endpoint in teleport example

### DIFF
--- a/examples/simple-teleport/vlayer/.env.mainnet
+++ b/examples/simple-teleport/vlayer/.env.mainnet
@@ -1,4 +1,4 @@
 CHAIN_NAME=mainnet
 PROVER_URL=https://stable-prod-prover.vlayer.xyz
 L2_JSON_RPC_URL=https://mainnet.optimism.io
-JSON_RPC_URL=https://eth.merkle.io
+JSON_RPC_URL=https://ethereum-rpc.publicnode.com


### PR DESCRIPTION
The current one didn't work for me despite retrying multiple times - it was failing on gas estimation during Verifier contract deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the mainnet environment configuration to use a new JSON RPC URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->