### PR TITLE
update example usage

### DIFF
--- a/book/src/web-proof/server-side.md
+++ b/book/src/web-proof/server-side.md
@@ -21,8 +21,7 @@ Available options:
 
 Example usage: 
 ```sh
-vlayer web-proof-fetch  
-  --url "https://api.kraken.com/0/public/Ticker?pair=ETHUSD"
+vlayer web-proof-fetch --url "https://api.kraken.com/0/public/Ticker?pair=ETHUSD"
 ```
 
 Such produced Web Proof (including url, headers and body) can be passed into vlayer prover and then verified on-chain. 


### PR DESCRIPTION
Omit `--notary` flag from example usage so `web-proof-fetch` executes successfully 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Simplified the server-side web-proof fetch example to show a single-line invocation using only the --url option, removing the separate notary line for clarity.
  * Makes the example match current CLI usage and reduces potential confusion for users following the docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->