### PR TITLE
ci: Change Bonsai configuration in docker from config to env vars

### DIFF
--- a/ansible/roles/prover_docker/tasks/main.yml
+++ b/ansible/roles/prover_docker/tasks/main.yml
@@ -7,6 +7,15 @@
     mode: '755'
   notify: "Restart prover docker {{ prover_docker_version }}"
 
+- name: Install prover environment file
+  become: true
+  no_log: true
+  ansible.builtin.template:
+    src: "prover.env.j2"
+    dest: /etc/vlayer-prover/{{ prover_docker_version }}/prover.env
+    mode: '600'
+  notify: "Restart prover docker {{ prover_docker_version }}"
+
 - name: Install config
   become: true
   no_log: true

--- a/ansible/roles/prover_docker/templates/config.toml.j2
+++ b/ansible/roles/prover_docker/templates/config.toml.j2
@@ -1,15 +1,7 @@
 host = "0.0.0.0"
 port = 3000
-rust_log = "{{ prover_docker_rust_log | join(',') }}"
 log_format = "json"
 proof_mode = "{{ prover_docker_proof_type }}"
-
-{% if prover_docker_bonsai_api_url is defined %}
-bonsai_api_url = "{{ prover_docker_bonsai_api_url }}"
-{% endif %}
-{% if prover_docker_bonsai_api_key is defined %}
-bonsai_api_key = "{{ prover_docker_bonsai_api_key }}"
-{% endif %}
 
 {% if prover_docker_gas_meter_url is defined %}
 [gas_meter]

--- a/ansible/roles/prover_docker/templates/docker-compose.yml.j2
+++ b/ansible/roles/prover_docker/templates/docker-compose.yml.j2
@@ -9,3 +9,5 @@ services:
     volumes:
       - /etc/vlayer-prover/{{ prover_docker_version }}/config/config.toml:/config.toml:ro
       - {{ prover_docker_jwt_public_key_location }}:/jwt.key.pub:ro
+    env_file:
+      - prover.env

--- a/ansible/roles/prover_docker/templates/prover.env.j2
+++ b/ansible/roles/prover_docker/templates/prover.env.j2
@@ -1,0 +1,7 @@
+RUST_LOG={{ prover_docker_rust_log | join(',') }}
+{% if prover_docker_bonsai_api_url is defined %}
+BONSAI_API_URL={{ prover_docker_bonsai_api_url }}
+{% endif %}
+{% if prover_docker_bonsai_api_key is defined %}
+BONSAI_API_KEY={{ prover_docker_bonsai_api_key }}
+{% endif %}


### PR DESCRIPTION
- This was required by the prover
- Moved RUST_LOG as well because it is not a part of our TOML config.