### PR TITLE
ci: Add rollup overrides to stable provers

### DIFF
--- a/ansible/host_vars/nightly_fake_prover.yml
+++ b/ansible/host_vars/nightly_fake_prover.yml
@@ -25,7 +25,7 @@ vlayer_prover_rpc_urls:
  - "11155420:https://opt-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
  # Base mainnet remains in fake provers for the time being, supporting one use case.
  - "8453:https://omniscient-flashy-frog.base-mainnet.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
- - "84532:https://omniscient-flashy-frog.base-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
+ - "84532:https://base-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
  - "4801:https://omniscient-flashy-frog.worldchain-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
  - "80002:https://polygon-amoy.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
  - "421614:https://arb-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"

--- a/ansible/host_vars/stable_fake_prover.yml
+++ b/ansible/host_vars/stable_fake_prover.yml
@@ -21,10 +21,10 @@ vlayer_alchemy_api_key: !vault |
   6164386166343532386262626237643763623366376537663030
 vlayer_prover_rpc_urls:
  - "11155111:https://omniscient-flashy-frog.ethereum-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
- - "11155420:https://omniscient-flashy-frog.optimism-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
+ - "11155420:https://opt-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
  # Base mainnet remains in fake provers for the time being, supporting one use case.
  - "8453:https://omniscient-flashy-frog.base-mainnet.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
- - "84532:https://omniscient-flashy-frog.base-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
+ - "84532:https://base-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
  - "4801:https://omniscient-flashy-frog.worldchain-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
  - "80002:https://polygon-amoy.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
  - "421614:https://arb-sepolia.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
@@ -58,6 +58,8 @@ vlayer_prover_gas_meter_api_key: !vault |
   333634303764653162643233336133656661
 vlayer_prover_chain_proof_base_url: "https://stable-fake-chainservice.vlayer.xyz"
 vlayer_prover_chain_proof_latest_url: "{{ vlayer_prover_chain_proof_base_url }}/latest/"
+vlayer_prover_optimism_sepolia_rollup_endpoint: "https://omniscient-flashy-frog.optimism-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
+vlayer_prover_base_sepolia_rollup_endpoint: "https://omniscient-flashy-frog.base-sepolia.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
 prover_docker_containers:
  - version: "1.4.0"
    port: 4002

--- a/ansible/host_vars/stable_prod_prover.yml
+++ b/ansible/host_vars/stable_prod_prover.yml
@@ -31,8 +31,8 @@ vlayer_alchemy_api_key: !vault |
   6164386166343532386262626237643763623366376537663030
 vlayer_prover_rpc_urls:
  - "1:https://eth-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
- - "8453:https://omniscient-flashy-frog.base-mainnet.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
- - "10:https://omniscient-flashy-frog.optimism.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
+ - "8453:https://base-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
+ - "10:https://opt-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
  - "480:https://omniscient-flashy-frog.worldchain-mainnet.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
  - "42161:https://arb-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
  - "42170:https://arbnova-mainnet.g.alchemy.com/v2/{{ vlayer_alchemy_api_key | trim }}"
@@ -68,6 +68,8 @@ vlayer_prover_gas_meter_api_key: !vault |
   333634303764653162643233336133656661
 vlayer_prover_chain_proof_base_url: "https://chainservice.vlayer.xyz"
 vlayer_prover_chain_proof_latest_url: "{{ vlayer_prover_chain_proof_base_url }}/latest/"
+vlayer_prover_optimism_rollup_endpoint: "https://omniscient-flashy-frog.optimism.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
+vlayer_prover_base_rollup_endpoint: "https://omniscient-flashy-frog.base-mainnet.quiknode.pro/{{ vlayer_quicknode_api_key | trim }}"
 prover_docker_containers:
  - version: "1.4.0"
    port: 4002

--- a/ansible/prover.yml
+++ b/ansible/prover.yml
@@ -56,6 +56,9 @@
         prover_docker_rpc_urls: "{{ vlayer_prover_rpc_urls }}"
         prover_docker_jwt_public_key_location: "{{ vlayer_jwt_public_key_location }}"
         prover_docker_optimism_sepolia_rollup_endpoint: "{{ vlayer_prover_optimism_sepolia_rollup_endpoint | default(omit) }}"
+        prover_docker_base_sepolia_rollup_endpoint: "{{ vlayer_prover_base_sepolia_rollup_endpoint | default(omit) }}"
+        prover_docker_optimism_rollup_endpoint: "{{ vlayer_prover_optimism_rollup_endpoint | default(omit) }}"
+        prover_docker_base_rollup_endpoint: "{{ vlayer_prover_base_rollup_endpoint | default(omit) }}"
       when: prover_docker_containers | length > 0
       loop: "{{ prover_docker_containers }}"
       no_log: true

