### PR TITLE
refactor: rename static variable to follow Rust naming conventions

### DIFF
--- a/rust/services/call/rpc/src/lib.rs
+++ b/rust/services/call/rpc/src/lib.rs
@@ -22,27 +22,27 @@ fn get_quicknode_key() -> String {
 }
 
 lazy_static! {
-    static ref alchemy_key: String = get_alchemy_key();
+    static ref ALCHEMY_KEY: String = get_alchemy_key();
     static ref mainnet_url: String =
-        format!("https://eth-mainnet.g.alchemy.com/v2/{}", *alchemy_key);
+        format!("https://eth-mainnet.g.alchemy.com/v2/{}", *ALCHEMY_KEY);
     static ref sepolia_url: String =
-        format!("https://eth-sepolia.g.alchemy.com/v2/{}", *alchemy_key);
+        format!("https://eth-sepolia.g.alchemy.com/v2/{}", *ALCHEMY_KEY);
     static ref op_mainnet_url: String =
-        format!("https://opt-mainnet.g.alchemy.com/v2/{}", *alchemy_key);
+        format!("https://opt-mainnet.g.alchemy.com/v2/{}", *ALCHEMY_KEY);
     static ref op_sepolia_url: String =
-        format!("https://opt-sepolia.g.alchemy.com/v2/{}", *alchemy_key);
+        format!("https://opt-sepolia.g.alchemy.com/v2/{}", *ALCHEMY_KEY);
     static ref base_mainnet_url: String =
-        format!("https://base-mainnet.g.alchemy.com/v2/{}", *alchemy_key);
+        format!("https://base-mainnet.g.alchemy.com/v2/{}", *ALCHEMY_KEY);
     static ref base_sepolia_url: String =
-        format!("https://base-sepolia.g.alchemy.com/v2/{}", *alchemy_key);
+        format!("https://base-sepolia.g.alchemy.com/v2/{}", *ALCHEMY_KEY);
     static ref world_sepolia_url: String =
-        format!("https://worldchain-sepolia.g.alchemy.com/v2/{}", *alchemy_key);
+        format!("https://worldchain-sepolia.g.alchemy.com/v2/{}", *ALCHEMY_KEY);
     static ref world_mainnet_url: String =
-        format!("https://worldchain-mainnet.g.alchemy.com/v2/{}", *alchemy_key);
+        format!("https://worldchain-mainnet.g.alchemy.com/v2/{}", *ALCHEMY_KEY);
     static ref unichain_sepolia_url: String =
-        format!("https://unichain-sepolia.g.alchemy.com/v2/{}", *alchemy_key);
+        format!("https://unichain-sepolia.g.alchemy.com/v2/{}", *ALCHEMY_KEY);
     static ref unichain_mainnet_url: String =
-        format!("https://unichain-mainnet.g.alchemy.com/v2/{}", *alchemy_key);
+        format!("https://unichain-mainnet.g.alchemy.com/v2/{}", *ALCHEMY_KEY);
     static ref anvil_url: String = format!("http://localhost:8545");
     static ref op_anvil_url: String = format!("http://localhost:8546");
     static ref quicknode_key: String = get_quicknode_key();


### PR DESCRIPTION
Change `alchemy_key` to `ALCHEMY_KEY` in lazy_static block to comply with Rust RFC 430 naming conventions for static variables.

This fixes potential clippy::non_upper_case_globals warnings and improves code consistency with Rust standards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal constant naming for configuration keys to improve consistency.
  * Adjusted internal URL construction to align with updated naming, with no functional changes.

* **Chores**
  * Minor code cleanup to enhance maintainability.

No user-facing changes or API modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->