### PR TITLE
feat(examples): avoid logging proverAbi in prove.ts.

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -76,6 +76,23 @@ export default tseslint.config(
       "no-console": "off",
     },
   },
+  // Allow underscore variables to be unused (common convention)
+  {
+    files: [
+      "packages/**/*.{ts,tsx,js,jsx}",
+      "examples/**/*.{ts,tsx,js,jsx}",
+    ],
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_",
+          "caughtErrorsIgnorePattern": "^_"
+        }
+      ],
+    },
+  },
   // Disable type-checking rules for specific files to avoid forcing their inclusion in tsconfig.json
   {
     files: [

--- a/examples/kraken-web-proof/vlayer/prove.ts
+++ b/examples/kraken-web-proof/vlayer/prove.ts
@@ -90,7 +90,7 @@ const proveArgs = {
   chainId: chain.id,
   gasLimit: config.gasLimit,
 } as ProveArgs<typeof proverSpec.abi, "main">;
-const { ...argsToLog } = proveArgs;
+const { proverAbi: _, ...argsToLog } = proveArgs;
 log.debug("Proving args:", argsToLog);
 
 const hash = await vlayer.prove(proveArgs);

--- a/examples/simple-email-proof/vlayer/prove.ts
+++ b/examples/simple-email-proof/vlayer/prove.ts
@@ -80,7 +80,7 @@ const proveArgs = {
   gasLimit: config.gasLimit,
   args: [emailArgs],
 } as ProveArgs<typeof proverSpec.abi, "main">;
-const { ...argsToLog } = proveArgs;
+const { proverAbi: _, ...argsToLog } = proveArgs;
 log.debug("Proving args:", argsToLog);
 
 const hash = await vlayer.prove(proveArgs);

--- a/examples/simple-teleport/vlayer/prove.ts
+++ b/examples/simple-teleport/vlayer/prove.ts
@@ -91,7 +91,7 @@ const proveArgs = {
   chainId: chain.id,
   gasLimit: config.gasLimit,
 } as ProveArgs<typeof proverSpec.abi, "crossChainBalanceOf">;
-const { ...argsToLog } = proveArgs;
+const { proverAbi: _, ...argsToLog } = proveArgs;
 log.debug("Proving args:", argsToLog);
 
 const proofHash = await vlayer.prove(proveArgs);

--- a/examples/simple-time-travel/vlayer/prove.ts
+++ b/examples/simple-time-travel/vlayer/prove.ts
@@ -75,7 +75,7 @@ const proveArgs = {
   chainId: ethClient.chain.id,
   gasLimit: config.gasLimit,
 } as ProveArgs<typeof proverSpec.abi, "averageBalanceOf">;
-const { ...argsToLog } = proveArgs;
+const { proverAbi: _, ...argsToLog } = proveArgs;
 log.debug("Proving args:", argsToLog);
 
 const provingHash = await vlayer.prove(proveArgs);

--- a/examples/simple-web-proof/vlayer/prove.ts
+++ b/examples/simple-web-proof/vlayer/prove.ts
@@ -100,7 +100,7 @@ async function testSuccessProvingAndVerification({
     chainId: chain.id,
     gasLimit: config.gasLimit,
   } as ProveArgs<typeof proverSpec.abi, "main">;
-  const { ...argsToLog } = proveArgs;
+  const { proverAbi: _, ...argsToLog } = proveArgs;
   log.debug("Proving args:", argsToLog);
 
   const hash = await vlayer.prove(proveArgs);
@@ -190,7 +190,7 @@ async function testFailedProving({
       chainId: chain.id,
       gasLimit: config.gasLimit,
     } as ProveArgs<typeof proverSpec.abi, "main">;
-    const { ...argsToLog } = proveArgs;
+    const { proverAbi: _, ...argsToLog } = proveArgs;
     log.debug("Proving args:", argsToLog);
 
     const hash = await vlayer.prove(proveArgs);

--- a/examples/simple/vlayer/prove.ts
+++ b/examples/simple/vlayer/prove.ts
@@ -93,7 +93,7 @@ const proveArgs = {
   gasLimit: config.gasLimit,
 } as ProveArgs<typeof proverSpec.abi, "balance">;
 
-const { ...argsToLog } = proveArgs;
+const { proverAbi: _, ...argsToLog } = proveArgs;
 log.debug("Proving args:", argsToLog);
 
 const hash = await vlayer.prove(proveArgs);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug log output in multiple examples by omitting the potentially large or sensitive `proverAbi` field from proving argument logs.

* **Style**
  * Updated linting rules to allow unused variables, arguments, and caught errors prefixed with an underscore (`_`), reducing unnecessary lint errors for intentionally unused code elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->