### PR TITLE
chore: allow to specify notary tag in docker compose

### DIFF
--- a/docker/web-proof/docker-compose-release.yaml
+++ b/docker/web-proof/docker-compose-release.yaml
@@ -6,7 +6,7 @@ services:
       - "3003:80"
     command: "80 lotr-api.online:3011"
   notary-server:
-    image: ghcr.io/tlsnotary/tlsn/notary-server:v0.1.0-alpha.11
+    image: ghcr.io/tlsnotary/tlsn/notary-server:${NOTARY_TAG:-v0.1.0-alpha.11}
     ports:
       - "7047:7047"
     volumes:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made the notary server image version configurable via an environment variable in the release deployment configuration. This enables dynamic version selection with a sensible default, simplifying upgrades, rollbacks, and environment-specific deployments without modifying configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->