### PR TITLE
feat: Add ca-certificates to docker images

### DIFF
--- a/docker/call_server/Dockerfile
+++ b/docker/call_server/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir -p vlayer
 RUN tar -xzf binaries-linux-amd64.tar.gz -C vlayer
 
 FROM --platform=linux/amd64 ubuntu:24.04
-RUN apt-get update && apt-get install -y --no-install-recommends dumb-init curl
+RUN apt-get update && apt-get install -y --no-install-recommends dumb-init curl ca-certificates
 COPY --from=build /cargo-risczero/r0vm /bin/r0vm
 COPY --from=build /vlayer/bin/call_server /bin/call_server
 

--- a/docker/chain_server/Dockerfile
+++ b/docker/chain_server/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir -p vlayer
 RUN tar -xzf binaries-linux-amd64.tar.gz -C vlayer
 
 FROM --platform=linux/amd64 ubuntu:24.04
-RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
+RUN apt-get update && apt-get install -y --no-install-recommends dumb-init ca-certificates
 
 COPY --from=build /vlayer/bin/chain_server /bin/chain_server
 

--- a/docker/chain_worker/Dockerfile
+++ b/docker/chain_worker/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir -p vlayer
 RUN tar -xzf binaries-linux-amd64.tar.gz -C vlayer
 
 FROM --platform=linux/amd64 ubuntu:24.04
-RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
+RUN apt-get update && apt-get install -y --no-install-recommends dumb-init ca-certificates
 
 COPY --from=build /cargo-risczero/r0vm /bin/r0vm
 COPY --from=build /vlayer/bin/worker /bin/worker

--- a/docker/vdns_server/Dockerfile
+++ b/docker/vdns_server/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir -p vlayer
 RUN tar -xzf binaries-linux-amd64.tar.gz -C vlayer
 
 FROM --platform=linux/amd64 ubuntu:24.04
-RUN apt-get update && apt-get install -y --no-install-recommends dumb-init curl 
+RUN apt-get update && apt-get install -y --no-install-recommends dumb-init curl ca-certificates
 
 COPY --from=build /vlayer/bin/dns_server /bin/dns_server
 

--- a/docker/vlayer/Dockerfile
+++ b/docker/vlayer/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir -p vlayer
 RUN tar -xzf binaries-linux-amd64.tar.gz -C vlayer
 
 FROM --platform=linux/amd64 ubuntu:24.04
-RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
+RUN apt-get update && apt-get install -y --no-install-recommends dumb-init ca-certificates
 
 COPY --from=build /vlayer/bin/vlayer /bin/vlayer
 


### PR DESCRIPTION
- The `ca-certificates` are added to first stages of the docker images, but not to the final one.
- The certificates are needed in the call_server to make calls to L2 RPC endpoints. This is only used when using the teleport feature.
- The problem surfaces when using `jsonrpsee::proc_macros::rpc::client`. It's only used in this one place in our codebase.
- Added `ca-certificates` to all docker images, I think it's reasonable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server and worker environments to include CA certificates, ensuring support for secure HTTPS connections across all relevant services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->