### PR TITLE
docs: update React link

### DIFF
--- a/book/src/javascript/react-hooks.md
+++ b/book/src/javascript/react-hooks.md
@@ -6,7 +6,7 @@ These hooks provide functions that help manage state and side effects in React c
 
 ## Prerequisites
 The following libraries are required to use `@vlayer/react`:
-- [React](https://reactjs.org/docs/getting-started.html): A library for building user interfaces.
+- [React](https://react.dev/learn): A library for building user interfaces.
 - [Wagmi](https://wagmi.sh/react/getting-started): A library of React hooks for Ethereum.
 - [TanStack Query](https://tanstack.com/query/latest): A library for efficient data fetching and caching.
 


### PR DESCRIPTION
The React link was old - switched it to the latest one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the React prerequisite link in the React Hooks guide to the current React.dev learning page. Readers are now directed to the most accurate, up-to-date learning resource, improving onboarding and reducing confusion from outdated links. The visible link text remains the same, and no other content in the guide was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->