### PR TITLE
ci: Add a pinned version of services via docker containers in the stable fake chain service

### DIFF
--- a/ansible/chain_service.yml
+++ b/ansible/chain_service.yml
@@ -34,6 +34,10 @@
         mode: '755'
 
   roles:
+    - role: geerlingguy.docker
+      vars:
+        docker_users: "{{ ansible_user }}"
+      become: true
     - role: geerlingguy.swap
       become: true
       vars:
@@ -60,4 +64,17 @@
         chain_worker_bonsai_api_url: "{{ item.chain_worker_bonsai_api_url | default('') }}"
         chain_worker_bonsai_api_key: "{{ item.chain_worker_bonsai_api_key | default('') }}"
       loop: "{{ chain_workers }}"
+      no_log: true
+
+    - name: Chain service docker containers
+      ansible.builtin.include_role:
+        name: chain_service_docker
+      vars:
+        chain_service_docker_version: "{{ item.version }}"
+        chain_service_docker_server_port: "{{ item.chain_server_port }}"
+        chain_service_docker_workers: "{{ item.chain_workers }}"
+        chain_service_docker_server_rust_log: "{{ chain_server_rust_log }}"
+        chain_service_docker_worker_rust_log: "{{ chain_worker_rust_log }}"
+      when: chain_service_docker_containers | length > 0
+      loop: "{{ chain_service_docker_containers }}"
       no_log: true

--- a/ansible/group_vars/chain_services.yml
+++ b/ansible/group_vars/chain_services.yml
@@ -6,3 +6,4 @@ chain_server_rust_log:
   - info
 chain_services_db_path: "/data/chain_db"
 vlayer_release_channel: stable
+chain_service_docker_containers: []

--- a/ansible/host_vars/stable_fake_chain_service.yml
+++ b/ansible/host_vars/stable_fake_chain_service.yml
@@ -32,3 +32,28 @@ chain_workers:
     chain_worker_max_back_propagation_blocks: 0
     chain_worker_max_head_blocks: 10
     chain_worker_confirmations: 8
+chain_service_docker_containers:
+  - version: "1.3.0"
+    chain_server_port: 4001
+    chain_workers:
+      - identifier: ethereum-sepolia
+        rpc_url: https://fragrant-small-sheet.ethereum-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}
+        chain_id: 11155111
+        proof_mode: fake
+        max_back_propagation_blocks: 0
+        max_head_blocks: 10
+        confirmations: 8
+      - identifier: base-sepolia
+        rpc_url: https://fragrant-small-sheet.base-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}
+        chain_id: 84532
+        proof_mode: fake
+        max_back_propagation_blocks: 0
+        max_head_blocks: 10
+        confirmations: 8
+      - identifier: optimism-sepolia
+        rpc_url: https://fragrant-small-sheet.optimism-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key }}
+        chain_id: 11155420
+        proof_mode: fake
+        max_back_propagation_blocks: 0
+        max_head_blocks: 10
+        confirmations: 8

