### PR TITLE
 feat: Change `State` to `EstimatingCycles` when cycles are estimated

### DIFF
--- a/packages/sdk/src/api/lib/client.test.ts
+++ b/packages/sdk/src/api/lib/client.test.ts
@@ -116,14 +116,6 @@ describe("Success zk-proving", () => {
     expect(zkProvingSpy).toHaveBeenNthCalledWith(2, ZkProvingStatus.Done);
   });
   it("should handle successful cycle estimation flow", async () => {
-    await vlayer.prove({
-      address: `0x${"a".repeat(40)}`,
-      functionName: "main",
-      proverAbi: [],
-      args: [],
-      chainId: 42,
-    });
-
     fetchMocker.mockResponseOnce(() => {
       return {
         body: JSON.stringify({
@@ -151,6 +143,14 @@ describe("Success zk-proving", () => {
           id: 1,
         }),
       };
+    });
+
+    await vlayer.prove({
+      address: `0x${"a".repeat(40)}`,
+      functionName: "main",
+      proverAbi: [],
+      args: [],
+      chainId: 42,
     });
 
     const hash = { hash: hashStr } as BrandedHash<[], string>;
@@ -259,14 +259,6 @@ describe("Failed zk-proving", () => {
       };
     });
 
-    const hash = await vlayer.prove({
-      address: `0x${"a".repeat(40)}`,
-      functionName: "main",
-      proverAbi: [],
-      args: [],
-      chainId: 42,
-    });
-
     fetchMocker.mockResponseOnce(() => {
       return {
         body: JSON.stringify({
@@ -280,6 +272,14 @@ describe("Failed zk-proving", () => {
           id: 1,
         }),
       };
+    });
+
+    const hash = await vlayer.prove({
+      address: `0x${"a".repeat(40)}`,
+      functionName: "main",
+      proverAbi: [],
+      args: [],
+      chainId: 42,
     });
 
     try {

--- a/packages/sdk/src/api/lib/client.test.ts
+++ b/packages/sdk/src/api/lib/client.test.ts
@@ -181,52 +181,6 @@ describe("Success zk-proving", () => {
     expect(zkProvingSpy).toHaveBeenNthCalledWith(1, ZkProvingStatus.Proving);
     expect(zkProvingSpy).toHaveBeenNthCalledWith(2, ZkProvingStatus.Done);
   });
-  it("should handle failed cycle estimation", async () => {
-    fetchMocker.mockResponseOnce(() => {
-      return {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: "2.0",
-          result: hashStr,
-        }),
-      };
-    });
-
-    const hash = await vlayer.prove({
-      address: `0x${"a".repeat(40)}`,
-      functionName: "main",
-      proverAbi: [],
-      args: [],
-      chainId: 42,
-    });
-
-    fetchMocker.mockResponseOnce(() => {
-      return {
-        body: JSON.stringify({
-          result: {
-            state: "estimating_cycles",
-            status: 0,
-            metrics: {},
-            error: "Cycle estimation failed",
-          },
-          jsonrpc: "2.0",
-          id: 1,
-        }),
-      };
-    });
-
-    try {
-      await vlayer.waitForProvingResult({ hash });
-    } catch (e) {
-      expect((e as Error).message).toMatch(
-        "Cycle estimation failed with error: Cycle estimation failed",
-      );
-    }
-
-    expect(zkProvingSpy).toBeCalledTimes(2);
-    expect(zkProvingSpy).toHaveBeenNthCalledWith(1, ZkProvingStatus.Proving);
-    expect(zkProvingSpy).toHaveBeenNthCalledWith(2, ZkProvingStatus.Error);
-  });
   it("should notify that zk-proving failed", async () => {
     fetchMocker.mockResponseOnce(() => {
       throw new Error("test");
@@ -323,6 +277,52 @@ describe("Failed zk-proving", () => {
     } catch (e) {
       expect((e as Error).message).toMatch(
         "Preflight failed with error: Preflight error: ...",
+      );
+    }
+
+    expect(zkProvingSpy).toBeCalledTimes(2);
+    expect(zkProvingSpy).toHaveBeenNthCalledWith(1, ZkProvingStatus.Proving);
+    expect(zkProvingSpy).toHaveBeenNthCalledWith(2, ZkProvingStatus.Error);
+  });
+  it("should handle failed cycle estimation", async () => {
+    fetchMocker.mockResponseOnce(() => {
+      return {
+        body: JSON.stringify({
+          id: 1,
+          jsonrpc: "2.0",
+          result: hashStr,
+        }),
+      };
+    });
+
+    const hash = await vlayer.prove({
+      address: `0x${"a".repeat(40)}`,
+      functionName: "main",
+      proverAbi: [],
+      args: [],
+      chainId: 42,
+    });
+
+    fetchMocker.mockResponseOnce(() => {
+      return {
+        body: JSON.stringify({
+          result: {
+            state: "estimating_cycles",
+            status: 0,
+            metrics: {},
+            error: "Cycle estimation failed",
+          },
+          jsonrpc: "2.0",
+          id: 1,
+        }),
+      };
+    });
+
+    try {
+      await vlayer.waitForProvingResult({ hash });
+    } catch (e) {
+      expect((e as Error).message).toMatch(
+        "Cycle estimation failed with error: Cycle estimation failed",
       );
     }
 

--- a/packages/sdk/src/api/lib/client.test.ts
+++ b/packages/sdk/src/api/lib/client.test.ts
@@ -219,7 +219,7 @@ describe("Success zk-proving", () => {
       await vlayer.waitForProvingResult({ hash });
     } catch (e) {
       expect((e as Error).message).toMatch(
-        "Cycle estimation failed with error: Cycle estimation failed",
+        "Cycle estimation failed with error: Cycle estimation failed"
       );
     }
 

--- a/packages/sdk/src/api/lib/client.test.ts
+++ b/packages/sdk/src/api/lib/client.test.ts
@@ -60,8 +60,7 @@ describe("Success zk-proving", () => {
     const webProofProvider = createExtensionWebProofProvider();
     zkProvingSpy = vi.spyOn(webProofProvider, "notifyZkProvingStatus");
     vlayer = createVlayerClient({ webProofProvider });
-  });
-  it("should send message to extension that zkproving started", async () => {
+
     fetchMocker.mockResponseOnce(() => {
       return {
         body: JSON.stringify({
@@ -71,7 +70,8 @@ describe("Success zk-proving", () => {
         }),
       };
     });
-
+  });
+  it("should send message to extension that zkproving started", async () => {
     const result = await vlayer.prove({
       address: `0x${"a".repeat(40)}`,
       functionName: "main",
@@ -85,16 +85,6 @@ describe("Success zk-proving", () => {
     expect(zkProvingSpy).toHaveBeenNthCalledWith(1, ZkProvingStatus.Proving);
   });
   it("should send message to extension that zkproving is done", async () => {
-    fetchMocker.mockResponseOnce(() => {
-      return {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: "2.0",
-          result: hashStr,
-        }),
-      };
-    });
-
     await vlayer.prove({
       address: `0x${"a".repeat(40)}`,
       functionName: "main",
@@ -126,16 +116,6 @@ describe("Success zk-proving", () => {
     expect(zkProvingSpy).toHaveBeenNthCalledWith(2, ZkProvingStatus.Done);
   });
   it("should handle successful cycle estimation flow", async () => {
-    fetchMocker.mockResponseOnce(() => {
-      return {
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: "2.0",
-          result: hashStr,
-        }),
-      };
-    });
-
     await vlayer.prove({
       address: `0x${"a".repeat(40)}`,
       functionName: "main",

--- a/packages/sdk/src/api/lib/client.test.ts
+++ b/packages/sdk/src/api/lib/client.test.ts
@@ -181,22 +181,6 @@ describe("Success zk-proving", () => {
     expect(zkProvingSpy).toHaveBeenNthCalledWith(1, ZkProvingStatus.Proving);
     expect(zkProvingSpy).toHaveBeenNthCalledWith(2, ZkProvingStatus.Done);
   });
-  it("should notify that zk-proving failed", async () => {
-    fetchMocker.mockResponseOnce(() => {
-      throw new Error("test");
-    });
-
-    const hash = { hash: hashStr } as BrandedHash<[], string>;
-    try {
-      await vlayer.waitForProvingResult({ hash });
-    } catch (e) {
-      //eslint-disable-next-line no-console
-      console.log("Error waiting for proving result", e);
-    }
-
-    expect(zkProvingSpy).toBeCalledTimes(1);
-    expect(zkProvingSpy).toHaveBeenNthCalledWith(1, ZkProvingStatus.Error);
-  });
 });
 
 describe("Failed zk-proving", () => {
@@ -329,6 +313,22 @@ describe("Failed zk-proving", () => {
     expect(zkProvingSpy).toBeCalledTimes(2);
     expect(zkProvingSpy).toHaveBeenNthCalledWith(1, ZkProvingStatus.Proving);
     expect(zkProvingSpy).toHaveBeenNthCalledWith(2, ZkProvingStatus.Error);
+  });
+  it("should notify that zk-proving failed", async () => {
+    fetchMocker.mockResponseOnce(() => {
+      throw new Error("test");
+    });
+
+    const hash = { hash: hashStr } as BrandedHash<[], string>;
+    try {
+      await vlayer.waitForProvingResult({ hash });
+    } catch (e) {
+      //eslint-disable-next-line no-console
+      console.log("Error waiting for proving result", e);
+    }
+
+    expect(zkProvingSpy).toBeCalledTimes(1);
+    expect(zkProvingSpy).toHaveBeenNthCalledWith(1, ZkProvingStatus.Error);
   });
 });
 

--- a/packages/sdk/src/api/lib/client.test.ts
+++ b/packages/sdk/src/api/lib/client.test.ts
@@ -219,7 +219,7 @@ describe("Success zk-proving", () => {
       await vlayer.waitForProvingResult({ hash });
     } catch (e) {
       expect((e as Error).message).toMatch(
-        "Cycle estimation failed with error: Cycle estimation failed"
+        "Cycle estimation failed with error: Cycle estimation failed",
       );
     }
 
@@ -322,7 +322,7 @@ describe("Failed zk-proving", () => {
       await vlayer.waitForProvingResult({ hash });
     } catch (e) {
       expect((e as Error).message).toMatch(
-        "Preflight failed with error: Preflight error: ..."
+        "Preflight failed with error: Preflight error: ...",
       );
     }
 
@@ -442,9 +442,9 @@ describe("Authentication", () => {
           proverAbi: [],
           args: [],
           chainId: 42,
-        })
+        }),
       ).rejects.toThrowError(
-        `Missing JWT token${VLAYER_ERROR_NOTES[HttpAuthorizationError.name]}`
+        `Missing JWT token${VLAYER_ERROR_NOTES[HttpAuthorizationError.name]}`,
       );
     });
 
@@ -456,9 +456,9 @@ describe("Authentication", () => {
           proverAbi: [],
           args: [],
           chainId: 42,
-        })
+        }),
       ).rejects.toThrowError(
-        `Invalid JWT token${VLAYER_ERROR_NOTES[HttpAuthorizationError.name]}`
+        `Invalid JWT token${VLAYER_ERROR_NOTES[HttpAuthorizationError.name]}`,
       );
     });
   });

--- a/packages/sdk/src/api/lib/types/vlayer.ts
+++ b/packages/sdk/src/api/lib/types/vlayer.ts
@@ -50,6 +50,7 @@ export enum ProofState {
   Queued = "queued",
   AllocateGas = "allocate_gas",
   Preflight = "preflight",
+  EstimatingCycles = "estimating_cycles",
   Proving = "proving",
   Done = "done",
 }
@@ -118,6 +119,7 @@ export const proofReceiptSchema = z.discriminatedUnion("status", [
     state: z.enum([
       ProofState.AllocateGas,
       ProofState.Preflight,
+      ProofState.EstimatingCycles,
       ProofState.Proving,
     ]),
   }),
@@ -128,6 +130,7 @@ export const proofReceiptSchema = z.discriminatedUnion("status", [
       ProofState.Done,
       ProofState.AllocateGas,
       ProofState.Preflight,
+      ProofState.EstimatingCycles,
       ProofState.Proving,
       ProofState.Queued,
     ]),

--- a/packages/sdk/src/api/prover/prover.ts
+++ b/packages/sdk/src/api/prover/prover.ts
@@ -85,6 +85,9 @@ const handleErrors = ({ status, state, error }: ProofReceipt) => {
       .with(ProofState.Preflight, () => {
         throw new Error(`Preflight failed with error: ${error}`);
       })
+      .with(ProofState.EstimatingCycles, () => {
+        throw new Error(`Cycle estimation failed with error: ${error}`);
+      })
       .with(ProofState.Proving, () => {
         throw new Error(`Proving failed with error: ${error}`);
       })

--- a/rust/services/call/server_lib/src/handlers/v_get_proof_receipt/types.rs
+++ b/rust/services/call/server_lib/src/handlers/v_get_proof_receipt/types.rs
@@ -16,6 +16,7 @@ pub enum State {
     Preflight,
     Proving,
     Done,
+    EstimatingCycles,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -49,6 +50,7 @@ impl From<&ProofState> for State {
         match value {
             ProofState::Queued => Self::Queued,
             ProofState::AllocateGasPending | ProofState::AllocateGasError(..) => Self::AllocateGas,
+            ProofState::EstimatingCycles => Self::EstimatingCycles,
             ProofState::PreflightPending | ProofState::PreflightError(..) => Self::Preflight,
             ProofState::ProvingPending | ProofState::ProvingError(..) => Self::Proving,
             ProofState::Done(..) => Self::Done,

--- a/rust/services/call/server_lib/src/proof.rs
+++ b/rust/services/call/server_lib/src/proof.rs
@@ -31,6 +31,7 @@ pub enum State {
     AllocateGasError(Box<Error>),
     PreflightPending,
     PreflightError(Box<Error>),
+    EstimatingCycles,
     ProvingPending,
     ProvingError(Box<Error>),
     Done(Box<RawData>),
@@ -134,6 +135,9 @@ pub async fn generate(
         };
 
     let estimation_start = std::time::Instant::now();
+
+    set_state(&state, call_hash, State::EstimatingCycles);
+
     match Risc0CycleEstimator.estimate(&preflight_result.input, preflight_result.guest_elf) {
         Ok(result) => {
             info!(estimated_cycles = result, "Cycle estimation");
@@ -144,6 +148,8 @@ pub async fn generate(
     };
     let elapsed = estimation_start.elapsed();
     info!(estimating_cycles_elapsed_time = ?elapsed, "Cycle estimation lasted");
+
+    set_state(&state, call_hash, State::ProvingPending);
 
     let proving_input = ProvingInput::new(preflight_result.host_output, preflight_result.input);
     match proving::await_proving(

--- a/rust/services/call/server_lib/src/proof.rs
+++ b/rust/services/call/server_lib/src/proof.rs
@@ -122,7 +122,7 @@ pub async fn generate(
             .map_err(Error::Preflight)
         {
             Ok(res) => {
-                let entry = set_state(&state, call_hash, State::ProvingPending);
+                let entry = set_state(&state, call_hash, State::EstimatingCycles);
                 set_metrics(entry, metrics);
                 res
             }
@@ -135,8 +135,6 @@ pub async fn generate(
         };
 
     let estimation_start = std::time::Instant::now();
-
-    set_state(&state, call_hash, State::EstimatingCycles);
 
     match Risc0CycleEstimator.estimate(&preflight_result.input, preflight_result.guest_elf) {
         Ok(result) => {


### PR DESCRIPTION
### Refactor `client.test.ts`
1. `should notify that zk-proving failed` sdk test moved from `Success zk-proving` section to `Failed zk-proving` section.
2. `fetchMocker.mockResponseOnce` call dried in `client.test.ts` and moved from each test to `beforeEach`.

### Add `EstimatingCycles` value to `ProofState`:
1. During estimating the cycles to be used when gererating the proof, the state is changed to `EstimatingCycles`.
2. Updated `proofReceiptSchema` validation schema in `sdk` to include `EstimatingCycles` state.
3. Added logic for handling error in `sdk` when `EstimatingCycles` fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "EstimatingCycles" state to more clearly represent the cycle estimation phase during proof generation.

* **Bug Fixes**
  * Improved error handling and notifications for failures occurring during the cycle estimation phase.

* **Tests**
  * Expanded test coverage to include scenarios for successful and failed cycle estimation, as well as enhanced assertions for status notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->