### PR TITLE
chore: fix infinite recursion in default reference

### DIFF
--- a/nix/risc0.nix
+++ b/nix/risc0.nix
@@ -62,11 +62,11 @@ let
     };
   };
 in
-rec {
+{
   risc0 = {
-    default = risc0."3.0.3";
     inherit (package "3.0.3") "3.0.3";
     inherit (package "2.3.1") "2.3.1";
     inherit (package "1.2.4") "1.2.4";
+    default = (package "3.0.3")."3.0.3";
   };
 }


### PR DESCRIPTION
fixed an issue where `default = risc0."3.0.3";` caused a self-referential definition leading to infinite recursion.
now it correctly uses `default = (package "3.0.3")."3.0.3";` to reference the value from the `package` function instead of `risc0` itself.

this change removes the recursive loop and restores proper evaluation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured package configuration for improved attribute resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->