--- a/ansible/roles/chain_service_docker/README.md
+++ b/ansible/roles/chain_service_docker/README.md
@@ -1,0 +1,15 @@
+# Vlayer Chain Service Docker Ansible Role
+
+Installs the vlayer Chain Service docker containers (1 chain server + multiple chain workers).
+
+## Variables
+
+| Name | Purpose |
+| --- | --- |
+| `chain_service_docker_version` | A docker image tag to use. |
+| `chain_service_docker_server_host` | Host to bind to for chain server, for example `127.0.0.1` or `0.0.0.0`. |
+| `chain_service_docker_server_port` | The port to bind to on host system for chain server. |
+| `chain_service_docker_workers` | Array of chain worker configurations with blockchain settings. |
+| `chain_service_docker_server_rust_log` | An array of log levels for chain server [`RUST_LOG`](https://rust-lang-nursery.github.io/rust-cookbook/development_tools/debugging/config_log.html). |
+| `chain_service_docker_worker_rust_log` | An array of log levels for chain workers [`RUST_LOG`](https://rust-lang-nursery.github.io/rust-cookbook/development_tools/debugging/config_log.html). |
+| `chain_service_docker_db_path` | Database path for containers (inside container). |

--- a/ansible/roles/chain_service_docker/defaults/main.yml
+++ b/ansible/roles/chain_service_docker/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+chain_service_docker_server_host: 127.0.0.1
+chain_service_docker_db_path: /chain_db

--- a/ansible/roles/chain_service_docker/handlers/main.yml
+++ b/ansible/roles/chain_service_docker/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Restart chain service docker {{ chain_service_docker_version }}
+  become: true
+  no_log: true
+  community.docker.docker_compose_v2:
+    project_src: /etc/vlayer-chain-service/{{ chain_service_docker_version }}
+    state: restarted
+    recreate: always

--- a/ansible/roles/chain_service_docker/tasks/main.yml
+++ b/ansible/roles/chain_service_docker/tasks/main.yml
@@ -1,0 +1,54 @@
+---
+- name: Create versioned database directory
+  become: true
+  ansible.builtin.file:
+    path: /data/{{ chain_service_docker_version }}/chain_db
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: '755'
+  notify: "Restart chain service docker {{ chain_service_docker_version }}"
+
+- name: Create configuration directory
+  become: true
+  ansible.builtin.file:
+    path: /etc/vlayer-chain-service/{{ chain_service_docker_version }}
+    state: directory
+    mode: '755'
+  notify: "Restart chain service docker {{ chain_service_docker_version }}"
+
+- name: Install chain server environment file
+  become: true
+  no_log: true
+  ansible.builtin.template:
+    src: "chain-server.env.j2"
+    dest: /etc/vlayer-chain-service/{{ chain_service_docker_version }}/chain-server.env
+    mode: '600'
+  notify: "Restart chain service docker {{ chain_service_docker_version }}"
+
+- name: Install chain worker environment files
+  become: true
+  no_log: true
+  ansible.builtin.template:
+    src: "chain-worker.env.j2"
+    dest: /etc/vlayer-chain-service/{{ chain_service_docker_version }}/chain-worker-{{ worker.identifier }}.env
+    mode: '600'
+  loop: "{{ chain_service_docker_workers }}"
+  loop_control:
+    loop_var: worker
+  notify: "Restart chain service docker {{ chain_service_docker_version }}"
+
+- name: Install docker compose
+  become: true
+  ansible.builtin.template:
+    src: "docker-compose.yml.j2"
+    dest: /etc/vlayer-chain-service/{{ chain_service_docker_version }}/docker-compose.yml
+    mode: '755'
+  notify: "Restart chain service docker {{ chain_service_docker_version }}"
+
+- name: Start chain service containers
+  become: true
+  no_log: true
+  community.docker.docker_compose_v2:
+    project_src: /etc/vlayer-chain-service/{{ chain_service_docker_version }}
+    state: present

--- a/ansible/roles/chain_service_docker/templates/chain-server.env.j2
+++ b/ansible/roles/chain_service_docker/templates/chain-server.env.j2
@@ -1,0 +1,3 @@
+RUST_LOG={{ chain_service_docker_server_rust_log | join(',') }}
+VLAYER_LOG_FORMAT=json
+DB_PATH={{ chain_service_docker_db_path }}

--- a/ansible/roles/chain_service_docker/templates/chain-worker.env.j2
+++ b/ansible/roles/chain_service_docker/templates/chain-worker.env.j2
@@ -1,0 +1,15 @@
+RUST_LOG={{ chain_service_docker_worker_rust_log | join(',') }}
+VLAYER_LOG_FORMAT=json
+DB_PATH={{ chain_service_docker_db_path }}
+RPC_URL={{ worker.rpc_url }}
+CHAIN_ID={{ worker.chain_id }}
+PROOF_MODE={{ worker.proof_mode }}
+MAX_BACK_PROPAGATION_BLOCKS={{ worker.max_back_propagation_blocks }}
+MAX_HEAD_BLOCKS={{ worker.max_head_blocks }}
+CONFIRMATIONS={{ worker.confirmations }}
+{% if worker.bonsai_api_url is defined and worker.bonsai_api_url != '' %}
+BONSAI_API_URL={{ worker.bonsai_api_url }}
+{% endif %}
+{% if worker.bonsai_api_key is defined and worker.bonsai_api_key != '' %}
+BONSAI_API_KEY={{ worker.bonsai_api_key }}
+{% endif %}

--- a/ansible/roles/chain_service_docker/templates/docker-compose.yml.j2
+++ b/ansible/roles/chain_service_docker/templates/docker-compose.yml.j2
@@ -1,0 +1,28 @@
+services:
+  vlayer-chain-server:
+    image: ghcr.io/vlayer-xyz/chain_server:{{ chain_service_docker_version }}
+    container_name: vlayer-chain-server-{{ chain_service_docker_version }}
+    restart: always
+    # https://github.com/erthink/libmdbx?tab=readme-ov-file#containers
+    pid: host
+    ports:
+      - "{{ chain_service_docker_server_host }}:{{ chain_service_docker_server_port }}:3000"
+    volumes:
+      - /data/{{ chain_service_docker_version }}/chain_db:{{ chain_service_docker_db_path }}
+    env_file:
+      - chain-server.env
+    command: "--listen-addr 0.0.0.0:3000"
+
+{% for worker in chain_service_docker_workers %}
+  vlayer-chain-worker-{{ worker.identifier }}:
+    image: ghcr.io/vlayer-xyz/chain_worker:{{ chain_service_docker_version }}
+    container_name: vlayer-chain-worker-{{ chain_service_docker_version }}-{{ worker.identifier }}
+    restart: always
+    # https://github.com/erthink/libmdbx?tab=readme-ov-file#containers
+    pid: host
+    volumes:
+      - /data/{{ chain_service_docker_version }}/chain_db:{{ chain_service_docker_db_path }}
+    env_file:
+      - chain-worker-{{ worker.identifier }}.env
+
+{% endfor %}

--- a/ansible/roles/chain_service_nginx/templates/vlayer-chainservice.conf.j2
+++ b/ansible/roles/chain_service_nginx/templates/vlayer-chainservice.conf.j2
@@ -1,11 +1,23 @@
 limit_req_zone $binary_remote_addr zone=requestlimit:10m rate={{- chain_service_nginx_ip_rate_limit_per_minute }}r/m;
 
+{% set common_location_settings %}
+    limit_req zone=requestlimit burst={{- chain_service_nginx_ip_rate_limit_burst }} nodelay;
+{%- endset %}
+
 server {
   listen 443 ssl;
   ssl_certificate /etc/ssl/certs/chainservice.vlayer.xyz.pem;
   ssl_certificate_key /etc/ssl/private/chainservice.vlayer.xyz.key;
+
+{% for chain_service_docker_container in chain_service_docker_containers %}
+  location /{{ chain_service_docker_container.version }}/ {
+{{ common_location_settings | safe }}
+    proxy_pass http://127.0.0.1:{{ chain_service_docker_container.chain_server_port }}/;
+  }
+{% endfor %}
+
   location / {
-    limit_req zone=requestlimit burst={{- chain_service_nginx_ip_rate_limit_burst }} nodelay;
+{{ common_location_settings | safe }}
     proxy_pass http://127.0.0.1:{{- chain_server_port if chain_server_port is defined else '3001' }};
   }
 }


### PR DESCRIPTION
Analogous to https://github.com/vlayer-xyz/vlayer/pull/2562, but for chain services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deploying the chain service and its workers as Docker containers via Ansible.
  * Introduced configurable variables for Docker-based chain service deployment.
  * Provided templates for environment and Docker Compose files to enable flexible container configuration.

* **Documentation**
  * Added documentation for the new Docker deployment role, detailing available configuration options.

* **Refactor**
  * Centralized and simplified NGINX rate limiting configuration for chain service endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->