### PR TITLE
fix: drop `debug.disable()`

### DIFF
--- a/examples/kraken-web-proof/vlayer/prove.ts
+++ b/examples/kraken-web-proof/vlayer/prove.ts
@@ -18,7 +18,7 @@ const createLogger = (namespace: string) => {
 
   // Enable info logs by default
   if (!debug.enabled(namespace + ":info")) {
-    debug.enable(`${debug.disable()},${namespace}:info`);
+    debug.enable(`${namespace}:info`);
   }
 
   return {


### PR DESCRIPTION
`debug.disable()` is gone in newer versions and was breaking TS.
switched to toggling via `DEBUG` env directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Info-level logging now enables only the intended namespace, preventing unrelated debug logs from being activated.
  * Reduces console noise for clearer, more targeted output during proof runs.
  * Minimizes unexpected overhead from unnecessary log processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->