### PR TITLE
Remove redaction of boolean key in test-web-app

### DIFF
--- a/packages/test-web-app/src/Dapp.tsx
+++ b/packages/test-web-app/src/Dapp.tsx
@@ -90,7 +90,7 @@ function DappWithProfile(profile: string) {
           [
             {
               response: {
-                json_body_except: ["name"],
+                json_body_except: ["name", "success"],
               },
             },
             {

--- a/packages/test-web-app/src/DappProveWeb.tsx
+++ b/packages/test-web-app/src/DappProveWeb.tsx
@@ -51,7 +51,7 @@ function DappProveWeb() {
           [
             {
               response: {
-                json_body_except: ["name"],
+                json_body_except: ["name", "success"],
               },
             },
             {


### PR DESCRIPTION
After changing redaction in extension so that it allows to redact also non-string keys, we need to redact less since solidity doesn't support it