### PR TITLE
Update optimism sepolia info

### DIFF
--- a/examples/simple-teleport/vlayer/constants.ts
+++ b/examples/simple-teleport/vlayer/constants.ts
@@ -16,7 +16,7 @@ export const chainToTeleportConfig: Record<string, TeleportConfig> = {
       erc20BlockNumbers: "3",
     },
   },
-  sepolia: {
+  optimismSepolia: {
     tokenHolder: "0x4631d3E5803332448e0D9cBb9bF501A4C50B95ed",
     prover: {
       erc20Addresses: "0xc6e1fb449b08b26b2063c289df9bbcb79b91c992",


### PR DESCRIPTION
The current chainId has been applying for OP Sepolia but the chain name is sepolia leading to wrong chain Id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the identifier for the Optimism Sepolia chain in the teleport configuration to improve clarity. No functional changes to configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->