### PR TITLE
feat(vlayer update): insert version to prover URL.

### DIFF
--- a/rust/cli/src/commands/init.rs
+++ b/rust/cli/src/commands/init.rs
@@ -8,7 +8,6 @@ use std::{
 use anyhow::Context;
 use clap::Parser;
 use flate2::read::GzDecoder;
-
 use reqwest::get;
 use serde_json::{Map, Value};
 use tar::Archive;

--- a/rust/cli/src/commands/init.rs
+++ b/rust/cli/src/commands/init.rs
@@ -8,12 +8,11 @@ use std::{
 use anyhow::Context;
 use clap::Parser;
 use flate2::read::GzDecoder;
-use regex::Regex;
+
 use reqwest::get;
 use serde_json::{Map, Value};
 use tar::Archive;
 use tracing::{error, info};
-use version::is_stable;
 
 use crate::{
     config::{Config, Error as ConfigError, JsDependencies, SolDependencies, Template},
@@ -22,6 +21,7 @@ use crate::{
     utils::{
         parse_toml::{add_deps_to_foundry_toml, get_src_from_str},
         path::{copy_dir_to, find_foundry_root},
+        url::update_prover_url,
     },
     version,
 };
@@ -275,45 +275,6 @@ fn add_fs_permissions_to_foundry_toml(root_path: &Path) -> Result<(), std::io::E
     )
 }
 
-fn update_prover_url(root_path: &Path) -> Result<(), crate::errors::Error> {
-    let env_files = ["vlayer/.env.testnet", "vlayer/.env.mainnet"];
-
-    for env_file in env_files {
-        let env_path = root_path.join(env_file);
-
-        if env_path.exists() {
-            info!("Updating prover URL in {}", env_file);
-
-            let content = fs::read_to_string(&env_path)?;
-            let channel = if is_stable() { "stable" } else { "nightly" };
-            let version_str = is_stable().then(version);
-            let output =
-                modify_url_with_channel_and_version(&content, channel, version_str.as_deref())?;
-            fs::write(env_path, output)?;
-        } else {
-            info!("{} file not found in \"{}\". Skipping update.", env_file, root_path.display());
-        }
-    }
-
-    Ok(())
-}
-
-fn modify_url_with_channel_and_version(
-    file_content: &str,
-    channel: &str,
-    version: Option<&str>,
-) -> Result<String, regex::Error> {
-    // Match URLs with or without existing version paths
-    let re = Regex::new(r"https://(stable|nightly|dev)-([^.]+)\.vlayer\.xyz(?:/[^\s]*)?/?")?;
-
-    let replacement = match version {
-        Some(v) => format!("https://{channel}-$2.vlayer.xyz/{v}/"),
-        None => format!("https://{channel}-$2.vlayer.xyz"),
-    };
-
-    Ok(re.replace_all(file_content, replacement).to_string())
-}
-
 fn init_soldeer(root_path: &Path) -> CLIResult<()> {
     add_deps_to_gitignore(root_path)?;
     add_deps_section_to_foundry_toml(root_path)?;
@@ -463,93 +424,6 @@ mod tests {
         let (_temp_dir, src_path, root_path) = prepare_foundry_dir(src);
         let path = find_src_path(&root_path).unwrap();
         assert_eq!(path, src_path);
-    }
-
-    mod test_modify_url_with_channel_and_version {
-        use super::*;
-
-        #[test]
-        fn stable_with_version() {
-            let content = "PROVER_URL=https://stable-fake-prover.vlayer.xyz";
-            let modified_url =
-                modify_url_with_channel_and_version(content, "stable", Some("1.3.0")).unwrap();
-            assert_eq!(modified_url, "PROVER_URL=https://stable-fake-prover.vlayer.xyz/1.3.0/");
-        }
-
-        #[test]
-        fn nightly_without_version() {
-            let content = "PROVER_URL=https://nightly-fake-prover.vlayer.xyz";
-            let modified_url =
-                modify_url_with_channel_and_version(content, "nightly", None).unwrap();
-            assert_eq!(modified_url, "PROVER_URL=https://nightly-fake-prover.vlayer.xyz");
-        }
-
-        #[test]
-        fn stable_url_with_existing_version() {
-            let content = "PROVER_URL=https://stable-fake-prover.vlayer.xyz/0.9.0/";
-            let modified_url =
-                modify_url_with_channel_and_version(content, "stable", Some("1.3.0")).unwrap();
-            assert_eq!(modified_url, "PROVER_URL=https://stable-fake-prover.vlayer.xyz/1.3.0/");
-        }
-
-        #[test]
-        fn change_channel_stable_to_nightly_remove_version() {
-            let content = "PROVER_URL=https://stable-fake-prover.vlayer.xyz/1.2.0/";
-            let modified_url =
-                modify_url_with_channel_and_version(content, "nightly", None).unwrap();
-            assert_eq!(modified_url, "PROVER_URL=https://nightly-fake-prover.vlayer.xyz");
-        }
-
-        #[test]
-        fn change_channel_nightly_to_stable_add_version() {
-            let content = "PROVER_URL=https://nightly-fake-prover.vlayer.xyz";
-            let modified_url =
-                modify_url_with_channel_and_version(content, "stable", Some("2.0.0")).unwrap();
-            assert_eq!(modified_url, "PROVER_URL=https://stable-fake-prover.vlayer.xyz/2.0.0/");
-        }
-
-        #[test]
-        fn env_file_with_version() {
-            let content = "CHAIN_NAME=optimismSepolia\nPROVER_URL=https://stable-fake-prover.vlayer.xyz\nJSON_RPC_URL=https://sepolia.optimism.io\n";
-            let modified_url =
-                modify_url_with_channel_and_version(content, "stable", Some("1.5.0")).unwrap();
-            assert_eq!(
-                modified_url,
-                "CHAIN_NAME=optimismSepolia\nPROVER_URL=https://stable-fake-prover.vlayer.xyz/1.5.0/\nJSON_RPC_URL=https://sepolia.optimism.io\n"
-            );
-        }
-
-        #[test]
-        fn url_with_trailing_slash() {
-            let content = "PROVER_URL=https://stable-fake-prover.vlayer.xyz/";
-            let modified_url =
-                modify_url_with_channel_and_version(content, "stable", Some("1.3.0")).unwrap();
-            assert_eq!(modified_url, "PROVER_URL=https://stable-fake-prover.vlayer.xyz/1.3.0/");
-        }
-
-        #[test]
-        fn url_with_complex_existing_path() {
-            let content = "PROVER_URL=https://stable-fake-prover.vlayer.xyz/old/version/1.0.0";
-            let modified_url =
-                modify_url_with_channel_and_version(content, "stable", Some("2.1.0")).unwrap();
-            assert_eq!(modified_url, "PROVER_URL=https://stable-fake-prover.vlayer.xyz/2.1.0/");
-        }
-
-        #[test]
-        fn no_url() {
-            let content = "some random text";
-            let modified_url =
-                modify_url_with_channel_and_version(content, "stable", Some("1.0.0")).unwrap();
-            assert_eq!(modified_url, "some random text");
-        }
-
-        #[test]
-        fn empty() {
-            let content = "";
-            let modified_url =
-                modify_url_with_channel_and_version(content, "stable", Some("1.0.0")).unwrap();
-            assert_eq!(modified_url, "");
-        }
     }
 
     #[test]

--- a/rust/cli/src/utils/mod.rs
+++ b/rust/cli/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod parse_toml;
 pub(crate) mod path;
+pub(crate) mod url;

--- a/rust/cli/src/utils/url.rs
+++ b/rust/cli/src/utils/url.rs
@@ -1,0 +1,132 @@
+use std::{fs, path::Path};
+
+use regex::Regex;
+use tracing::info;
+use version::is_stable;
+
+use crate::{errors::Error, version};
+
+pub fn update_prover_url(root_path: &Path) -> Result<(), Error> {
+    let env_files = ["vlayer/.env.testnet", "vlayer/.env.mainnet"];
+
+    for env_file in env_files {
+        let env_path = root_path.join(env_file);
+
+        if env_path.exists() {
+            info!("Updating prover URL in {}", env_file);
+
+            let content = fs::read_to_string(&env_path)?;
+            let channel = if is_stable() { "stable" } else { "nightly" };
+            let version_str = is_stable().then(version);
+            let output =
+                modify_url_with_channel_and_version(&content, channel, version_str.as_deref())?;
+            fs::write(env_path, output)?;
+        } else {
+            info!("{} file not found in \"{}\". Skipping update.", env_file, root_path.display());
+        }
+    }
+
+    Ok(())
+}
+
+pub fn modify_url_with_channel_and_version(
+    file_content: &str,
+    channel: &str,
+    version: Option<&str>,
+) -> Result<String, regex::Error> {
+    // Match URLs with or without existing version paths
+    let re = Regex::new(r"https://(stable|nightly|dev)-([^.]+)\.vlayer\.xyz(?:/[^\s]*)?/?")?;
+
+    let replacement = match version {
+        Some(v) => format!("https://{channel}-$2.vlayer.xyz/{v}/"),
+        None => format!("https://{channel}-$2.vlayer.xyz"),
+    };
+
+    Ok(re.replace_all(file_content, replacement).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stable_with_version() {
+        let content = "PROVER_URL=https://stable-fake-prover.vlayer.xyz";
+        let modified_url =
+            modify_url_with_channel_and_version(content, "stable", Some("1.3.0")).unwrap();
+        assert_eq!(modified_url, "PROVER_URL=https://stable-fake-prover.vlayer.xyz/1.3.0/");
+    }
+
+    #[test]
+    fn nightly_without_version() {
+        let content = "PROVER_URL=https://nightly-fake-prover.vlayer.xyz";
+        let modified_url = modify_url_with_channel_and_version(content, "nightly", None).unwrap();
+        assert_eq!(modified_url, "PROVER_URL=https://nightly-fake-prover.vlayer.xyz");
+    }
+
+    #[test]
+    fn stable_url_with_existing_version() {
+        let content = "PROVER_URL=https://stable-fake-prover.vlayer.xyz/0.9.0/";
+        let modified_url =
+            modify_url_with_channel_and_version(content, "stable", Some("1.3.0")).unwrap();
+        assert_eq!(modified_url, "PROVER_URL=https://stable-fake-prover.vlayer.xyz/1.3.0/");
+    }
+
+    #[test]
+    fn change_channel_stable_to_nightly_remove_version() {
+        let content = "PROVER_URL=https://stable-fake-prover.vlayer.xyz/1.2.0/";
+        let modified_url = modify_url_with_channel_and_version(content, "nightly", None).unwrap();
+        assert_eq!(modified_url, "PROVER_URL=https://nightly-fake-prover.vlayer.xyz");
+    }
+
+    #[test]
+    fn change_channel_nightly_to_stable_add_version() {
+        let content = "PROVER_URL=https://nightly-fake-prover.vlayer.xyz";
+        let modified_url =
+            modify_url_with_channel_and_version(content, "stable", Some("2.0.0")).unwrap();
+        assert_eq!(modified_url, "PROVER_URL=https://stable-fake-prover.vlayer.xyz/2.0.0/");
+    }
+
+    #[test]
+    fn env_file_with_version() {
+        let content = "CHAIN_NAME=optimismSepolia\nPROVER_URL=https://stable-fake-prover.vlayer.xyz\nJSON_RPC_URL=https://sepolia.optimism.io\n";
+        let modified_url =
+            modify_url_with_channel_and_version(content, "stable", Some("1.5.0")).unwrap();
+        assert_eq!(
+            modified_url,
+            "CHAIN_NAME=optimismSepolia\nPROVER_URL=https://stable-fake-prover.vlayer.xyz/1.5.0/\nJSON_RPC_URL=https://sepolia.optimism.io\n"
+        );
+    }
+
+    #[test]
+    fn url_with_trailing_slash() {
+        let content = "PROVER_URL=https://stable-fake-prover.vlayer.xyz/";
+        let modified_url =
+            modify_url_with_channel_and_version(content, "stable", Some("1.3.0")).unwrap();
+        assert_eq!(modified_url, "PROVER_URL=https://stable-fake-prover.vlayer.xyz/1.3.0/");
+    }
+
+    #[test]
+    fn url_with_complex_existing_path() {
+        let content = "PROVER_URL=https://stable-fake-prover.vlayer.xyz/old/version/1.0.0";
+        let modified_url =
+            modify_url_with_channel_and_version(content, "stable", Some("2.1.0")).unwrap();
+        assert_eq!(modified_url, "PROVER_URL=https://stable-fake-prover.vlayer.xyz/2.1.0/");
+    }
+
+    #[test]
+    fn no_url() {
+        let content = "some random text";
+        let modified_url =
+            modify_url_with_channel_and_version(content, "stable", Some("1.0.0")).unwrap();
+        assert_eq!(modified_url, "some random text");
+    }
+
+    #[test]
+    fn empty() {
+        let content = "";
+        let modified_url =
+            modify_url_with_channel_and_version(content, "stable", Some("1.0.0")).unwrap();
+        assert_eq!(modified_url, "");
+    }
+}

--- a/rust/cli/src/utils/url.rs
+++ b/rust/cli/src/utils/url.rs
@@ -1,4 +1,7 @@
-use std::{fs, path::{Path, PathBuf}};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use regex::Regex;
 use tracing::info;

--- a/rust/cli/src/utils/url.rs
+++ b/rust/cli/src/utils/url.rs
@@ -22,7 +22,10 @@ pub fn update_prover_url(root_path: &Path) -> Result<(), Error> {
                 modify_url_with_channel_and_version(&content, channel, version_str.as_deref())?;
             fs::write(env_path, output)?;
         } else {
-            info!("{} file not found in \"{}\". Skipping update.", env_file, root_path.display());
+            return Err(Error::CommandExecution(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("{} file not found in \"{}\"", env_file, root_path.display()),
+            )));
         }
     }
 


### PR DESCRIPTION
This has been tested locally by:
1. Running `vlayer init`.
2. Running `vlayer update`.
3. Verifying that URLs got updated fine.

Also repeated this flow with removing .env file and seeing an error returned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The update process now automatically updates prover URLs in environment files, ensuring they reflect the correct software channel and version.
* **Bug Fixes**
  * Improved handling and validation of environment files during prover URL updates, with clear error messages if files are missing.
* **Tests**
  * Added comprehensive tests to verify prover URL updates across various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->