### PR TITLE
fix: Revert change `State` to `EstimatingCycles` when cycles are estimated

### DIFF
--- a/packages/sdk/src/api/lib/types/vlayer.ts
+++ b/packages/sdk/src/api/lib/types/vlayer.ts
@@ -50,7 +50,6 @@ export enum ProofState {
   Queued = "queued",
   AllocateGas = "allocate_gas",
   Preflight = "preflight",
-  EstimatingCycles = "estimating_cycles",
   Proving = "proving",
   Done = "done",
 }
@@ -119,7 +118,6 @@ export const proofReceiptSchema = z.discriminatedUnion("status", [
     state: z.enum([
       ProofState.AllocateGas,
       ProofState.Preflight,
-      ProofState.EstimatingCycles,
       ProofState.Proving,
     ]),
   }),
@@ -130,7 +128,6 @@ export const proofReceiptSchema = z.discriminatedUnion("status", [
       ProofState.Done,
       ProofState.AllocateGas,
       ProofState.Preflight,
-      ProofState.EstimatingCycles,
       ProofState.Proving,
       ProofState.Queued,
     ]),

--- a/packages/sdk/src/api/prover/prover.ts
+++ b/packages/sdk/src/api/prover/prover.ts
@@ -85,9 +85,6 @@ const handleErrors = ({ status, state, error }: ProofReceipt) => {
       .with(ProofState.Preflight, () => {
         throw new Error(`Preflight failed with error: ${error}`);
       })
-      .with(ProofState.EstimatingCycles, () => {
-        throw new Error(`Cycle estimation failed with error: ${error}`);
-      })
       .with(ProofState.Proving, () => {
         throw new Error(`Proving failed with error: ${error}`);
       })

--- a/rust/services/call/server_lib/src/handlers/v_get_proof_receipt/types.rs
+++ b/rust/services/call/server_lib/src/handlers/v_get_proof_receipt/types.rs
@@ -16,7 +16,6 @@ pub enum State {
     Preflight,
     Proving,
     Done,
-    EstimatingCycles,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -50,7 +49,6 @@ impl From<&ProofState> for State {
         match value {
             ProofState::Queued => Self::Queued,
             ProofState::AllocateGasPending | ProofState::AllocateGasError(..) => Self::AllocateGas,
-            ProofState::EstimatingCycles => Self::EstimatingCycles,
             ProofState::PreflightPending | ProofState::PreflightError(..) => Self::Preflight,
             ProofState::ProvingPending | ProofState::ProvingError(..) => Self::Proving,
             ProofState::Done(..) => Self::Done,


### PR DESCRIPTION
Reverts vlayer-xyz/vlayer#2524 cause it contains breaking changes. It will be merged again after the next stable release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the "EstimatingCycles" state from proof processing, simplifying state transitions and error handling.
  * Updated related types and schemas to reflect the removal of this state.
  * Streamlined test cases to consolidate error notification checks and remove redundant scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->