### PR TITLE
chore: fix Open Graph meta tag attribute order

### DIFF
--- a/examples/simple-email-proof/vlayer/index.html
+++ b/examples/simple-email-proof/vlayer/index.html
@@ -7,7 +7,7 @@
     <title>vlayer Email Proof example</title>
     <meta name="description" content="Proving email ownership on-chain using vlayer." />
     <link rel="shortcut icon" href="/favicon.png">
-    <meta content="/vlayer-og-image.jpg" property="og:image">
+    <meta property="og:image" content="/vlayer-og-image.jpg" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
noticed the `og:image` meta tag had its attributes in the wrong order.
browsers still parse it, but some external services (Facebook, X, Telegram) might ignore the tag if the order isn’t `property` followed by `content`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized formatting of the Open Graph image meta tag in the Simple Email Proof example to align with HTML conventions.
  * Minor attribute order adjustment and cleaner syntax improve readability and consistency across examples.
  * No user-facing changes: page behavior, rendering, and social sharing previews remain unaffected.
  * Low-risk update intended to keep markup consistent and easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->