### PR TITLE
docs: fix typo 'EVM-comptable' → 'EVM-compatible'

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Our four core features include:
 - [Web Proofs](https://book.vlayer.xyz/features/web.html): Access verified web data, including APIs and websites, in your smart contracts 
 - [Email Proofs](https://book.vlayer.xyz/features/email.html): Tap into email content from your smart contracts and use it on-chain
 - [Time Travel](https://book.vlayer.xyz/features/time-travel.html): Leverage historical on-chain data in your smart contracts
-- [Teleport](https://book.vlayer.xyz/features/teleport.html): Execute a smart contract across different EVM-comptable blockchain networks
+- [Teleport](https://book.vlayer.xyz/features/teleport.html): Execute a smart contract across different EVM-compatible blockchain networks
 
 ## Getting started
 

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -8,7 +8,7 @@ Our four core features include:
 - [Web Proofs](/features/web.html): Access verified web data, including APIs and websites, in your smart contracts 
 - [Email Proofs](/features/email.html): Tap into email content from your smart contracts and use it on-chain
 - [Time Travel](/features/time-travel.html): Leverage historical on-chain data in your smart contracts
-- [Teleport](/features/teleport.html): Execute a smart contract across different EVM-comptable blockchain networks
+- [Teleport](/features/teleport.html): Execute a smart contract across different EVM-compatible blockchain networks
 
 vlayer allows smart contracts to be executed [off-chain](/advanced/prover.html). The result of the execution can then be used by [on-chain contracts](/advanced/verifier.html).
 


### PR DESCRIPTION
## Description
This PR fixes a spelling typo in the documentation where **"EVM-comptable"** was incorrectly spelled.  
Corrected to **"EVM-compatible"** in:

- `README.md` line 8
- `book/src/introduction.md` line 11

## Related Issue
Closes #2591

## Type of Change
- [x] Documentation (typos, wording, etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed typo in the Teleport feature description: “EVM-comptable blockchain networks” → “EVM-compatible blockchain networks.”
  * Applied the correction across overview and introduction pages for consistent terminology.
  * No functional or API changes; content, links, and examples unchanged.
  * Improves clarity and professionalism of user-facing docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->