--- a/ansible/roles/prover/README.md
+++ b/ansible/roles/prover/README.md
@@ -23,3 +23,5 @@ Installs the vlayer Prover server.
 | `vlayer_rust_log` | An array of log levels for constructing [`RUST_LOG`](https://rust-lang-nursery.github.io/rust-cookbook/development_tools/debugging/config_log.html). |
 | `vlayer_prover_optimism_sepolia_rollup_endpoint` | Optional override URL for Optimism Sepolia rollup node endpoint. |
 | `vlayer_prover_base_sepolia_rollup_endpoint` | Optional override URL for Base Sepolia rollup node endpoint. |
+| `vlayer_prover_optimism_rollup_endpoint` | Optional override URL for Optimism mainnet rollup node endpoint. |
+| `vlayer_prover_base_rollup_endpoint` | Optional override URL for Base mainnet rollup node endpoint. |

--- a/ansible/roles/prover/templates/vlayer.service.j2
+++ b/ansible/roles/prover/templates/vlayer.service.j2
@@ -45,6 +45,12 @@ Environment=OPTIMISM_SEPOLIA_ROLLUP_ENDPOINT={{ vlayer_prover_optimism_sepolia_r
 {% if vlayer_prover_base_sepolia_rollup_endpoint is defined %}
 Environment=BASE_SEPOLIA_ROLLUP_ENDPOINT={{ vlayer_prover_base_sepolia_rollup_endpoint }}
 {% endif %}
+{% if vlayer_prover_optimism_rollup_endpoint is defined %}
+Environment=OPTIMISM_ROLLUP_ENDPOINT={{ vlayer_prover_optimism_rollup_endpoint }}
+{% endif %}
+{% if vlayer_prover_base_rollup_endpoint is defined %}
+Environment=BASE_ROLLUP_ENDPOINT={{ vlayer_prover_base_rollup_endpoint }}
+{% endif %}
 Environment=VLAYER_AUTH__JWT__PUBLIC_KEY={{ vlayer_jwt_public_key_location }}
 Environment=VLAYER_AUTH__JWT__ALGORITHM={{ vlayer_jwt_algorithm }}
 Environment='VLAYER_AUTH__JWT__CLAIMS={{ vlayer_jwt_claims | join(' ') }}'

--- a/ansible/roles/prover_docker/README.md
+++ b/ansible/roles/prover_docker/README.md
@@ -22,3 +22,5 @@ Installs the vlayer Prover docker container.
 | `prover_docker_jwt_public_key_location` | Where is the JWT public key file installed. |
 | `prover_docker_optimism_sepolia_rollup_endpoint` | Optional override URL for Optimism Sepolia rollup node endpoint. |
 | `prover_docker_base_sepolia_rollup_endpoint` | Optional override URL for Base Sepolia rollup node endpoint. |
+| `prover_docker_optimism_rollup_endpoint` | Optional override URL for Optimism mainnet rollup node endpoint. |
+| `prover_docker_base_rollup_endpoint` | Optional override URL for Base mainnet rollup node endpoint. |

--- a/ansible/roles/prover_docker/templates/prover.env.j2
+++ b/ansible/roles/prover_docker/templates/prover.env.j2
@@ -11,3 +11,9 @@ OPTIMISM_SEPOLIA_ROLLUP_ENDPOINT={{ prover_docker_optimism_sepolia_rollup_endpoi
 {% if prover_docker_base_sepolia_rollup_endpoint is defined %}
 BASE_SEPOLIA_ROLLUP_ENDPOINT={{ prover_docker_base_sepolia_rollup_endpoint }}
 {% endif %}
+{% if prover_docker_optimism_rollup_endpoint is defined %}
+OPTIMISM_ROLLUP_ENDPOINT={{ prover_docker_optimism_rollup_endpoint }}
+{% endif %}
+{% if prover_docker_base_rollup_endpoint is defined %}
+BASE_ROLLUP_ENDPOINT={{ prover_docker_base_rollup_endpoint }}
+{% endif %}


### PR DESCRIPTION
Same as in we did for nightly prover in https://github.com/vlayer-xyz/vlayer/pull/2637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional override endpoints for Optimism and Base rollups (mainnet and Sepolia).
  * Service and Docker environments now expose OPTIMISM_ROLLUP_ENDPOINT and BASE_ROLLUP_ENDPOINT when provided.

* **Chores**
  * Replaced several default Optimism/Base RPC endpoints (mainnet and Sepolia) with Alchemy-backed URLs.
  * Added dedicated override variables for QuikNode-backed rollup endpoints.

* **Documentation**
  * Updated Prover and Prover Docker docs to document the new rollup endpoint variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->