### PR TITLE
fix: Don't disable other namespaces when adding an `:info` default in the examples

### DIFF
--- a/examples/kraken-web-proof/vlayer/prove.ts
+++ b/examples/kraken-web-proof/vlayer/prove.ts
@@ -18,7 +18,7 @@ const createLogger = (namespace: string) => {
 
   // Enable info logs by default
   if (!debug.enabled(namespace + ":info")) {
-    debug.enable(namespace + ":info");
+    debug.enable(`${debug.disable()},${namespace}:info`);
   }
 
   return {

--- a/examples/simple-email-proof/vlayer/prove.ts
+++ b/examples/simple-email-proof/vlayer/prove.ts
@@ -19,7 +19,7 @@ const createLogger = (namespace: string) => {
 
   // Enable info logs by default
   if (!debug.enabled(namespace + ":info")) {
-    debug.enable(namespace + ":info");
+    debug.enable(`${debug.disable()},${namespace}:info`);
   }
 
   return {

--- a/examples/simple-teleport/vlayer/prove.ts
+++ b/examples/simple-teleport/vlayer/prove.ts
@@ -19,7 +19,7 @@ const createLogger = (namespace: string) => {
 
   // Enable info logs by default
   if (!debug.enabled(namespace + ":info")) {
-    debug.enable(namespace + ":info");
+    debug.enable(`${debug.disable()},${namespace}:info`);
   }
 
   return {

--- a/examples/simple-time-travel/vlayer/prove.ts
+++ b/examples/simple-time-travel/vlayer/prove.ts
@@ -18,7 +18,7 @@ const createLogger = (namespace: string) => {
 
   // Enable info logs by default
   if (!debug.enabled(namespace + ":info")) {
-    debug.enable(namespace + ":info");
+    debug.enable(`${debug.disable()},${namespace}:info`);
   }
 
   return {

--- a/examples/simple-web-proof/vlayer/prove.ts
+++ b/examples/simple-web-proof/vlayer/prove.ts
@@ -21,7 +21,7 @@ const createLogger = (namespace: string) => {
 
   // Enable info logs by default
   if (!debug.enabled(namespace + ":info")) {
-    debug.enable(namespace + ":info");
+    debug.enable(`${debug.disable()},${namespace}:info`);
   }
 
   return {

--- a/examples/simple/vlayer/prove.ts
+++ b/examples/simple/vlayer/prove.ts
@@ -18,7 +18,7 @@ const createLogger = (namespace: string) => {
 
   // Enable info logs by default
   if (!debug.enabled(namespace + ":info")) {
-    debug.enable(namespace + ":info");
+    debug.enable(`${debug.disable()},${namespace}:info`);
   }
 
   return {


### PR DESCRIPTION
`debug.enable()` overrides all previously configured namespaces.
When the user specifies a `xxx:debug` namespace, this default removes it.
The PR contains a fix to only append the `:info` default, preserving the previously configured namespaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved logging behavior across example apps: enabling info logs no longer overrides existing debug namespace settings, resulting in more predictable and consistent output.
  - Preserves previously configured debug namespaces when turning on info-level logs in examples.

- Chores
  - Aligned logger behavior across multiple examples for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->