### PR TITLE
feat(update): enforce execution from within 'vlayer' directory

### DIFF
--- a/rust/cli/src/commands/update.rs
+++ b/rust/cli/src/commands/update.rs
@@ -56,7 +56,6 @@ pub async fn run_update(args: UpdateArgs) -> Result<()> {
 }
 
 fn ensure_in_vlayer_directory() -> Result<()> {
-    // Can happen if current working directory doesn't exist
     let current_dir = std::env::current_dir()
         .map_err(|e| Error::Upgrade(format!("Failed to get current directory: {e}")))?;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a check to ensure updates are only run from within a "vlayer" directory or its parent. Users will now see an error message if attempting to update from an incorrect directory, improving guidance and preventing misoperation.
  * Improved update process by requiring the presence of a `package.json` file to proceed with SDK updates, providing clearer error messages when missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->