### PR TITLE
fix: Switch to URL prefix verification in web proof example

### DIFF
--- a/examples/simple-web-proof/src/vlayer/WebProofProver.sol
+++ b/examples/simple-web-proof/src/vlayer/WebProofProver.sol
@@ -9,8 +9,7 @@ contract WebProofProver is Prover {
     using WebProofLib for WebProof;
     using WebLib for Web;
 
-    string public constant DATA_URL =
-        "https://api.x.com/1.1/account/settings.json";
+    string public constant DATA_URL = "https://api.x.com/1.1/account/settings.json";
 
     function main(WebProof calldata webProof, address account)
         public

--- a/examples/simple-web-proof/src/vlayer/WebProofProver.sol
+++ b/examples/simple-web-proof/src/vlayer/WebProofProver.sol
@@ -10,14 +10,14 @@ contract WebProofProver is Prover {
     using WebLib for Web;
 
     string public constant DATA_URL =
-        "https://api.x.com/1.1/account/settings.json?include_ext_sharing_audiospaces_listening_data_with_followers=true&include_mention_filter=true&include_nsfw_user_flag=true&include_nsfw_admin_flag=true&include_ranked_timeline=true&include_alt_text_compose=true&include_ext_dm_av_call_settings=true&ext=ssoConnections&include_country_code=true&include_ext_dm_nsfw_media_filter=true";
+        "https://api.x.com/1.1/account/settings.json";
 
     function main(WebProof calldata webProof, address account)
         public
         view
         returns (Proof memory, string memory, address)
     {
-        Web memory web = webProof.verify(DATA_URL);
+        Web memory web = webProof.verifyWithUrlPrefix(DATA_URL);
 
         string memory screenName = web.jsonGetString("screen_name");
 


### PR DESCRIPTION
- Follow-up to https://github.com/vlayer-xyz/vlayer/pull/2652
- In order to make sure it doesn't break uncontrollably agian.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined external URL handling by switching to a stable, shorter endpoint and adjusting verification to use a URL prefix, reducing brittleness from parameterized URLs.
  - Maintains the same inputs/outputs and public behavior; no integration changes required.

- Bug Fixes
  - Improved verification reliability with X API endpoints, minimizing failures caused by URL format variations.

- Chores
  - Internal cleanup to align URL usage with current service conventions, with no impact on user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->