### PR TITLE
feat: Add a way to override rollup endpoints

### DIFF
--- a/ansible/host_vars/nightly_fake_prover.yml
+++ b/ansible/host_vars/nightly_fake_prover.yml
@@ -21,8 +21,8 @@ vlayer_alchemy_api_key: !vault |
   63343030643438373066326432356565363534623131306166383939656563623537656535626161
   6164386166343532386262626237643763623366376537663030
 vlayer_prover_rpc_urls:
- - "11155111:https://omniscient-flashy-frog.ethereum-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
- - "11155420:https://omniscient-flashy-frog.optimism-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
+ - "11155111:https://eth-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
+ - "11155420:https://opt-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
  # Base mainnet remains in fake provers for the time being, supporting one use case.
  - "8453:https://omniscient-flashy-frog.base-mainnet.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
  - "84532:https://omniscient-flashy-frog.base-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
@@ -59,3 +59,4 @@ vlayer_prover_gas_meter_api_key: !vault |
   333634303764653162643233336133656661
 vlayer_prover_chain_proof_base_url: "https://nightly-fake-chainservice.vlayer.xyz"
 vlayer_prover_chain_proof_latest_url: "{{ vlayer_prover_chain_proof_base_url }}/latest/"
+vlayer_prover_optimism_sepolia_rollup_endpoint: "https://omniscient-flashy-frog.optimism-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"

--- a/ansible/prover.yml
+++ b/ansible/prover.yml
@@ -55,6 +55,7 @@
         prover_docker_jwt_claims: "{{ vlayer_jwt_claims }}"
         prover_docker_rpc_urls: "{{ vlayer_prover_rpc_urls }}"
         prover_docker_jwt_public_key_location: "{{ vlayer_jwt_public_key_location }}"
+        prover_docker_optimism_sepolia_rollup_endpoint: "{{ vlayer_prover_optimism_sepolia_rollup_endpoint | default(omit) }}"
       when: prover_docker_containers | length > 0
       loop: "{{ prover_docker_containers }}"
       no_log: true

--- a/ansible/roles/prover_docker/README.md
+++ b/ansible/roles/prover_docker/README.md
@@ -20,3 +20,4 @@ Installs the vlayer Prover docker container.
 | `prover_docker_jwt_algorithm` | Algorithm type used in JWT.. |
 | `prover_docker_jwt_claims` | A list of JWT claims. |
 | `prover_docker_jwt_public_key_location` | Where is the JWT public key file installed. |
+| `prover_docker_optimism_sepolia_rollup_endpoint` | Optional override URL for Optimism Sepolia rollup node endpoint. |

--- a/ansible/roles/prover_docker/templates/prover.env.j2
+++ b/ansible/roles/prover_docker/templates/prover.env.j2
@@ -5,3 +5,6 @@ BONSAI_API_URL={{ prover_docker_bonsai_api_url }}
 {% if prover_docker_bonsai_api_key is defined %}
 BONSAI_API_KEY={{ prover_docker_bonsai_api_key }}
 {% endif %}
+{% if prover_docker_optimism_sepolia_rollup_endpoint is defined %}
+OPTIMISM_SEPOLIA_ROLLUP_ENDPOINT={{ prover_docker_optimism_sepolia_rollup_endpoint }}
+{% endif %}

--- a/examples/simple-teleport/vlayer/constants.ts
+++ b/examples/simple-teleport/vlayer/constants.ts
@@ -21,7 +21,7 @@ export const chainToTeleportConfig: Record<string, TeleportConfig> = {
     prover: {
       erc20Addresses: "0xc6e1fb449b08b26b2063c289df9bbcb79b91c992",
       erc20ChainIds: "11155420",
-      erc20BlockNumbers: "30665000",
+      erc20BlockNumbers: "32894867",
     },
   },
   mainnet: {


### PR DESCRIPTION
Because we use a special `optimism_outputAtBlock` method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-chain override for Optimism rollup RPC endpoints via environment variables; overrides are preferred over defaults.
  * Prover container can accept an optional Optimism Sepolia rollup endpoint via environment variable.

* **Chores**
  * Updated Sepolia Teleport starting block number to a newer value.
  * Switched two Sepolia RPC entries to different provider endpoints.

* **Documentation**
  * Added docs for the new prover endpoint variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->