### PR TITLE
fix: User friendly errors when gas balance is enough for allocation

### DIFF
--- a/rust/server_utils/src/rpc.rs
+++ b/rust/server_utils/src/rpc.rs
@@ -22,6 +22,22 @@ pub enum Error {
     InvalidResponse(Value),
 }
 
+impl Error {
+    pub fn jsonrpc_code(&self) -> Option<u64> {
+        match self {
+            Error::JsonRpc(value) => value
+                .as_object()
+                .and_then(|obj| obj.get("code"))
+                .and_then(|code| code.as_u64()),
+            _ => None,
+        }
+    }
+
+    pub fn has_error_code(&self, expected_code: u64) -> bool {
+        self.jsonrpc_code() == Some(expected_code)
+    }
+}
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 pub struct RequestBuilder(reqwest::RequestBuilder);

--- a/rust/services/call/server_lib/src/gas_meter.rs
+++ b/rust/services/call/server_lib/src/gas_meter.rs
@@ -140,10 +140,7 @@ impl Client for RpcClient {
     async fn allocate(&self, gas_limit: u64) -> Result<()> {
         let req = AllocateGas::new(self.hash, gas_limit, self.time_to_live.as_secs());
         info!("v_allocateGas => {req:#?}");
-        if let Err(err) = self.call(req).await {
-            error!("v_allocateGas failed with error: {err}");
-            return Err(err);
-        }
+        self.call(req).await?;
         Ok(())
     }
 

--- a/rust/services/call/server_lib/src/gas_meter.rs
+++ b/rust/services/call/server_lib/src/gas_meter.rs
@@ -22,8 +22,6 @@ type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     #[error(transparent)]
     Rpc(#[from] RpcError),
-    #[error("{0}")]
-    UserFriendly(String),
 }
 
 impl Error {

--- a/rust/services/call/server_lib/src/gas_meter.rs
+++ b/rust/services/call/server_lib/src/gas_meter.rs
@@ -28,7 +28,6 @@ impl Error {
     pub fn is_insufficient_gas_balance(&self) -> bool {
         match self {
             Error::Rpc(rpc_err) => rpc_err.has_error_code(INSUFFICIENT_GAS_BALANCE_ERROR_CODE),
-            _ => false,
         }
     }
 }

--- a/rust/services/call/server_lib/src/gas_meter.rs
+++ b/rust/services/call/server_lib/src/gas_meter.rs
@@ -14,12 +14,25 @@ use tracing::{error, info};
 
 use crate::handlers::v_call::types::CallHash;
 
+pub const INSUFFICIENT_GAS_BALANCE_ERROR_CODE: u64 = 1003;
+
 type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]
     Rpc(#[from] RpcError),
+    #[error("{0}")]
+    UserFriendly(String),
+}
+
+impl Error {
+    pub fn is_insufficient_gas_balance(&self) -> bool {
+        match self {
+            Error::Rpc(rpc_err) => rpc_err.has_error_code(INSUFFICIENT_GAS_BALANCE_ERROR_CODE),
+            _ => false,
+        }
+    }
 }
 
 #[derive(new, Serialize, Debug)]

--- a/rust/services/call/server_lib/src/proof.rs
+++ b/rust/services/call/server_lib/src/proof.rs
@@ -108,20 +108,13 @@ pub async fn generate(
             set_state(&state, call_hash, State::PreflightPending);
         }
         Err(err) => {
-            if err.is_insufficient_gas_balance() {
-                set_state(
-                    &state,
-                    call_hash,
-                    State::AllocateGasError(Error::AllocateGasInsufficientBalance.into()),
-                );
+            let state_value = if err.is_insufficient_gas_balance() {
+                State::AllocateGasError(Error::AllocateGasInsufficientBalance.into())
             } else {
                 error!("Gas meter failed with error: {err}");
-                set_state(
-                    &state,
-                    call_hash,
-                    State::AllocateGasError(Error::AllocateGasRpc(err).into()),
-                );
-            }
+                State::AllocateGasError(Error::AllocateGasRpc(err).into())
+            };
+            set_state(&state, call_hash, state_value);
             return;
         }
     };


### PR DESCRIPTION
- Split error types about allocation into:
  - Generic `AllocateGasRpc`.
  - `AllocateGasInsufficientBalance`, when the RPC error is detected to be of 1003 code.
- Log allocation error only for unknown errors - logging `AllocateGasInsufficientBalance` as errors is not needed.
- Remove the `v_allocateGas failed with error:` error log, it caused a duplicate log with the same information.