### PR TITLE
refactor: Import `version` function directly for cleaner clap macro

### DIFF
--- a/rust/services/dns/server/src/cli.rs
+++ b/rust/services/dns/server/src/cli.rs
@@ -3,6 +3,7 @@ use std::{net::SocketAddr, path::PathBuf};
 use clap::Parser;
 use common::GlobalArgs;
 use server_utils::jwt::cli::Args as JwtArgs;
+use version::version;
 
 #[derive(Debug, clap::Args)]
 #[group(required = false, multiple = false)]
@@ -19,7 +20,7 @@ pub(crate) struct PrivateKeyArgs {
 }
 
 #[derive(Debug, Parser)]
-#[command(version = version::version())]
+#[command(version = version())]
 pub(crate) struct Cli {
     #[arg(
         long,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified how version information is referenced in the CLI command metadata. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->