### PR TITLE
fix: jsx error with step.component

### DIFF
--- a/examples/simple-web-proof/vlayer/src/App.tsx
+++ b/examples/simple-web-proof/vlayer/src/App.tsx
@@ -75,7 +75,7 @@ const App = () => {
                       <Route
                         key={step.path}
                         path={step.path}
-                        element={<step.component />}
+                        element={React.createElement(step.component)}
                       />
                     ))}
                   </Route>

--- a/examples/simple-web-proof/vlayer/src/App.tsx
+++ b/examples/simple-web-proof/vlayer/src/App.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { steps } from "./utils/steps";
 import { WagmiProvider } from "wagmi";
 import { ProofProvider } from "@vlayer/react";


### PR DESCRIPTION
jsx doesn't support `<step.component />`, changed to `<Component />` with assignment. works now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Changed how route components are instantiated to improve internal consistency; no changes to public APIs, exported entities, or user-visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->