### PR TITLE
docs: fixed wording in Proving args

### DIFF
--- a/book/src/javascript/javascript.md
+++ b/book/src/javascript/javascript.md
@@ -47,11 +47,11 @@ const vlayer = createVlayerClient();
 ## Proving
 
 In order to start proving, we will need to provide:
-- `address` - an address of prover contract
-- `proverAbi` - abi of prover contract
-- `functionName` - name of prover contract function to call
+- `address` - the address of the prover contract
+- `proverAbi` - the ABI of the prover contract
+- `functionName` - the name of the prover contract function to call
 - `args` - an array of arguments to `functionName` prover contract function 
-- `chainId` - id of the chain in whose context the prover contract call shall be executed
+- `chainId` - the ID of the chain in which the prover contract call will be executed
 
 ```ts
 const hash = await vlayer.prove({


### PR DESCRIPTION
cleaned up the docs in **Proving**: fixed articles and style so the argument descriptions read more natural and consistent. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified parameter descriptions in the Proving section of the JavaScript docs for improved readability and accuracy.
  * Updated wording for: address (prover contract address), proverAbi (prover contract ABI), functionName (prover contract function to call), and chainId (ID of the target chain).
  * No changes to parameter names, behavior, or semantics; other content in the section remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->