### PR TITLE
fix(constants): update `erc20BlockNumbers` in teleport example

### DIFF
--- a/examples/simple-teleport/vlayer/constants.ts
+++ b/examples/simple-teleport/vlayer/constants.ts
@@ -29,7 +29,7 @@ export const chainToTeleportConfig: Record<string, TeleportConfig> = {
     prover: {
       erc20Addresses: "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
       erc20ChainIds: "10",
-      erc20BlockNumbers: "138900000",
+      erc20BlockNumbers: "138820000",
     },
   },
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated block numbers for Sepolia and Mainnet chains in the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->