### PR TITLE
ci: Add a pinned version of prover via a docker container in the stable groth16 prover

### DIFF
--- a/ansible/host_vars/stable_prod_prover.yml
+++ b/ansible/host_vars/stable_prod_prover.yml
@@ -67,3 +67,6 @@ vlayer_prover_gas_meter_api_key: !vault |
   35633263303637613536333463643966336565313263396131623132306632333631313165376534
   333634303764653162643233336133656661
 vlayer_prover_chain_proof_url: "https://chainservice.vlayer.xyz"
+prover_docker_containers:
+ - version: "1.3.0"
+   port: 4001


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option for specifying prover Docker containers, including version and port settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->