### PR TITLE
docs: update Forge command to remove `soldeer` typo

### DIFF
--- a/book/src/getting-started/first-steps.md
+++ b/book/src/getting-started/first-steps.md
@@ -58,7 +58,7 @@ forge build
 ```
 This compiles the smart contracts and prepares them for deployment and testing.
 
-> Please note that `vlayer init` installs Solidity dependencies and generates `remappings.txt`. Running `forge soldeer install` is not needed to build the example and may overwrite remappings, which can cause build errors.
+> Please note that `vlayer init` installs Solidity dependencies and generates `remappings.txt`. Running `forge install` is not needed to build the example and may overwrite remappings, which can cause build errors.
 
 Then, install Typescript dependencies in vlayer folder by running:
 ```bash


### PR DESCRIPTION
noticed that the command `forge soldeer install` contains a typo - `soldeer` isn’t a valid Forge command.
the context doesn’t require any additional installation, so I corrected it to `soldier`.
this should prevent confusion for anyone following the instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the command in the “Running examples” section from “forge soldeer install” to the accurate “forge install” to prevent setup errors.
  * Improved formatting with a blockquote for the note, enhancing readability and clarity for users following the steps.
  * No functional changes to examples or workflows; guidance is now more precise and easier to follow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->