### PR TITLE
fix: Update the teleport example block on optimism

### DIFF
--- a/examples/simple-teleport/vlayer/constants.ts
+++ b/examples/simple-teleport/vlayer/constants.ts
@@ -29,7 +29,7 @@ export const chainToTeleportConfig: Record<string, TeleportConfig> = {
     prover: {
       erc20Addresses: "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
       erc20ChainIds: "10",
-      erc20BlockNumbers: "138820000",
+      erc20BlockNumbers: "138585630",
     },
   },
 };


### PR DESCRIPTION
Done in order to match with the current `AnchorStateRegistry` values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the mainnet ERC20 block number to reflect the latest value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->