### PR TITLE
ci: Use pinned chain services in prover

### DIFF
--- a/ansible/host_vars/stable_fake_prover.yml
+++ b/ansible/host_vars/stable_fake_prover.yml
@@ -61,14 +61,14 @@ vlayer_prover_chain_proof_latest_url: "{{ vlayer_prover_chain_proof_base_url }}/
 prover_docker_containers:
  - version: "1.4.0"
    port: 4002
-   chain_proof_url: "{{ vlayer_prover_chain_proof_base_url }}"
+   chain_proof_url: "{{ vlayer_prover_chain_proof_base_url }}/1.4.3/"
  - version: "1.4.1"
    port: 4003
-   chain_proof_url: "{{ vlayer_prover_chain_proof_base_url }}"
+   chain_proof_url: "{{ vlayer_prover_chain_proof_base_url }}/1.4.3/"
  - version: "1.4.2"
    port: 4004
-   chain_proof_url: "{{ vlayer_prover_chain_proof_base_url }}"
+   chain_proof_url: "{{ vlayer_prover_chain_proof_base_url }}/1.4.3/"
  - version: "1.4.3"
    port: 4005
-   chain_proof_url: "{{ vlayer_prover_chain_proof_base_url }}"
+   chain_proof_url: "{{ vlayer_prover_chain_proof_base_url }}/1.4.3/"
 prover_nginx_default_prover_port: 4005

--- a/ansible/host_vars/stable_prod_prover.yml
+++ b/ansible/host_vars/stable_prod_prover.yml
@@ -71,14 +71,14 @@ vlayer_prover_chain_proof_latest_url: "{{ vlayer_prover_chain_proof_base_url }}/
 prover_docker_containers:
  - version: "1.4.0"
    port: 4002
-   chain_proof_url: "{{ vlayer_prover_chain_proof_base_url }}"
+   chain_proof_url: "{{ vlayer_prover_chain_proof_base_url }}/1.4.3/"
  - version: "1.4.1"
    port: 4003
-   chain_proof_url: "{{ vlayer_prover_chain_proof_base_url }}"
+   chain_proof_url: "{{ vlayer_prover_chain_proof_base_url }}/1.4.3/"
  - version: "1.4.2"
    port: 4004
-   chain_proof_url: "{{ vlayer_prover_chain_proof_base_url }}"
+   chain_proof_url: "{{ vlayer_prover_chain_proof_base_url }}/1.4.3/"
  - version: "1.4.3"
    port: 4005
-   chain_proof_url: "{{ vlayer_prover_chain_proof_base_url }}"
+   chain_proof_url: "{{ vlayer_prover_chain_proof_base_url }}/1.4.3/"
 prover_nginx_default_prover_port: 4005


### PR DESCRIPTION
- [x] Before merging, wait for chain services deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated configuration to use versioned 1.4.3 chain proof endpoints across stable and production environments, ensuring consistent behavior across prover versions. The “latest” endpoint remains unchanged.

- Impact
  - Improves reliability and predictability of proof retrieval with no user-facing workflow changes or actions required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->