### PR TITLE
fix: bump default blocks in teleport example

### DIFF
--- a/examples/simple-teleport/vlayer/constants.ts
+++ b/examples/simple-teleport/vlayer/constants.ts
@@ -21,7 +21,7 @@ export const chainToTeleportConfig: Record<string, TeleportConfig> = {
     prover: {
       erc20Addresses: "0xc6e1fb449b08b26b2063c289df9bbcb79b91c992",
       erc20ChainIds: "11155420",
-      erc20BlockNumbers: "32894867",
+      erc20BlockNumbers: "32936638",
     },
   },
   mainnet: {
@@ -29,7 +29,7 @@ export const chainToTeleportConfig: Record<string, TeleportConfig> = {
     prover: {
       erc20Addresses: "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
       erc20ChainIds: "10",
-      erc20BlockNumbers: "138585630",
+      erc20BlockNumbers: "141038686",
     },
   },
 };


### PR DESCRIPTION
After a `1.5.0` release which resetted the chain services, bumping the default blocks in the examples to the minimum indexed by chain workers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network configuration for Sepolia and Mainnet ERC‑20 prover block numbers to the latest values, improving compatibility and reliability for teleport operations on both networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->