### PR TITLE
Fix Typos and Improve Clarity in Documentation

### DIFF
--- a/book/src/appendix/architecture/time_travel_teleport.md
+++ b/book/src/appendix/architecture/time_travel_teleport.md
@@ -6,7 +6,7 @@ vlayer allows seamless aggregation of data from different blocks and chains. We 
 
 ## Verification
 
-At the [beggining of the `guest::main`](https://github.com/vlayer-xyz/vlayer/blob/main/rust/services/call/guest/src/guest.rs#L38) we verify whether the data for each execution location is coherent. However, we have not yet checked whether data from multiple execution locations align with each other. Specifically, we need to ensure that:
+At the [beginning of the `guest::main`](https://github.com/vlayer-xyz/vlayer/blob/main/rust/services/call/guest/src/guest.rs#L38) we verify whether the data for each execution location is coherent. However, we have not yet checked whether data from multiple execution locations align with each other. Specifically, we need to ensure that:
 
 - The blocks we claim to be on the same chain are actually there (allowing time travel between blocks on the same chain).
 - The blocks associated with a given chain truly belong to that chain (enabling teleportation to the specified chain).

--- a/book/src/appendix/architecture/web_proof.md
+++ b/book/src/appendix/architecture/web_proof.md
@@ -6,7 +6,7 @@ The following diagram depicts the high-level architecture of how the [Web Proof]
 
 Arrows on the diagram depict data flow between the actors (rectangles).
 
-Generating and ZK-proving a Web Proof consits of the following steps:
+Generating and ZK-proving a Web Proof consists of the following steps:
 1. vlayer [SDK](../../javascript/javascript.md) (used in a webapp) requests a Web Proof from vlayer browser extension.
 2. The extension opens a TLS connection to a Server (2a) through a WebSocket proxy (2b), while conducting MPC-TLS session with the Notary (2c), generating a Web Proof of an HTTPS request to the Server. The WebSocket proxy is needed to provide the extension access to low-level details of the TLS handshake, which is normally not available within the browser, while the Notary acts as a trusted third party who certifies the transcript of the HTTPS request (without actually seeing it). For details of how the TLSN protocol works, please check [TLSN documentation](https://docs.tlsnotary.org/).
 3. The Web Proof is then sent back to vlayer SDK.

--- a/book/src/getting-started/how-it-works.md
+++ b/book/src/getting-started/how-it-works.md
@@ -73,7 +73,7 @@ contract Airdrop is Verifier {
   }
 }
 ```
-Note that the above contract inherits from the `Verfier` vlayer contract. 
+Note that the above contract inherits from the `Verifier` vlayer contract. 
 It is necessary for veryfing the computation done by the Prover contract from the previous step. 
 
 `claim()` function takes proof returned by the vlayer SDK as the first argument. Other arguments are public inputs returned from Prover `main()` function (in the same order). 


### PR DESCRIPTION


**Description:**  
This pull request corrects minor typos and improves the clarity of several documentation files.  
- Fixed spelling errors (e.g., "Verfier" → "Verifier", "consits" → "consists").
- Enhanced wording for better readability.
