### PR TITLE
ci: Add a pinned version of prover via a docker container in the stable fake prover

### DIFF
--- a/ansible/group_vars/provers.yml
+++ b/ansible/group_vars/provers.yml
@@ -5,3 +5,4 @@ vlayer_rust_log:
 vlayer_jwt_public_key_location: /home/{{ ansible_user }}/.vlayer/jwt.key.pub
 vlayer_jwt_algorithm: rs256
 prover_nginx_ssl_certificate: "fake-prover.vlayer.xyz"
+prover_docker_containers: []

--- a/ansible/host_vars/nightly_fake_prover.yml
+++ b/ansible/host_vars/nightly_fake_prover.yml
@@ -5,6 +5,7 @@ ansible_user: ubuntu
 vlayer_release_channel: nightly
 vlayer_prover_host: 127.0.0.1
 vlayer_prover_port: 3000
+vlayer_proof_type: fake
 vlayer_jwt_claims:
  - "sub"
  - "environment:test"

--- a/ansible/host_vars/stable_fake_prover.yml
+++ b/ansible/host_vars/stable_fake_prover.yml
@@ -58,5 +58,5 @@ vlayer_prover_gas_meter_api_key: !vault |
   333634303764653162643233336133656661
 vlayer_prover_chain_proof_url: "https://stable-fake-chainservice.vlayer.xyz"
 prover_docker_containers:
-  - version: "1.3.0"
-    port: 4001
+ - version: "1.3.0"
+   port: 4001

--- a/ansible/host_vars/stable_fake_prover.yml
+++ b/ansible/host_vars/stable_fake_prover.yml
@@ -5,6 +5,7 @@ ansible_user: ubuntu
 vlayer_release_channel: stable
 vlayer_prover_host: 127.0.0.1
 vlayer_prover_port: 3000
+vlayer_proof_type: fake
 vlayer_jwt_claims:
  - "sub"
  - "environment:test"
@@ -56,3 +57,6 @@ vlayer_prover_gas_meter_api_key: !vault |
   35633263303637613536333463643966336565313263396131623132306632333631313165376534
   333634303764653162643233336133656661
 vlayer_prover_chain_proof_url: "https://stable-fake-chainservice.vlayer.xyz"
+prover_docker_containers:
+  - version: "1.3.0"
+    port: 4001

--- a/ansible/prover.yml
+++ b/ansible/prover.yml
@@ -25,6 +25,10 @@
       ansible.builtin.gather_facts:
 
   roles:
+    - role: geerlingguy.docker
+      vars:
+        docker_users: "{{ ansible_user }}"
+      become: true
     - role: geerlingguy.swap
       become: true
       vars:
@@ -32,3 +36,24 @@
     - role: prover
     - role: prover_nginx
       become: true
+
+  tasks:
+    - name: Prover docker container
+      ansible.builtin.include_role:
+        name: prover_docker
+      vars:
+        prover_docker_version: "{{ item.version }}"
+        prover_docker_port: "{{ item.port }}"
+        prover_docker_proof_type: "{{ vlayer_proof_type }}"
+        prover_docker_rust_log: "{{ vlayer_rust_log }}"
+        prover_docker_bonsai_api_url: "{{ vlayer_bonsai_api_url }}"
+        prover_docker_bonsai_api_key: "{{ vlayer_bonsai_api_key }}"
+        prover_docker_gas_meter_url: "{{ vlayer_prover_gas_meter_url }}"
+        prover_docker_gas_meter_api_key: "{{ vlayer_prover_gas_meter_api_key }}"
+        prover_docker_chain_proof_url: "{{ vlayer_prover_chain_proof_url }}"
+        prover_docker_jwt_algorithm: "{{ vlayer_jwt_algorithm }}"
+        prover_docker_jwt_claims: "{{ vlayer_jwt_claims }}"
+        prover_docker_rpc_urls: "{{ vlayer_prover_rpc_urls }}"
+        prover_docker_jwt_public_key_location: "{{ vlayer_jwt_public_key_location }}"
+      loop: "{{ prover_docker_containers }}"
+      no_log: true

