### PR TITLE
fix(anchor_status): Update base finalization time

### DIFF
--- a/rust/services/call/anchor_status/src/main.rs
+++ b/rust/services/call/anchor_status/src/main.rs
@@ -24,11 +24,11 @@ lazy_static::lazy_static! {
     static ref PROVIDER_FACTORY: EthersProviderFactory = EthersProviderFactory::new(rpc_urls());
     static ref CHAIN_TO_FINALISATION_TIME: HashMap<u64, u64> = HashMap::from([
         (Chain::optimism_sepolia().id(), SEVEN_DAYS),
-        (Chain::base_sepolia().id(), THREE_AND_A_HALF_DAYS),
+        (Chain::base_sepolia().id(), SEVEN_DAYS),
         (Chain::from_named(NamedChain::WorldSepolia).id(), THREE_AND_A_HALF_DAYS),
         (Chain::from_named(NamedChain::UnichainSepolia).id(), SEVEN_DAYS),
         (Chain::optimism_mainnet().id(), SEVEN_DAYS),
-        (Chain::base_mainnet().id(), THREE_AND_A_HALF_DAYS),
+        (Chain::base_mainnet().id(), SEVEN_DAYS),
         (Chain::from_named(NamedChain::World).id(), THREE_AND_A_HALF_DAYS),
         (Chain::from_named(NamedChain::Unichain).id(), SEVEN_DAYS),
     ]);


### PR DESCRIPTION
1. https://l2beat.com/scaling/projects/base?utm_source=chatgpt.com#withdrawals - withdrawals on base are possible after 7 days.
2. Base `AnchorStateRegistry` consistently has anchors that are 7 days old.

Based on this premises it makes sense to increase base finalization time to 7 days.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the finalization time for Base Sepolia and Base Mainnet chains to seven days, affecting anchor state liveliness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->