### PR TITLE
fix: update broken unichain-sepolia configuration link

### DIFF
--- a/rust/chain/chain_specs.toml
+++ b/rust/chain/chain_specs.toml
@@ -77,7 +77,7 @@ forks = [
     { spec = "GRANITE", activation = { Timestamp = 1727780400 } },
 ]
 
-# https://github.com/Uniswap/unichain-node/blob/main/chainconfig/sepolia/genesis-l2.json
+# https://docs.unichain.org/docs/technical-information/network-information
 # https://docs.unichain.org/docs/technical-information/contract-addresses
 [[chains]]
 name = "unichain-sepolia"


### PR DESCRIPTION
Replace broken GitHub link to genesis.json file with official Unichain documentation link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated the in-file reference link for network information to the latest Unichain documentation, replacing an outdated source.
  * This is a comment-only update intended to improve clarity and maintainability.
  * No functional or configuration changes; app behavior remains unchanged.
  * No user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->