--- a/ansible/prover.yml
+++ b/ansible/prover.yml
@@ -55,5 +55,6 @@
         prover_docker_jwt_claims: "{{ vlayer_jwt_claims }}"
         prover_docker_rpc_urls: "{{ vlayer_prover_rpc_urls }}"
         prover_docker_jwt_public_key_location: "{{ vlayer_jwt_public_key_location }}"
+      when: prover_docker_containers | length > 0
       loop: "{{ prover_docker_containers }}"
       no_log: true

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -2,6 +2,8 @@
 roles:
   - name: geerlingguy.swap
     version: 1.2.0
+  - name: geerlingguy.docker
+    version: 7.4.1
   - name: nginxinc.nginx
     version: 0.24.3
 
@@ -11,4 +13,7 @@ collections:
     source: https://galaxy.ansible.com
   - name: grafana.grafana
     version: 5.5.1
+    source: https://galaxy.ansible.com
+  - name: community.docker
+    version: 4.0.1
     source: https://galaxy.ansible.com

--- a/ansible/roles/prover/README.md
+++ b/ansible/roles/prover/README.md
@@ -11,9 +11,12 @@ Installs the vlayer Prover server.
 | `vlayer_release_channel` | Stable or nightly release channel. |
 | `vlayer_prover_rpc_urls` | A list of RPC urls for the Prover. |
 | `vlayer_prover_gas_meter_url` | Optional url to the gas meter endpoint. |
+| `vlayer_prover_gas_meter_api_key` | API key for the gas meter endpoint. |
 | `vlayer_prover_chain_proof_url` | Optional url to the chain proof server. |
 | `vlayer_proof_type` | Type of proof - `fake` or `groth16`. |
 | `vlayer_bonsai_api_url` | API url for Bonsai, required for real proofs. |
 | `vlayer_bonsai_api_key` | API key for Bonsai, required for real proofs. |
