### PR TITLE
chore: Add missing environment variable to systemd service

### DIFF
--- a/ansible/roles/prover/templates/vlayer.service.j2
+++ b/ansible/roles/prover/templates/vlayer.service.j2
@@ -39,6 +39,9 @@ Environment=VLAYER_PROOF_MODE={{ vlayer_proof_type }}
 {% if vlayer_prover_chain_proof_latest_url is defined %}
 Environment=VLAYER_CHAIN_CLIENT__URL={{ vlayer_prover_chain_proof_latest_url }}
 {% endif %}
+{% if vlayer_prover_optimism_sepolia_rollup_endpoint is defined %}
+Environment=OPTIMISM_SEPOLIA_ROLLUP_ENDPOINT={{ vlayer_prover_optimism_sepolia_rollup_endpoint }}
+{% endif %}
 Environment=VLAYER_AUTH__JWT__PUBLIC_KEY={{ vlayer_jwt_public_key_location }}
 Environment=VLAYER_AUTH__JWT__ALGORITHM={{ vlayer_jwt_algorithm }}
 Environment='VLAYER_AUTH__JWT__CLAIMS={{ vlayer_jwt_claims | join(' ') }}'


### PR DESCRIPTION
Follow-up to https://github.com/vlayer-xyz/vlayer/pull/2637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for configuring the Optimism Sepolia rollup endpoint via a new optional environment variable. When provided, the service will use this endpoint for connectivity.
  - Backward compatible: no changes required for existing setups unless the variable is set.
  - Improves flexibility for deployments targeting Optimism Sepolia.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->