### PR TITLE
feat: `v_call` accepts both `vgas_limit` and `gas_limit` fields

### DIFF
--- a/rust/services/call/server_lib/src/handlers/v_call/types.rs
+++ b/rust/services/call/server_lib/src/handlers/v_call/types.rs
@@ -47,6 +47,7 @@ impl From<Error> for ErrorObjectOwned {
 pub struct Call {
     pub to: String,
     pub data: String,
+    #[serde(alias = "vgas_limit")]
     pub gas_limit: u64,
 }
 


### PR DESCRIPTION
Makes it possible to pass both `gas_limit` and `vgas_limit` to `v_call`. Current deserialization demands at least one of them is present and if both are provided it returns an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for accepting the alternative field name "vgas_limit" in addition to "gas_limit" when processing call parameters.

* **Tests**
  * Introduced a new integration test to verify that requests using "vgas_limit" are correctly handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->