### PR TITLE
ci: Adjust backpropagation

### DIFF
--- a/ansible/host_vars/stable_prod_chain_service.yml
+++ b/ansible/host_vars/stable_prod_chain_service.yml
@@ -47,7 +47,7 @@ chain_workers:
     chain_worker_rpc_url: https://clean-proud-spring.optimism.quiknode.pro/{{ vlayer_quicknode_api_key }}
     chain_worker_chain_id: 10
     chain_worker_proof_mode: succinct
-    chain_worker_max_back_propagation_blocks: 10
+    chain_worker_max_back_propagation_blocks: 0
     chain_worker_max_head_blocks: 100
     chain_worker_confirmations: 8
     chain_worker_bonsai_api_url: "https://api.bonsai.xyz/"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated production configuration for the Optimism network, setting block back-propagation to zero.
  - This adjusts how recent blocks are processed on Optimism and may slightly change processing latency and reprocessing behavior.
  - No user-facing interface changes; functionality remains the same. No action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->