### PR TITLE
Make add_remappings fail fast when remappings are missing

### DIFF
--- a/rust/cli/src/soldeer.rs
+++ b/rust/cli/src/soldeer.rs
@@ -43,9 +43,14 @@ pub fn add_remappings<'a>(
     foundry_root: &Path,
     iter: impl Iterator<Item = &'a Dependency>,
 ) -> Result<()> {
-    let remappings: Vec<(String, String)> = iter
-        .flat_map(Dependency::remappings)
-        .flatten()
+    // Collect all remappings, failing fast if any dependency lacks remappings
+    let remappings_slices: Vec<&[(String, String)]> = iter
+        .map(Dependency::remappings)
+        .collect::<config::Result<Vec<_>>>()?;
+
+    let remappings: Vec<(String, String)> = remappings_slices
+        .into_iter()
+        .flat_map(|slice| slice.iter())
         .map(|(x, y)| (x.clone(), y.clone()))
         .collect();
     do_add_remappings(foundry_root, &remappings)


### PR DESCRIPTION
This change updates add_remappings to strictly propagate errors from Dependency::remappings() instead of silently discarding them via flat_map on Result. We now collect the results with ?, flatten the successful slices, and write the remappings deterministically.

Why this is necessary:
- Silent suppression led to incomplete remappings.txt without any explicit failure, making builds flaky and hard to diagnose.
- Aligns behavior with init.rs where missing remappings for local deps already error.
- Matches the contract of Dependency::remappings() (RequiredField on missing remappings) and documentation expectations that vlayer generates a correct remappings.txt or fails clearly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improves dependency remapping handling to fail fast when any dependency lacks remappings, preventing partial or ambiguous configurations and providing clearer feedback.

- Refactor
  - Streamlines the internal process for collecting and validating remappings without changing public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->