### PR TITLE
fix: update broken link in prover.rs

### DIFF
--- a/rust/services/call/host/src/host/prover.rs
+++ b/rust/services/call/host/src/host/prover.rs
@@ -43,7 +43,7 @@ fn build_executor_env(
             Ok::<_, anyhow::Error>(builder)
         })?
         .write(&input)?
-        // Workaround for r0vm bug reproed in: https://github.com/vlayer-xyz/risc0-r0vm-fake-repro
+        // Workaround for r0vm bug reproed in: https://github.com/vlayer-xyz/risc0-ring-repro
         .segment_limit_po2(22)
         .build()
 }


### PR DESCRIPTION
https://github.com/vlayer-xyz/risc0-r0vm-fake-repro - broken
https://github.com/vlayer-xyz/risc0-ring-repro - actual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated an internal reference link for a known issue to point to the latest source, improving clarity and maintainability of developer-facing notes.
  - No changes to functionality, performance, or user experience.
  - No impact on configuration, APIs, or compatibility.
  - This update is informational only; end users do not need to take any action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->