### PR TITLE
fix: Add a`@wagmi/connectors` override in web examples

### DIFF
--- a/examples/simple-email-proof/vlayer/package.json
+++ b/examples/simple-email-proof/vlayer/package.json
@@ -60,6 +60,7 @@
   },
   "overrides": {
     "viem": "2.27.0",
-    "wagmi": "2.14.16"
+    "wagmi": "2.14.16",
+    "@wagmi/connectors": "5.7.12"
   }
 }

--- a/examples/simple-teleport/vlayer/package.json
+++ b/examples/simple-teleport/vlayer/package.json
@@ -61,6 +61,7 @@
   },
   "overrides": {
     "viem": "2.27.0",
-    "wagmi": "2.14.16"
+    "wagmi": "2.14.16",
+    "@wagmi/connectors": "5.7.12"
   }
 }

--- a/examples/simple-time-travel/vlayer/package.json
+++ b/examples/simple-time-travel/vlayer/package.json
@@ -60,6 +60,7 @@
   },
   "overrides": {
     "viem": "2.27.0",
-    "wagmi": "2.14.16"
+    "wagmi": "2.14.16",
+    "@wagmi/connectors": "5.7.12"
   }
 }

--- a/examples/simple-web-proof/vlayer/package.json
+++ b/examples/simple-web-proof/vlayer/package.json
@@ -65,6 +65,7 @@
   },
   "overrides": {
     "viem": "2.27.0",
-    "wagmi": "2.14.16"
+    "wagmi": "2.14.16",
+    "@wagmi/connectors": "5.7.12"
   }
 }


### PR DESCRIPTION
We were running into issues like `[ERROR] No matching export in "node_modules/viem/_esm/actions/index.js" for import "waitForCallsStatus"` in post-release tests.

The problem didn't appear inside the repo because of a global bun lock file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized dependency overrides across example apps by pinning @wagmi/connectors to version 5.7.12 alongside existing wagmi and viem pins.
  - Applied updates to package manifests in: simple-email-proof/vlayer, simple-teleport/vlayer, simple-time-travel/vlayer, and simple-web-proof/vlayer.
  - Minor formatting adjustments to JSON entries (commas/structure) in package manifests.
  - No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->