### PR TITLE
ci: Change approach of detecting fork permissions

### DIFF
--- a/.github/workflows/performance_rust_compilation.yaml
+++ b/.github/workflows/performance_rust_compilation.yaml
@@ -14,30 +14,13 @@ concurrency:
   # Do not cancel jobs on main by forcing a unique group name.
   group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.run_id || github.ref_name }}
   cancel-in-progress: true
-permissions:
-  contents: read
-  pull-requests: write
 
 jobs:
-  permissions:
-    runs-on: ubuntu-latest
-    outputs:
-      has-permissions: ${{ steps.check-permissions.outputs.require-result }}
-    steps:
-      - name: Check user permissions
-        id: check-permissions
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
-
   performance-rust-compilation:
     name: Rust incremental compilation performance
     runs-on: aws-linux-medium
-    needs: permissions
-    if: needs.permissions.outputs.has-permissions == 'true'
+    # Don't run this test on forked PRs because of required secrets - it will get tested in the merge queue.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test_e2e_sepolias.yaml
+++ b/.github/workflows/test_e2e_sepolias.yaml
@@ -27,27 +27,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  permissions:
-    runs-on: ubuntu-latest
-    outputs:
-      has-permissions: ${{ steps.check-permissions.outputs.require-result }}
-    steps:
-      - name: Check user permissions
-        id: check-permissions
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
-
   changes:
     runs-on: ubuntu-latest
-    needs: permissions
     outputs:
       code-changes: ${{ steps.filter.outputs.code-changes }}
       workflow-changes: ${{ steps.filter.outputs.workflow-changes }}
-    if: needs.permissions.outputs.has-permissions == 'true'
+    # Don't run this test on forked PRs because of required secrets - it will get tested in the merge queue.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -83,11 +69,11 @@ jobs:
   # `rust/zkvm-benchmarks/benchmarks/src/benchmarks/precompiles/gas_price_checker.rs`
   check-gas:
     name: Check gas price
-    needs: permissions
     runs-on: ubuntu-latest
     outputs:
       gas-ok: ${{ steps.set-result.outputs.gas-ok }}
-    if: needs.permissions.outputs.has-permissions == 'true'
+    # Don't run this test on forked PRs because of required secrets - it will get tested in the merge queue.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test_e2e_web_apps.yaml
+++ b/.github/workflows/test_e2e_web_apps.yaml
@@ -12,26 +12,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  permissions:
-    runs-on: ubuntu-latest
-    outputs:
-      has-permissions: ${{ steps.check-permissions.outputs.require-result }}
-    steps:
-      - name: Check user permissions
-        id: check-permissions
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
-
   changes:
     runs-on: ubuntu-latest
-    needs: permissions
     outputs:
       relevant-changes: ${{ steps.filter.outputs.relevant-changes }}
-    if: needs.permissions.outputs.has-permissions == 'true'
+    # Don't run this test on forked PRs because of required secrets - it will get tested in the merge queue.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test_e2e_web_apps_opsepolia.yaml
+++ b/.github/workflows/test_e2e_web_apps_opsepolia.yaml
@@ -20,27 +20,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  permissions:
-    runs-on: ubuntu-latest
-    outputs:
-      has-permissions: ${{ steps.check-permissions.outputs.require-result }}
-    steps:
-      - name: Check user permissions
-        id: check-permissions
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
-
   changes:
     runs-on: ubuntu-latest
-    needs: permissions
     outputs:
       code-changes: ${{ steps.filter.outputs.code-changes }}
       workflow-changes: ${{ steps.filter.outputs.workflow-changes }}
-    if: needs.permissions.outputs.has-permissions == 'true'
+    # Don't run this test on forked PRs because of required secrets - it will get tested in the merge queue.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test_e2e_web_flow.yaml
+++ b/.github/workflows/test_e2e_web_flow.yaml
@@ -6,26 +6,12 @@ on:
     branches:
       - main
 jobs:
-  permissions:
-    runs-on: ubuntu-latest
-    outputs:
-      has-permissions: ${{ steps.check-permissions.outputs.require-result }}
-    steps:
-      - name: Check user permissions
-        id: check-permissions
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
-
   changes:
     runs-on: ubuntu-latest
-    needs: permissions
     outputs:
       relevant-changes: ${{ steps.filter.outputs.relevant-changes }}
-    if: needs.permissions.outputs.has-permissions == 'true'
+    # Don't run this test on forked PRs because of required secrets - it will get tested in the merge queue.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Instead of detecting a `github.actor` (which can be misleading when the fork authored allowed edits to his fork, and we help out by commiting to the fork), change the approach to more specifically checking if this is a fork or not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Tests
  - Adjusted E2E workflow execution rules: runs on pushes and same-repo PRs; forked PRs are skipped due to secrets. No change to test coverage when executed.

- Chores
  - Simplified CI by removing explicit permission checks and streamlining gating conditions across performance and E2E workflows.
  - Added clarifying comments about forked PR behavior and merge-queue coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->