+| `vlayer_jwt_algorithm` | Algorithm type used in JWT. |
+| `vlayer_jwt_claims` | A list of JWT claims. |
 | `vlayer_jwt_public_key_location` | Where to install the JWT public key file. |
 | `vlayer_rust_log` | An array of log levels for constructing [`RUST_LOG`](https://rust-lang-nursery.github.io/rust-cookbook/development_tools/debugging/config_log.html). |

--- a/ansible/roles/prover_docker/README.md
+++ b/ansible/roles/prover_docker/README.md
@@ -1,0 +1,24 @@
+# Vlayer Prover Docker Ansible Role
+
+Installs the vlayer Prover docker container.
+
+## Variables
+
+### todo update
+
+| Name | Purpose |
+| --- | --- |
+| `prover_docker_version` | A docker image tag to use. |
+| `prover_docker_host` | Host to bind to, for example `127.0.0.1` or `0.0.0.0`. |
+| `prover_docker_port` | The port to bind to on host system. |
+| `prover_docker_proof_type` | Type of proof - `fake` or `groth16`. |
+| `prover_docker_rust_log` | An array of log levels for constructing [`RUST_LOG`](https://rust-lang-nursery.github.io/rust-cookbook/development_tools/debugging/config_log.html). |
+| `prover_docker_bonsai_api_url` | API url for Bonsai, required for real proofs. |
+| `prover_docker_bonsai_api_key` | API key for Bonsai, required for real proofs. |
+| `prover_docker_gas_meter_url` | Optional url to the gas meter endpoint. |
+| `prover_docker_gas_meter_api_key` | API key for the gas meter endpoint. |
+| `prover_docker_chain_proof_url` | Optional url to the chain proof server. |
+| `prover_docker_rpc_urls` | A list of RPC urls for the Prover. |
+| `prover_docker_jwt_algorithm` | Algorithm type used in JWT.. |
+| `prover_docker_jwt_claims` | A list of JWT claims. |
+| `prover_docker_jwt_public_key_location` | Where is the JWT public key file installed. |

--- a/ansible/roles/prover_docker/README.md
+++ b/ansible/roles/prover_docker/README.md
@@ -4,8 +4,6 @@ Installs the vlayer Prover docker container.
 
 ## Variables
 
-### todo update
-
 | Name | Purpose |
 | --- | --- |
 | `prover_docker_version` | A docker image tag to use. |

--- a/ansible/roles/prover_docker/defaults/main.yml
+++ b/ansible/roles/prover_docker/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+prover_docker_host: 127.0.0.1
+prover_docker_port: 4000

--- a/ansible/roles/prover_docker/handlers/main.yml
+++ b/ansible/roles/prover_docker/handlers/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Restart prover docker {{ prover_docker_version }}
   become: true
+  no_log: true
   community.docker.docker_compose_v2:
     project_src: /etc/vlayer-prover/{{ prover_docker_version }}
     state: restarted

--- a/ansible/roles/prover_docker/handlers/main.yml
+++ b/ansible/roles/prover_docker/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart prover docker {{ prover_docker_version }}
+  become: true
+  community.docker.docker_compose_v2:
+    project_src: /etc/vlayer-prover/{{ prover_docker_version }}
+    state: restarted
+    recreate: always

--- a/ansible/roles/prover_docker/tasks/main.yml
+++ b/ansible/roles/prover_docker/tasks/main.yml
@@ -9,6 +9,7 @@
 
 - name: Install config
   become: true
+  no_log: true
   ansible.builtin.template:
     src: "config.toml.j2"
     dest: /etc/vlayer-prover/{{ prover_docker_version }}/config/config.toml
@@ -25,6 +26,7 @@
 
 - name: Start prover container
   become: true
+  no_log: true
   community.docker.docker_compose_v2:
     project_src: /etc/vlayer-prover/{{ prover_docker_version }}
     state: present

--- a/ansible/roles/prover_docker/tasks/main.yml
+++ b/ansible/roles/prover_docker/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: Create configuration directory
+  become: true
+  ansible.builtin.file:
+    path: /etc/vlayer-prover/{{ prover_docker_version }}/config
+    state: directory
+    mode: '755'
+  notify: "Restart prover docker {{ prover_docker_version }}"
+
+- name: Install config
+  become: true
+  ansible.builtin.template:
+    src: "config.toml.j2"
+    dest: /etc/vlayer-prover/{{ prover_docker_version }}/config/config.toml
+    mode: '755'
+  notify: "Restart prover docker {{ prover_docker_version }}"
+
+- name: Install docker compose
+  become: true
+  ansible.builtin.template:
+    src: "docker-compose.yml.j2"
+    dest: /etc/vlayer-prover/{{ prover_docker_version }}/docker-compose.yml
+    mode: '755'
+  notify: "Restart prover docker {{ prover_docker_version }}"
+
+- name: Start prover container
+  become: true
+  community.docker.docker_compose_v2:
+    project_src: /etc/vlayer-prover/{{ prover_docker_version }}
+    state: present

--- a/ansible/roles/prover_docker/templates/config.toml.j2
+++ b/ansible/roles/prover_docker/templates/config.toml.j2
@@ -1,0 +1,45 @@
+host = "0.0.0.0"
+port = 3000
+rust_log = "{{ prover_docker_rust_log | join(',') }}"
+log_format = "json"
+proof_mode = "{{ prover_docker_proof_type }}"
+
+{% if prover_docker_bonsai_api_url is defined %}
+bonsai_api_url = "{{ prover_docker_bonsai_api_url }}"
+{% endif %}
+{% if prover_docker_bonsai_api_key is defined %}
+bonsai_api_key = "{{ prover_docker_bonsai_api_key }}"
+{% endif %}
+
+{% if prover_docker_gas_meter_url is defined %}
+[gas_meter]
+url = "{{ prover_docker_gas_meter_url }}"
+api_key = "{{ prover_docker_gas_meter_api_key }}"
+{% endif %}
+
+{% if prover_docker_chain_proof_url is defined %}
+[chain_client]
+url = "{{ prover_docker_chain_proof_url }}"
+{% endif %}
+
+[auth.jwt]
+public_key = "/jwt.key.pub"
+algorithm = "{{ prover_docker_jwt_algorithm }}"
+
+{% for claim in prover_docker_jwt_claims %}
+{% if ':' in claim %}
+{% set claim_parts = claim.split(':', 1) %}
+[[auth.jwt.claims]]
+name = "{{ claim_parts[0] }}"
+values = ["{{ claim_parts[1] }}"]
+{% else %}
+[[auth.jwt.claims]]
+name = "{{ claim }}"
+{% endif %}
+{% endfor %}
+
+{% for rpc_url in prover_docker_rpc_urls %}
+[[rpc_urls]]
+chain_id = {{ rpc_url.split(':', 1)[0] }}
+url = "{{ rpc_url.split(':', 1)[1] }}"
+{% endfor %}

--- a/ansible/roles/prover_docker/templates/docker-compose.yml.j2
+++ b/ansible/roles/prover_docker/templates/docker-compose.yml.j2
@@ -1,0 +1,11 @@
+services:
+  vlayer-prover:
+    image: ghcr.io/vlayer-xyz/call_server:{{ prover_docker_version }}
+    container_name: vlayer-prover-{{ prover_docker_version }}
+    restart: always
+    command: "--config-file /config.toml"
+    ports:
+      - "{{ prover_docker_host }}:{{ prover_docker_port }}:3000"
+    volumes:
+      - /etc/vlayer-prover/{{ prover_docker_version }}/config/config.toml:/config.toml:ro
+      - {{ prover_docker_jwt_public_key_location }}:/jwt.key.pub:ro

--- a/ansible/roles/prover_nginx/templates/vlayer-prover.conf.j2
+++ b/ansible/roles/prover_nginx/templates/vlayer-prover.conf.j2
@@ -1,11 +1,23 @@
 limit_req_zone $binary_remote_addr zone=requestlimit:10m rate={{- prover_nginx_ip_rate_limit_per_minute }}r/m;
 
+{% set common_location_settings %}
+    limit_req zone=requestlimit burst={{- prover_nginx_ip_rate_limit_burst }} nodelay;
+{%- endset %}
+
 server {
   listen 443 ssl;
   ssl_certificate /etc/ssl/certs/prover.vlayer.xyz.pem;
   ssl_certificate_key /etc/ssl/private/prover.vlayer.xyz.key;
+
+{% for prover_docker_container in prover_docker_containers %}
+  location /{{ prover_docker_container.version }}/ {
+{{ common_location_settings | safe }}
+    proxy_pass http://127.0.0.1:{{ prover_docker_container.port }}/;
+  }
+{% endfor %}
+
   location / {
-    limit_req zone=requestlimit burst={{- prover_nginx_ip_rate_limit_burst }} nodelay;
+{{ common_location_settings | safe }}
     proxy_pass http://127.0.0.1:{{- vlayer_prover_port if vlayer_prover_port is defined else '3000' }};
   }
 }


### PR DESCRIPTION
- Introduces a new Ansible role `prover_docker` - which installs a specific version of the prover docker container
- Specify `vlayer_proof_type` for each host - because `config.toml` requires it and doesn't fall back to the default like the approach without the config does.
- The nginx on the prover servers routes traffic to the docker container with URL paths, similarly to the TLS notary deployment.
- Added version `1.3.0` to the stable fake prover.
  - Currently it will use exactly identical config as the existing version running as a binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for deploying prover services as Docker containers, including configuration options for version, port, and proof type.
  * Introduced new Ansible roles and tasks to automate setup and management of prover Docker containers.
  * Enabled configuration of JWT authentication, logging, and external API integrations for prover services.

* **Documentation**
  * Updated and added documentation for new variables and roles related to prover Docker deployment.

* **Refactor**
  * Improved NGINX configuration by consolidating repeated rate limiting settings using reusable variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->