### PR TITLE
feat: Log cycle estimation during proof generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,6 +2582,7 @@ dependencies = [
  "auto_impl",
  "axum 0.8.1",
  "block_header",
+ "bytes",
  "call_common",
  "call_engine",
  "call_host",

--- a/rust/services/call/host/src/cycle_estimator.rs
+++ b/rust/services/call/host/src/cycle_estimator.rs
@@ -4,7 +4,7 @@ use call_engine::Input;
 use risc0_zkvm::{ExecutorEnv, default_executor};
 use thiserror::Error;
 
-pub trait CycleEstimator {
+pub trait Estimator {
     fn estimate(&self, input: &Input, elf: Bytes) -> Result<u64, Error>;
 }
 
@@ -13,9 +13,9 @@ pub trait CycleEstimator {
 pub struct Error(#[from] anyhow::Error);
 
 #[derive(Debug, Default, Clone)]
-pub struct Risc0CycleEstimator;
+pub struct Risc0Estimator;
 
-impl CycleEstimator for Risc0CycleEstimator {
+impl Estimator for Risc0Estimator {
     fn estimate(&self, input: &Input, elf: Bytes) -> Result<u64, Error> {
         let env = build_executor_env(input)?;
         let executor = default_executor();
@@ -71,7 +71,7 @@ mod tests {
             let call = call(USDT, &balanceOfCall { account: binance_8 });
             let result = preflight_raw_result("usdt_erc20_balance_of", call, &location).await?;
 
-            let cycle_estimate = Risc0CycleEstimator.estimate(&result.input, result.guest_elf)?;
+            let cycle_estimate = Risc0Estimator.estimate(&result.input, result.guest_elf)?;
 
             assert!(cycle_estimate > 0);
 
@@ -88,7 +88,7 @@ mod tests {
 
             let result = preflight_raw_result("time_travel", call, &location).await?;
 
-            let cycle_estimate = Risc0CycleEstimator.estimate(&result.input, result.guest_elf)?;
+            let cycle_estimate = Risc0Estimator.estimate(&result.input, result.guest_elf)?;
 
             assert!(cycle_estimate > 0);
 

--- a/rust/services/call/host/src/lib.rs
+++ b/rust/services/call/host/src/lib.rs
@@ -6,7 +6,10 @@ mod into_input;
 use call_common::RevmDB;
 use call_db::ProofDb;
 pub use call_engine::Call;
-pub use cycle_estimator::{CycleEstimator, Error as CycleEstimatorError, Risc0CycleEstimator};
+pub use cycle_estimator::{
+    Error as CycleEstimatorError, Estimator as CycleEstimator,
+    Risc0Estimator as Risc0CycleEstimator,
+};
 pub use host::{
     BuilderError, Config, Error, Host, PreflightResult, Prover, ProvingError, ProvingInput,
     error::preflight::Error as PreflightError,

--- a/rust/services/call/host/src/lib.rs
+++ b/rust/services/call/host/src/lib.rs
@@ -6,7 +6,7 @@ mod into_input;
 use call_common::RevmDB;
 use call_db::ProofDb;
 pub use call_engine::Call;
-pub use cycle_estimator::{CycleEstimator, Risc0CycleEstimator};
+pub use cycle_estimator::{CycleEstimator, Error as CycleEstimatorError, Risc0CycleEstimator};
 pub use host::{
     BuilderError, Config, Error, Host, PreflightResult, Prover, ProvingError, ProvingInput,
     error::preflight::Error as PreflightError,

--- a/rust/services/call/server_lib/Cargo.toml
+++ b/rust/services/call/server_lib/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 auto_impl = { workspace = true }
 axum = { workspace = true }
+bytes = { workspace = true }
 call_common = { workspace = true }
 call_engine = { workspace = true }
 call_host = { workspace = true }

--- a/rust/services/call/server_lib/src/preflight.rs
+++ b/rust/services/call/server_lib/src/preflight.rs
@@ -68,7 +68,9 @@ pub async fn await_preflight(
     gas_meter_client
         .refund(ComputationStage::Preflight, gas_used)
         .await?;
-    gas_meter_client.send_metadata(result.metadata.clone()).await?;
+    gas_meter_client
+        .send_metadata(result.metadata.clone())
+        .await?;
 
     metrics.gas = gas_used;
     metrics.times.preflight = metrics::elapsed_time_as_millis_u64(elapsed_time)?;

--- a/rust/services/call/server_lib/src/preflight.rs
+++ b/rust/services/call/server_lib/src/preflight.rs
@@ -70,9 +70,7 @@ pub async fn await_preflight(
     gas_meter_client
         .refund(ComputationStage::Preflight, *gas_used)
         .await?;
-    gas_meter_client
-        .send_metadata(metadata.clone())
-        .await?;
+    gas_meter_client.send_metadata(metadata.clone()).await?;
 
     metrics.gas = *gas_used;
     metrics.times.preflight = metrics::elapsed_time_as_millis_u64(*elapsed_time)?;

--- a/rust/services/call/server_lib/src/proof.rs
+++ b/rust/services/call/server_lib/src/proof.rs
@@ -1,6 +1,5 @@
-use bytes::Bytes;
-use call_engine::{Call as EngineCall, Input};
-use call_host::{CycleEstimator, CycleEstimatorError, Host, ProvingInput, Risc0CycleEstimator};
+use call_engine::Call as EngineCall;
+use call_host::{CycleEstimator, Host, ProvingInput, Risc0CycleEstimator};
 use dashmap::Entry;
 use tracing::{error, info, instrument};
 

--- a/rust/services/call/server_lib/src/proof.rs
+++ b/rust/services/call/server_lib/src/proof.rs
@@ -151,10 +151,11 @@ pub async fn generate(
     let elapsed = estimation_start.elapsed();
     info!("Cycle estimation lasted: {elapsed:?}");
 
+    let proving_input = ProvingInput::new(preflight_result.host_output, preflight_result.input);
     match proving::await_proving(
         &prover,
         call_guest_id,
-        ProvingInput::new(preflight_result.host_output, preflight_result.input),
+        proving_input,
         &gas_meter_client,
         &mut metrics,
     )


### PR DESCRIPTION
Log estimated cycles after preflight and before bonsai proving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cycle estimation to the proof generation process, allowing users to see estimated cycle counts for operations.

* **Bug Fixes**
  * Improved efficiency in the preflight process by avoiding repeated calls and returning the full preflight result.

* **Chores**
  * Updated dependencies to include the `bytes` crate for improved data handling.
  * Enhanced error handling capabilities by exposing cycle estimator errors for external use.
  * Renamed cycle estimator components for clarity without affecting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->